### PR TITLE
MVP-003 · Equipos, fallas y mantenimiento correctivo

### DIFF
--- a/src/app/equipment/[id]/page.tsx
+++ b/src/app/equipment/[id]/page.tsx
@@ -1,0 +1,7 @@
+import { AppShell } from "@/components/app-shell";
+import { EquipmentDetail } from "@/components/equipment-detail";
+
+export default async function EquipmentDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <AppShell><EquipmentDetail equipmentId={id} /></AppShell>;
+}

--- a/src/app/equipment/[id]/report/page.tsx
+++ b/src/app/equipment/[id]/report/page.tsx
@@ -1,0 +1,7 @@
+import { AppShell } from "@/components/app-shell";
+import { EquipmentReportForm } from "@/components/equipment-report-form";
+
+export default async function EquipmentReportPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <AppShell><EquipmentReportForm equipmentId={id} /></AppShell>;
+}

--- a/src/app/equipment/page.tsx
+++ b/src/app/equipment/page.tsx
@@ -1,0 +1,6 @@
+import { AppShell } from "@/components/app-shell";
+import { EquipmentList } from "@/components/equipment-list";
+
+export default function EquipmentPage() {
+  return <AppShell><EquipmentList /></AppShell>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import { OpsStoreProvider } from "@/components/ops-store";
+import { MaintenanceStoreProvider } from "@/components/maintenance-store";
 import "./globals.css";
 
 export const metadata: Metadata = { title: "GREENATICS OPS", description: "Operación, trazabilidad y gestión de GREENATICS" };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
-  return <html lang="es"><body><OpsStoreProvider>{children}</OpsStoreProvider></body></html>;
+  return <html lang="es"><body><OpsStoreProvider><MaintenanceStoreProvider>{children}</MaintenanceStoreProvider></OpsStoreProvider></body></html>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { AppShell } from "@/components/app-shell";
 import { TodayDashboard } from "@/components/today-dashboard";
+import { MaintenanceHome } from "@/components/maintenance-home";
 
 export default function Home() {
-  return <AppShell><TodayDashboard /></AppShell>;
+  return <AppShell><TodayDashboard /><MaintenanceHome /></AppShell>;
 }

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-const nav = [["Hoy", "/"], ["Calendario", "/calendar"], ["Recepciones", "/receptions"], ["Registrar actividad", "/activities/new"], ["Alertas", "/#alertas"], ["Dashboard", "/#dashboard"]] as const;
+const nav = [["Hoy", "/"], ["Calendario", "/calendar"], ["Recepciones", "/receptions"], ["Equipos", "/equipment"], ["Registrar actividad", "/activities/new"], ["Alertas", "/#alertas"], ["Dashboard", "/#dashboard"]] as const;
 
 export function AppShell({ children }: { children: ReactNode }) {
   return <div className="app-shell"><aside className="sidebar" aria-label="Navegación principal"><div className="brand-block"><div className="brand-mark" aria-hidden="true">G</div><div><strong>GREENATICS</strong><span>OPS</span></div></div><nav className="side-nav">{nav.map(([label, href]) => <Link key={label} href={href}>{label}</Link>)}</nav><div className="sidebar-foot"><span className="status-dot status-ok" /> MVP local · sync pendiente</div></aside><main className="main-area">{children}</main></div>;

--- a/src/components/equipment-detail.tsx
+++ b/src/components/equipment-detail.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useMaintenanceStore } from "@/components/maintenance-store";
+import { EquipmentStatusPill, MaintenanceStatusPill } from "@/components/equipment-status-pill";
+import { getDowntimeMinutes } from "@/lib/maintenance-domain";
+import { bogotaTime } from "@/lib/time";
+
+export function EquipmentDetail({ equipmentId }: { equipmentId: string }) {
+  const { equipment, tickets, startRepair, closeTicket } = useMaintenanceStore();
+  const asset = equipment.find((item) => item.id === equipmentId);
+  const assetTickets = useMemo(() => tickets.filter((ticket) => ticket.equipmentId === equipmentId).sort((a,b)=>new Date(b.openedAt).getTime()-new Date(a.openedAt).getTime()), [tickets, equipmentId]);
+  const active = assetTickets.find((ticket) => ticket.status !== "closed");
+  const [cause, setCause] = useState("");
+  const [resolution, setResolution] = useState("");
+  const [feedback, setFeedback] = useState("");
+
+  if (!asset) return <section className="panel mx-auto max-w-3xl"><h1 className="text-2xl">Equipo no encontrado</h1><Link className="button secondary mt-5" href="/equipment">Volver</Link></section>;
+
+  const beginRepair = () => { if (!active) return; const result = startRepair(active.id); setFeedback(result.ok ? "Reparación iniciada." : result.error); };
+  const close = () => { if (!active) return; const result = closeTicket(active.id, { cause, resolution }); if (!result.ok) return setFeedback(result.error); setCause(""); setResolution(""); setFeedback("Reparación cerrada y equipo disponible."); };
+
+  return <>
+    <header className="page-header"><div><p className="eyebrow">{asset.plant} · {asset.area}</p><h1>{asset.code} · {asset.name}</h1><p className="lede">Ficha operacional e historial de mantenimiento.</p></div><div className="header-actions"><Link className="button secondary" href="/equipment">Volver</Link>{!active && <Link className="button primary" href={`/equipment/${asset.id}/report`}>Reportar falla</Link>}</div></header>
+    <section className="panel mx-auto max-w-4xl"><div className="section-head"><div><p className="eyebrow">Estado</p><h2>Situación actual</h2></div><EquipmentStatusPill status={asset.status}/></div>{active ? <div className="rounded-xl border border-[var(--line)] bg-[var(--surface-soft)] p-4"><div className="flex flex-wrap items-start justify-between gap-3"><div><strong className="block text-sm">{active.title}</strong><span className="mt-1 block text-xs text-[var(--muted)]">{active.description}</span></div><MaintenanceStatusPill status={active.status}/></div><div className="mt-4 grid gap-3 border-t border-[var(--line)] pt-3 sm:grid-cols-3"><div><span className="quiet">Reportada</span><strong className="mt-1 block text-xs">{bogotaTime.format(new Date(active.openedAt))}</strong></div><div><span className="quiet">Fuera de servicio</span><strong className="mt-1 block text-xs">{Math.round(getDowntimeMinutes(active, new Date().toISOString()))} min</strong></div><div><span className="quiet">Severidad</span><strong className="mt-1 block text-xs capitalize">{active.severity}</strong></div></div>{active.status === "open" && <div className="mt-4 flex justify-end"><button className="button primary" type="button" onClick={beginRepair}>Iniciar reparación</button></div>}{active.status === "repairing" && <div className="mt-5 grid gap-4"><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Causa encontrada<textarea className="min-h-20 rounded-lg border border-[var(--line)] bg-white p-3 text-sm text-[var(--ink)]" value={cause} onChange={(e)=>setCause(e.target.value)} placeholder="Qué originó la falla"/></label><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Acción realizada<textarea className="min-h-20 rounded-lg border border-[var(--line)] bg-white p-3 text-sm text-[var(--ink)]" value={resolution} onChange={(e)=>setResolution(e.target.value)} placeholder="Qué se reparó o ajustó"/></label><div className="flex justify-end"><button className="button primary" type="button" onClick={close}>Cerrar reparación</button></div></div>}</div> : <div className="rounded-xl bg-[var(--green-soft)] p-4 text-sm text-[var(--green-dark)]">No hay fallas o reparaciones abiertas para este equipo.</div>}{feedback && <p className="mt-4 rounded-lg bg-[var(--blue-soft)] p-3 text-sm font-semibold text-[var(--blue)]" role="status">{feedback}</p>}</section>
+    <section className="panel mx-auto mt-4 max-w-4xl"><div className="section-head"><div><p className="eyebrow">Historial</p><h2>Tickets registrados</h2></div><span className="quiet">{assetTickets.length} eventos</span></div><div className="grid gap-3">{assetTickets.map((ticket)=><article className="rounded-xl border border-[var(--line)] p-4" key={ticket.id}><div className="flex flex-wrap items-start justify-between gap-3"><div><strong className="text-sm">{ticket.title}</strong><span className="mt-1 block text-xs text-[var(--muted)]">{bogotaTime.format(new Date(ticket.openedAt))} · {ticket.description}</span></div><MaintenanceStatusPill status={ticket.status}/></div>{ticket.status === "closed" && <div className="mt-3 grid gap-2 border-t border-[var(--line)] pt-3 text-xs sm:grid-cols-3"><div><span className="quiet">Parada total</span><strong className="mt-1 block">{Math.round(getDowntimeMinutes(ticket))} min</strong></div><div><span className="quiet">Causa</span><strong className="mt-1 block">{ticket.cause}</strong></div><div><span className="quiet">Acción</span><strong className="mt-1 block">{ticket.resolution}</strong></div></div>}</article>)}</div></section>
+  </>;
+}

--- a/src/components/equipment-list.tsx
+++ b/src/components/equipment-list.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import Link from "next/link";
+import { useMaintenanceStore } from "@/components/maintenance-store";
+import { EquipmentStatusPill } from "@/components/equipment-status-pill";
+import { getDowntimeMinutes } from "@/lib/maintenance-domain";
+
+export function EquipmentList() {
+  const { equipment, tickets, ready, resetMaintenanceDemo } = useMaintenanceStore();
+  const stopped = equipment.filter((asset) => asset.status === "stopped").length;
+  const inRepair = equipment.filter((asset) => asset.status === "maintenance").length;
+  const openTickets = tickets.filter((ticket) => ticket.status !== "closed");
+
+  return <>
+    <header className="page-header"><div><p className="eyebrow">Activos operativos</p><h1>Equipos y mantenimiento</h1><p className="lede">Estado actual, fallas abiertas y tiempo fuera de servicio por equipo.</p></div><div className="header-actions"><Link className="button secondary" href="/">Volver a hoy</Link></div></header>
+    <section className="metrics-grid" aria-label="Indicadores de equipos"><div className="metric-block"><span>Equipos</span><strong>{equipment.length}</strong><small>activos en la demo</small></div><div className="metric-block"><span>Detenidos</span><strong>{stopped}</strong><small>requieren atención</small></div><div className="metric-block"><span>En reparación</span><strong>{inRepair}</strong><small>trabajo iniciado</small></div><div className="metric-block"><span>Tickets abiertos</span><strong>{openTickets.length}</strong><small>falla + reparación</small></div></section>
+    <section className="panel plant-panel"><div className="section-head"><div><p className="eyebrow">Estado actual</p><h2>Equipos por planta</h2></div><div className="flex items-center gap-2"><span className="quiet">{ready ? "Persistencia local activa" : "Cargando…"}</span><button className="text-xs font-semibold text-[var(--green)] underline underline-offset-4" type="button" onClick={resetMaintenanceDemo}>Restablecer demo</button></div></div><div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">{equipment.map((asset) => { const ticket = openTickets.find((item) => item.equipmentId === asset.id); return <Link className="rounded-xl border border-[var(--line)] p-4 no-underline hover:bg-[var(--surface-soft)]" href={`/equipment/${asset.id}`} key={asset.id}><div className="flex items-start justify-between gap-3"><div><strong className="block text-sm">{asset.code} · {asset.name}</strong><span className="mt-1 block text-xs text-[var(--muted)]">{asset.plant} · {asset.area}</span></div><EquipmentStatusPill status={asset.status}/></div>{ticket && <div className="mt-4 border-t border-[var(--line)] pt-3"><span className="quiet">Falla actual</span><strong className="mt-1 block text-xs">{ticket.title}</strong><span className="mt-1 block text-[11px] text-[var(--muted)]">{Math.round(getDowntimeMinutes(ticket, new Date().toISOString()))} min fuera de servicio</span></div>}</Link>; })}</div></section>
+  </>;
+}

--- a/src/components/equipment-report-form.tsx
+++ b/src/components/equipment-report-form.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { AlertSeverity } from "@/lib/domain";
+import { useMaintenanceStore } from "@/components/maintenance-store";
+import { EquipmentStatusPill } from "@/components/equipment-status-pill";
+
+export function EquipmentReportForm({ equipmentId }: { equipmentId: string }) {
+  const router = useRouter();
+  const { equipment, reportFailure } = useMaintenanceStore();
+  const asset = equipment.find((item) => item.id === equipmentId);
+  const [severity, setSeverity] = useState<AlertSeverity>("medium");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [feedback, setFeedback] = useState("");
+
+  if (!asset) return <section className="panel mx-auto max-w-3xl"><h1 className="text-2xl">Equipo no encontrado</h1><Link className="button secondary mt-5" href="/equipment">Volver</Link></section>;
+
+  const save = () => { const result = reportFailure({ equipmentId: asset.id, severity, title, description }); if (!result.ok) return setFeedback(result.error); router.push(`/equipment/${asset.id}`); };
+
+  return <section className="panel mx-auto max-w-3xl"><div className="section-head"><div><p className="eyebrow">{asset.plant} · {asset.area}</p><h1 className="text-3xl">Reportar falla</h1><p className="lede">{asset.code} · {asset.name}. Al guardar, el equipo quedará marcado como detenido.</p></div><EquipmentStatusPill status={asset.status}/></div><div className="grid gap-5"><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Severidad<select className="min-h-11 rounded-lg border border-[var(--line)] bg-white px-3 text-sm text-[var(--ink)]" value={severity} onChange={(e)=>setSeverity(e.target.value as AlertSeverity)}><option value="low">Baja</option><option value="medium">Media</option><option value="high">Alta</option></select></label><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">¿Qué falló?<input className="min-h-11 rounded-lg border border-[var(--line)] px-3 text-sm text-[var(--ink)]" value={title} onChange={(e)=>setTitle(e.target.value)} placeholder="Ej. Bomba obstruida"/></label><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Qué ocurrió / impacto<textarea className="min-h-24 rounded-lg border border-[var(--line)] p-3 text-sm text-[var(--ink)]" value={description} onChange={(e)=>setDescription(e.target.value)} placeholder="Ej. Se detuvo la recirculación; no se debe operar hasta revisar."/></label><div className="rounded-xl border border-dashed border-[var(--line)] p-4 text-xs text-[var(--muted)]"><strong className="text-[var(--ink)]">Foto/evidencia:</strong> se conectará con el adapter documental junto con las evidencias de recepción.</div></div>{feedback && <p className="mt-4 rounded-lg bg-[var(--red-soft)] p-3 text-sm font-semibold text-[var(--red)]" role="alert">{feedback}</p>}<div className="mt-6 flex items-center justify-between gap-3"><Link className="button secondary" href={`/equipment/${asset.id}`}>Cancelar</Link><button className="button primary" type="button" onClick={save}>Reportar y detener equipo</button></div></section>;
+}

--- a/src/components/equipment-status-pill.tsx
+++ b/src/components/equipment-status-pill.tsx
@@ -1,0 +1,21 @@
+import type { EquipmentStatus, MaintenanceStatus } from "@/lib/maintenance-domain";
+
+const equipmentLabels: Record<EquipmentStatus, string> = { available: "Disponible", attention: "Atención", stopped: "Detenido", maintenance: "Mantenimiento" };
+const maintenanceLabels: Record<MaintenanceStatus, string> = { open: "Falla abierta", repairing: "En reparación", closed: "Cerrado" };
+const classes: Record<EquipmentStatus | MaintenanceStatus, string> = {
+  available: "bg-[var(--green-soft)] text-[var(--green-dark)]",
+  attention: "bg-[var(--amber-soft)] text-[var(--amber)]",
+  stopped: "bg-[var(--red-soft)] text-[var(--red)]",
+  maintenance: "bg-[var(--blue-soft)] text-[var(--blue)]",
+  open: "bg-[var(--red-soft)] text-[var(--red)]",
+  repairing: "bg-[var(--blue-soft)] text-[var(--blue)]",
+  closed: "bg-[var(--green-soft)] text-[var(--green-dark)]",
+};
+
+export function EquipmentStatusPill({ status }: { status: EquipmentStatus }) {
+  return <span className={`status-pill ${classes[status]}`}>{equipmentLabels[status]}</span>;
+}
+
+export function MaintenanceStatusPill({ status }: { status: MaintenanceStatus }) {
+  return <span className={`status-pill ${classes[status]}`}>{maintenanceLabels[status]}</span>;
+}

--- a/src/components/maintenance-home.tsx
+++ b/src/components/maintenance-home.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import Link from "next/link";
+import { useMaintenanceStore } from "@/components/maintenance-store";
+import { EquipmentStatusPill, MaintenanceStatusPill } from "@/components/equipment-status-pill";
+import { getDowntimeMinutes } from "@/lib/maintenance-domain";
+
+export function MaintenanceHome() {
+  const { equipment, tickets } = useMaintenanceStore();
+  const activeTickets = tickets.filter((ticket) => ticket.status !== "closed");
+  const affected = equipment.filter((asset) => asset.status === "stopped" || asset.status === "maintenance");
+  if (!affected.length && !activeTickets.length) return null;
+
+  return <section className="panel plant-panel mt-4"><div className="section-head"><div><p className="eyebrow">Equipos</p><h2>Mantenimiento que requiere atención</h2></div><Link className="button secondary" href="/equipment">Ver equipos</Link></div><div className="grid gap-3 md:grid-cols-2">{affected.map((asset)=>{ const ticket = activeTickets.find((item)=>item.equipmentId===asset.id); return <Link className="rounded-xl border border-[var(--line)] p-4 no-underline" href={`/equipment/${asset.id}`} key={asset.id}><div className="flex items-start justify-between gap-3"><div><strong className="block text-sm">{asset.code} · {asset.name}</strong><span className="mt-1 block text-xs text-[var(--muted)]">{asset.plant} · {asset.area}</span></div><EquipmentStatusPill status={asset.status}/></div>{ticket && <div className="mt-3 border-t border-[var(--line)] pt-3"><div className="flex items-center justify-between gap-2"><strong className="text-xs">{ticket.title}</strong><MaintenanceStatusPill status={ticket.status}/></div><span className="mt-2 block text-[11px] text-[var(--muted)]">{Math.round(getDowntimeMinutes(ticket,new Date().toISOString()))} min fuera de servicio</span></div>}</Link>;})}</div></section>;
+}

--- a/src/components/maintenance-store.tsx
+++ b/src/components/maintenance-store.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import type { AlertSeverity } from "@/lib/domain";
+import type { EquipmentRecord, MaintenanceTicket } from "@/lib/maintenance-domain";
+import { seedEquipment, seedMaintenanceTickets } from "@/lib/maintenance-data";
+
+const STORAGE_KEY = "greenatics-ops-maintenance-mvp-003";
+
+type Result = { ok: true } | { ok: false; error: string };
+type CreateResult = { ok: true; id: string } | { ok: false; error: string };
+type FailurePayload = { equipmentId: string; severity: AlertSeverity; title: string; description: string };
+type ClosePayload = { cause: string; resolution: string };
+
+type MaintenanceStore = {
+  equipment: EquipmentRecord[];
+  tickets: MaintenanceTicket[];
+  ready: boolean;
+  reportFailure: (payload: FailurePayload) => CreateResult;
+  startRepair: (ticketId: string) => Result;
+  closeTicket: (ticketId: string, payload: ClosePayload) => Result;
+  resetMaintenanceDemo: () => void;
+};
+
+const MaintenanceContext = createContext<MaintenanceStore | null>(null);
+
+export function MaintenanceStoreProvider({ children }: { children: ReactNode }) {
+  const [equipment, setEquipment] = useState(seedEquipment);
+  const [tickets, setTickets] = useState(seedMaintenanceTickets);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw) as { equipment?: EquipmentRecord[]; tickets?: MaintenanceTicket[] };
+          if (parsed.equipment?.length) setEquipment(parsed.equipment);
+          if (parsed.tickets) setTickets(parsed.tickets);
+        }
+      } catch {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } finally {
+        setReady(true);
+      }
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    if (!ready) return;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ equipment, tickets }));
+  }, [equipment, tickets, ready]);
+
+  const value = useMemo<MaintenanceStore>(() => ({
+    equipment,
+    tickets,
+    ready,
+    reportFailure(payload) {
+      const asset = equipment.find((item) => item.id === payload.equipmentId);
+      if (!asset) return { ok: false, error: "Equipo no encontrado." };
+      if (!payload.title.trim()) return { ok: false, error: "Describe brevemente la falla." };
+      if (!payload.description.trim()) return { ok: false, error: "Indica qué ocurrió o qué efecto tuvo." };
+      if (tickets.some((ticket) => ticket.equipmentId === asset.id && ticket.status !== "closed")) return { ok: false, error: "Este equipo ya tiene una falla o reparación abierta." };
+      const id = crypto.randomUUID();
+      const openedAt = new Date().toISOString();
+      const ticket: MaintenanceTicket = { id, equipmentId: asset.id, plantId: asset.plantId, plant: asset.plant, severity: payload.severity, title: payload.title.trim(), description: payload.description.trim(), openedAt, status: "open" };
+      setTickets((current) => [ticket, ...current]);
+      setEquipment((current) => current.map((item) => item.id === asset.id ? { ...item, status: "stopped" } : item));
+      return { ok: true, id };
+    },
+    startRepair(ticketId) {
+      const ticket = tickets.find((item) => item.id === ticketId);
+      if (!ticket) return { ok: false, error: "Ticket no encontrado." };
+      if (ticket.status !== "open") return { ok: false, error: ticket.status === "closed" ? "La reparación ya está cerrada." : "La reparación ya fue iniciada." };
+      const repairStartedAt = new Date().toISOString();
+      setTickets((current) => current.map((item) => item.id === ticketId ? { ...item, repairStartedAt, status: "repairing" } : item));
+      setEquipment((current) => current.map((item) => item.id === ticket.equipmentId ? { ...item, status: "maintenance" } : item));
+      return { ok: true };
+    },
+    closeTicket(ticketId, payload) {
+      const ticket = tickets.find((item) => item.id === ticketId);
+      if (!ticket) return { ok: false, error: "Ticket no encontrado." };
+      if (ticket.status !== "repairing" || !ticket.repairStartedAt) return { ok: false, error: "Debes iniciar la reparación antes de cerrarla." };
+      if (!payload.cause.trim()) return { ok: false, error: "Registra la causa encontrada." };
+      if (!payload.resolution.trim()) return { ok: false, error: "Registra la acción realizada." };
+      const closedAt = new Date().toISOString();
+      setTickets((current) => current.map((item) => item.id === ticketId ? { ...item, cause: payload.cause.trim(), resolution: payload.resolution.trim(), closedAt, status: "closed" } : item));
+      setEquipment((current) => current.map((item) => item.id === ticket.equipmentId ? { ...item, status: "available" } : item));
+      return { ok: true };
+    },
+    resetMaintenanceDemo() {
+      setEquipment(seedEquipment);
+      setTickets(seedMaintenanceTickets);
+      window.localStorage.removeItem(STORAGE_KEY);
+    },
+  }), [equipment, tickets, ready]);
+
+  return <MaintenanceContext.Provider value={value}>{children}</MaintenanceContext.Provider>;
+}
+
+export function useMaintenanceStore() {
+  const context = useContext(MaintenanceContext);
+  if (!context) throw new Error("useMaintenanceStore debe usarse dentro de MaintenanceStoreProvider");
+  return context;
+}

--- a/src/lib/maintenance-data.ts
+++ b/src/lib/maintenance-data.ts
@@ -1,0 +1,13 @@
+import type { EquipmentRecord, MaintenanceTicket } from "@/lib/maintenance-domain";
+
+export const seedEquipment: EquipmentRecord[] = [
+  { id: "eq-tam-m01", plantId: "tamesis", plant: "Támesis", code: "M-01", name: "Molino", area: "Pretratamiento", status: "available" },
+  { id: "eq-tam-bp01", plantId: "tamesis", plant: "Támesis", code: "BP-01", name: "Bomba peristáltica", area: "Digestión", status: "stopped" },
+  { id: "eq-tam-r02", plantId: "tamesis", plant: "Támesis", code: "R-02", name: "Biodigestor", area: "Digestión", status: "available" },
+  { id: "eq-yar-m01", plantId: "yarumal", plant: "Yarumal", code: "M-01", name: "Molino", area: "Pretratamiento", status: "available" },
+  { id: "eq-yar-t01", plantId: "yarumal", plant: "Yarumal", code: "T-01", name: "Tamiz", area: "Compostaje", status: "attention" },
+];
+
+export const seedMaintenanceTickets: MaintenanceTicket[] = [
+  { id: "mnt-001", equipmentId: "eq-tam-bp01", plantId: "tamesis", plant: "Támesis", severity: "high", title: "Obstrucción recurrente", description: "La bomba se detuvo durante la recirculación y requiere revisión antes de volver a operar.", openedAt: "2026-08-11T10:14:00-05:00", status: "open" },
+];

--- a/src/lib/maintenance-domain.ts
+++ b/src/lib/maintenance-domain.ts
@@ -1,0 +1,36 @@
+import type { AlertSeverity } from "@/lib/domain";
+
+export type EquipmentStatus = "available" | "attention" | "stopped" | "maintenance";
+export type MaintenanceStatus = "open" | "repairing" | "closed";
+
+export type EquipmentRecord = {
+  id: string;
+  plantId: string;
+  plant: string;
+  code: string;
+  name: string;
+  area: string;
+  status: EquipmentStatus;
+};
+
+export type MaintenanceTicket = {
+  id: string;
+  equipmentId: string;
+  plantId: string;
+  plant: string;
+  severity: AlertSeverity;
+  title: string;
+  description: string;
+  openedAt: string;
+  repairStartedAt?: string;
+  closedAt?: string;
+  cause?: string;
+  resolution?: string;
+  status: MaintenanceStatus;
+};
+
+export function getDowntimeMinutes(ticket: MaintenanceTicket, nowIso?: string) {
+  const end = ticket.closedAt ?? nowIso;
+  if (!end) return 0;
+  return Math.max(0, (new Date(end).getTime() - new Date(ticket.openedAt).getTime()) / 60000);
+}

--- a/supabase/migrations/0003_maintenance.sql
+++ b/supabase/migrations/0003_maintenance.sql
@@ -1,0 +1,22 @@
+create table if not exists maintenance_tickets (
+  id uuid primary key default gen_random_uuid(),
+  equipment_id uuid not null references equipment(id),
+  plant_id uuid not null references plants(id),
+  severity text not null default 'medium' check (severity in ('low','medium','high')),
+  title text not null,
+  description text not null,
+  status text not null default 'open' check (status in ('open','repairing','closed')),
+  opened_at timestamptz not null default now(),
+  repair_started_at timestamptz,
+  closed_at timestamptz,
+  cause text,
+  resolution text,
+  created_at timestamptz not null default now(),
+  check (repair_started_at is null or repair_started_at >= opened_at),
+  check (closed_at is null or closed_at >= opened_at),
+  check (status <> 'closed' or (repair_started_at is not null and closed_at is not null))
+);
+
+create index if not exists maintenance_tickets_equipment_opened_idx on maintenance_tickets (equipment_id, opened_at desc);
+create index if not exists maintenance_tickets_status_idx on maintenance_tickets (status) where status <> 'closed';
+create unique index if not exists maintenance_tickets_one_active_per_equipment_idx on maintenance_tickets (equipment_id) where status <> 'closed';


### PR DESCRIPTION
Closes #7

## Qué cambia
- Subdominio de mantenimiento separado del store operativo.
- Fichas de equipo por planta/área.
- Estados disponible / atención / detenido / mantenimiento.
- Reporte de falla con severidad y descripción.
- Una sola falla/reparación activa por equipo, validada en UI y PostgreSQL.
- Falla → equipo detenido.
- Inicio reparación → equipo en mantenimiento.
- Cierre exige causa + acción → equipo disponible.
- Tiempo fuera de servicio derivado automáticamente.
- Historial por equipo.
- Panel de mantenimiento en `Hoy`.
- Migración Supabase `maintenance_tickets`.

## Fuera de alcance
MTBF, costo correctivo/ton, repuestos y mantenimiento preventivo por horómetro hasta contar con histórico/maestros suficientes.

## Gates
- typecheck
- lint
- build
- archivos canónicos
- memoria JSONL