### PR TITLE
MVP-008 · Ventas + despacho comercial por lote

### DIFF
--- a/e2e/sales.spec.ts
+++ b/e2e/sales.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+
+async function createStock(page: import("@playwright/test").Page) {
+  await page.goto("/production/new");
+  await page.getByLabel(/Cantidad producida/).fill("250");
+  await page.getByLabel("Proceso fuente").fill("Formulación comercial QA");
+  await page.getByRole("button", { name: "Guardar producción y entrar a inventario" }).click();
+  await expect(page).toHaveURL(/\/production$/);
+}
+
+test("sale creates linked commercial dispatch and reduces lot stock", async ({ page }) => {
+  await createStock(page);
+  await page.goto("/sales/new");
+  await expect(page.getByRole("heading", { name: "Registrar venta" })).toBeVisible();
+  await page.getByLabel("Cliente").fill("Cliente QA S.A.S.");
+  await page.getByLabel(/Cantidad vendida/).fill("60");
+  await page.getByLabel(/Precio unitario COP/).fill("2000");
+  await expect(page.getByText(/120[.]000/).first()).toBeVisible();
+  await page.getByRole("button", { name: "Guardar venta y descontar inventario" }).click();
+
+  await expect(page).toHaveURL(/\/sales$/);
+  const sale = page.locator("article").filter({ hasText: "Cliente QA S.A.S." }).first();
+  await expect(sale).toBeVisible();
+  await expect(sale).toContainText("60 kg");
+  await expect(sale).toContainText(/120[.]000/);
+  await expect(sale).toContainText("pago no modelado");
+
+  await page.getByRole("link", { name: "Ver inventario" }).click();
+  const stock = page.locator("article").filter({ hasText: "Wondergreen sólido" }).first();
+  await expect(stock).toContainText("190 kg");
+  const commercialMovement = page.locator("section.panel").filter({ has: page.getByRole("heading", { name: "Kardex reciente" }) });
+  await expect(commercialMovement).toContainText("Cliente QA S.A.S.");
+  await expect(commercialMovement).toContainText("− 60 kg");
+});
+
+test("oversell fails without creating a second sale", async ({ page }) => {
+  await createStock(page);
+  await page.goto("/sales/new");
+  await page.getByLabel("Cliente").fill("Cliente Inicial");
+  await page.getByLabel(/Cantidad vendida/).fill("60");
+  await page.getByLabel(/Precio unitario COP/).fill("2000");
+  await page.getByRole("button", { name: "Guardar venta y descontar inventario" }).click();
+  await expect(page).toHaveURL(/\/sales$/);
+
+  await page.getByRole("link", { name: "Registrar venta" }).click();
+  await page.getByLabel("Cliente").fill("Cliente Sobreventa");
+  await page.getByLabel(/Cantidad vendida/).fill("300");
+  await page.getByLabel(/Precio unitario COP/).fill("2100");
+  await page.getByRole("button", { name: "Guardar venta y descontar inventario" }).click();
+  const businessAlert = page.locator('p[role="alert"]');
+  await expect(businessAlert).toContainText("Stock insuficiente");
+  await expect(businessAlert).toContainText("190");
+
+  await page.goto("/sales");
+  await expect(page.locator("article").filter({ hasText: "Cliente Inicial" })).toHaveCount(1);
+  await expect(page.locator("article").filter({ hasText: "Cliente Sobreventa" })).toHaveCount(0);
+  await expect(page.getByText(/120[.]000/).first()).toBeVisible();
+});
+
+test("customer master reuses normalized equivalent names", async ({ page }) => {
+  await createStock(page);
+  await page.goto("/sales/new");
+  await page.getByLabel("Cliente").fill("Café José S.A.S.");
+  await page.getByLabel(/Cantidad vendida/).fill("20");
+  await page.getByLabel(/Precio unitario COP/).fill("2000");
+  await page.getByRole("button", { name: "Guardar venta y descontar inventario" }).click();
+
+  await page.getByRole("link", { name: "Registrar venta" }).click();
+  await page.getByLabel("Cliente").fill("CAFE JOSE SAS");
+  await page.getByLabel(/Cantidad vendida/).fill("10");
+  await page.getByLabel(/Precio unitario COP/).fill("2000");
+  await page.getByRole("button", { name: "Guardar venta y descontar inventario" }).click();
+
+  await expect(page).toHaveURL(/\/sales$/);
+  await expect(page.getByLabel("Indicadores de ventas")).toContainText("1");
+  await expect(page.locator("article").filter({ hasText: "Café José S.A.S." })).toHaveCount(2);
+});

--- a/src/app/sales/new/page.tsx
+++ b/src/app/sales/new/page.tsx
@@ -1,0 +1,4 @@
+import { AppShell } from "@/components/app-shell";
+import { SaleForm } from "@/components/sale-form";
+
+export default function NewSalePage(){return <AppShell><SaleForm/></AppShell>;}

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -1,0 +1,4 @@
+import { AppShell } from "@/components/app-shell";
+import { SalesView } from "@/components/sales-view";
+
+export default function SalesPage(){return <AppShell><SalesView/></AppShell>;}

--- a/src/components/commercial-store.tsx
+++ b/src/components/commercial-store.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useInventoryStore } from "@/components/inventory-store";
+import { customerIdFromKey, normalizeCustomerKey, saleTotalCop, type CustomerRecord, type SaleRecord } from "@/lib/commercial-domain";
+
+const STORAGE_KEY = "greenatics-ops-sales-mvp-008";
+
+type SaleResult = { ok:true; id:string; movementId:string } | { ok:false; error:string };
+type NewSale = { plantId:string; customerName:string; productId:string; lotCode:string; quantity:number; unitPriceCop:number; note?:string };
+
+type CommercialStore = {
+  customers: CustomerRecord[];
+  sales: SaleRecord[];
+  ready:boolean;
+  recordSale:(payload:NewSale)=>SaleResult;
+  resetCommercialDemo:()=>void;
+};
+
+const CommercialContext=createContext<CommercialStore|null>(null);
+
+function plantName(plantId:string){return plantId==="yarumal"?"Yarumal":"Támesis";}
+
+export function CommercialStoreProvider({children}:{children:ReactNode}){
+  const {products,dispatch}=useInventoryStore();
+  const [customers,setCustomers]=useState<CustomerRecord[]>([]);
+  const [sales,setSales]=useState<SaleRecord[]>([]);
+  const [ready,setReady]=useState(false);
+
+  useEffect(()=>{
+    const timer=window.setTimeout(()=>{
+      try{
+        const raw=window.localStorage.getItem(STORAGE_KEY);
+        if(raw){
+          const parsed=JSON.parse(raw) as {customers?:CustomerRecord[];sales?:SaleRecord[]};
+          if(parsed.customers) setCustomers(parsed.customers);
+          if(parsed.sales) setSales(parsed.sales);
+        }
+      }catch{window.localStorage.removeItem(STORAGE_KEY);}
+      finally{setReady(true);}
+    },0);
+    return()=>window.clearTimeout(timer);
+  },[]);
+
+  useEffect(()=>{
+    if(!ready)return;
+    window.localStorage.setItem(STORAGE_KEY,JSON.stringify({customers,sales}));
+  },[customers,sales,ready]);
+
+  const value=useMemo<CommercialStore>(()=>({
+    customers,sales,ready,
+    recordSale(payload){
+      const normalizedKey=normalizeCustomerKey(payload.customerName);
+      if(!normalizedKey)return {ok:false,error:"Indica el cliente de la venta."};
+      const cleanCustomerName=payload.customerName.trim().replace(/\s+/g," ");
+      const product=products.find((item)=>item.id===payload.productId && item.active);
+      if(!product)return {ok:false,error:"Producto no encontrado."};
+      if(!payload.lotCode.trim())return {ok:false,error:"Selecciona un lote con stock."};
+      if(!Number.isFinite(payload.quantity)||payload.quantity<=0)return {ok:false,error:"La cantidad vendida debe ser mayor que cero."};
+      if(!Number.isFinite(payload.unitPriceCop)||payload.unitPriceCop<=0)return {ok:false,error:"El precio unitario debe ser mayor que cero."};
+
+      const existingCustomer=customers.find((item)=>item.normalizedKey===normalizedKey);
+      const customer:CustomerRecord=existingCustomer??{id:customerIdFromKey(normalizedKey),name:cleanCustomerName,normalizedKey,createdAt:new Date().toISOString()};
+      const saleId=crypto.randomUUID();
+      const dispatchResult=dispatch({
+        plantId:payload.plantId,
+        productId:payload.productId,
+        lotCode:payload.lotCode,
+        quantity:payload.quantity,
+        destination:customer.name,
+        referenceId:saleId,
+        note:payload.note?.trim()||undefined,
+      });
+      if(!dispatchResult.ok)return dispatchResult;
+
+      const soldAt=new Date().toISOString();
+      const sale:SaleRecord={
+        id:saleId,
+        plantId:payload.plantId,
+        plant:plantName(payload.plantId),
+        customerId:customer.id,
+        customerName:customer.name,
+        productId:product.id,
+        productName:product.name,
+        unit:product.unit,
+        lotCode:payload.lotCode,
+        quantity:payload.quantity,
+        unitPriceCop:payload.unitPriceCop,
+        totalCop:saleTotalCop(payload.quantity,payload.unitPriceCop),
+        soldAt,
+        inventoryMovementId:dispatchResult.movementId,
+        note:payload.note?.trim()||undefined,
+      };
+      if(!existingCustomer)setCustomers((current)=>[customer,...current]);
+      setSales((current)=>[sale,...current]);
+      return {ok:true,id:saleId,movementId:dispatchResult.movementId};
+    },
+    resetCommercialDemo(){setCustomers([]);setSales([]);window.localStorage.removeItem(STORAGE_KEY);},
+  }),[customers,sales,ready,products,dispatch]);
+
+  return <CommercialContext.Provider value={value}>{children}</CommercialContext.Provider>;
+}
+
+export function useCommercialStore(){
+  const context=useContext(CommercialContext);
+  if(!context)throw new Error("useCommercialStore debe usarse dentro de CommercialStoreProvider");
+  return context;
+}

--- a/src/components/inventory-store.tsx
+++ b/src/components/inventory-store.tsx
@@ -13,10 +13,11 @@ const seedProducts: ProductMaster[] = [
 ];
 
 type Result = { ok:true } | { ok:false; error:string };
+type DispatchResult = { ok:true; movementId:string } | { ok:false; error:string };
 type CreateProductResult = { ok:true; id:string } | { ok:false; error:string };
 type ProductionResult = { ok:true; id:string; lotCode:string } | { ok:false; error:string };
 type NewProduction = { plantId:string; productId:string; quantity:number; sourceProcess:string; sourcePileId?:string; note?:string };
-type NewDispatch = { plantId:string; productId:string; lotCode:string; quantity:number; destination:string; note?:string };
+type NewDispatch = { plantId:string; productId:string; lotCode:string; quantity:number; destination:string; note?:string; referenceId?:string };
 
 type InventoryStore = {
   products: ProductMaster[];
@@ -27,7 +28,7 @@ type InventoryStore = {
   lots: ReturnType<typeof lotStocks>;
   createProduct:(name:string,unit:InventoryUnit)=>CreateProductResult;
   recordProduction:(payload:NewProduction)=>ProductionResult;
-  dispatch:(payload:NewDispatch)=>Result;
+  dispatch:(payload:NewDispatch)=>DispatchResult;
   resetInventoryDemo:()=>void;
 };
 
@@ -110,9 +111,10 @@ export function InventoryStoreProvider({children}:{children:ReactNode}) {
       if(!payload.destination.trim()) return {ok:false,error:"Indica el destino de la salida."};
       const available=stockForLot(movements,payload.plantId,payload.productId,payload.lotCode);
       if(payload.quantity>available+1e-9) return {ok:false,error:`Stock insuficiente en ${payload.lotCode}. Disponible: ${available.toLocaleString("es-CO")} ${product.unit}.`};
-      const movement:InventoryMovement={id:crypto.randomUUID(),plantId:payload.plantId,plant:plantName(payload.plantId),productId:product.id,productName:product.name,unit:product.unit,lotCode:payload.lotCode,kind:"dispatch",quantity:payload.quantity,occurredAt:new Date().toISOString(),destination:payload.destination.trim(),note:payload.note?.trim()||undefined};
+      const movementId=crypto.randomUUID();
+      const movement:InventoryMovement={id:movementId,plantId:payload.plantId,plant:plantName(payload.plantId),productId:product.id,productName:product.name,unit:product.unit,lotCode:payload.lotCode,kind:"dispatch",quantity:payload.quantity,occurredAt:new Date().toISOString(),referenceId:payload.referenceId,destination:payload.destination.trim(),note:payload.note?.trim()||undefined};
       setMovements((current)=>[movement,...current]);
-      return {ok:true};
+      return {ok:true,movementId};
     },
     resetInventoryDemo(){ setProducts(seedProducts); setProductions([]); setMovements([]); window.localStorage.removeItem(STORAGE_KEY); },
   }),[products,productions,movements,ready,stocks,lots]);

--- a/src/components/sale-form.tsx
+++ b/src/components/sale-form.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCommercialStore } from "@/components/commercial-store";
+import { useInventoryStore } from "@/components/inventory-store";
+import { saleTotalCop } from "@/lib/commercial-domain";
+
+const cop=new Intl.NumberFormat("es-CO",{style:"currency",currency:"COP",maximumFractionDigits:0});
+
+export function SaleForm(){
+  const router=useRouter();
+  const {recordSale}=useCommercialStore();
+  const {lots}=useInventoryStore();
+  const [plantId,setPlantId]=useState("tamesis");
+  const availableLots=useMemo(()=>lots.filter((lot)=>lot.plantId===plantId&&lot.quantity>0),[lots,plantId]);
+  const [lotKey,setLotKey]=useState("");
+  const [customerName,setCustomerName]=useState("");
+  const [quantity,setQuantity]=useState("");
+  const [unitPriceCop,setUnitPriceCop]=useState("");
+  const [note,setNote]=useState("");
+  const [feedback,setFeedback]=useState("");
+  const selected=availableLots.find((lot)=>`${lot.productId}|${lot.lotCode}`===lotKey)??availableLots[0];
+  const total=saleTotalCop(Number(quantity),Number(unitPriceCop));
+
+  function save(){
+    if(!selected){setFeedback("No hay un lote con stock disponible en esta planta.");return;}
+    const result=recordSale({plantId,customerName,productId:selected.productId,lotCode:selected.lotCode,quantity:Number(quantity),unitPriceCop:Number(unitPriceCop),note});
+    if(!result.ok){setFeedback(result.error);return;}
+    router.push("/sales");
+  }
+
+  return <section className="panel mx-auto max-w-3xl"><div className="section-head"><div><p className="eyebrow">Comercial · salida por lote</p><h1 className="text-3xl">Registrar venta</h1><p className="lede">La venta y la salida de inventario están ligadas. El total se deriva de cantidad × precio unitario.</p></div><Link className="button secondary" href="/sales">Cancelar</Link></div>
+    <div className="grid gap-5 md:grid-cols-2">
+      <label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Planta<select className="min-h-11 rounded-lg border border-[var(--line)] bg-white px-3 text-sm text-[var(--ink)]" value={plantId} onChange={(event)=>{setPlantId(event.target.value);setLotKey("");}}><option value="tamesis">Támesis</option><option value="yarumal">Yarumal</option></select></label>
+      <label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Lote con stock<select aria-label="Lote con stock" className="min-h-11 rounded-lg border border-[var(--line)] bg-white px-3 text-sm text-[var(--ink)]" value={selected?`${selected.productId}|${selected.lotCode}`:""} onChange={(event)=>setLotKey(event.target.value)} disabled={!availableLots.length}><option value="">Seleccionar lote</option>{availableLots.map((lot)=><option value={`${lot.productId}|${lot.lotCode}`} key={`${lot.productId}-${lot.lotCode}`}>{lot.lotCode} · {lot.productName} · {lot.quantity.toLocaleString("es-CO")} {lot.unit}</option>)}</select></label>
+      <label className="grid gap-2 text-xs font-bold text-[var(--muted)] md:col-span-2">Cliente<input className="min-h-11 rounded-lg border border-[var(--line)] px-3 text-sm text-[var(--ink)]" value={customerName} onChange={(event)=>setCustomerName(event.target.value)} placeholder="Nombre o razón social" /></label>
+      <label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Cantidad vendida {selected?`(${selected.unit})`:""}<input className="min-h-11 rounded-lg border border-[var(--line)] px-3 text-sm text-[var(--ink)]" inputMode="decimal" value={quantity} onChange={(event)=>setQuantity(event.target.value)} placeholder="Ej. 60" /></label>
+      <label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Precio unitario COP {selected?`/ ${selected.unit}`:""}<input className="min-h-11 rounded-lg border border-[var(--line)] px-3 text-sm text-[var(--ink)]" inputMode="numeric" value={unitPriceCop} onChange={(event)=>setUnitPriceCop(event.target.value)} placeholder="Ej. 2000" /></label>
+      <div className="rounded-xl bg-[var(--surface-soft)] p-4"><span className="quiet">Disponible en lote</span><strong className="mt-1 block text-2xl">{selected?`${selected.quantity.toLocaleString("es-CO")} ${selected.unit}`:"—"}</strong><span className="mt-1 block text-xs text-[var(--muted)]">{selected?.productName??"Sin stock disponible"}</span></div>
+      <div className="rounded-xl bg-[var(--green-soft)] p-4"><span className="quiet">Total venta</span><strong className="mt-1 block text-2xl text-[var(--green-dark)]">{total>0?cop.format(total):"—"}</strong><span className="mt-1 block text-xs text-[var(--muted)]">Derivado; no editable</span></div>
+      <label className="grid gap-2 text-xs font-bold text-[var(--muted)] md:col-span-2">Observación <span className="font-normal">(opcional)</span><textarea className="min-h-24 rounded-lg border border-[var(--line)] p-3 text-sm text-[var(--ink)]" value={note} onChange={(event)=>setNote(event.target.value)} placeholder="Condición comercial o detalle operativo relevante" /></label>
+    </div>
+    {!availableLots.length&&<div className="mt-5 rounded-xl border border-dashed border-[var(--line)] p-4 text-xs text-[var(--muted)]">No hay stock disponible en esta planta. <Link className="font-semibold text-[var(--green)]" href="/production/new">Registrar producción</Link>.</div>}
+    <div className="mt-5 rounded-xl border border-dashed border-[var(--line)] p-4 text-xs text-[var(--muted)]"><strong className="text-[var(--ink)]">Al guardar:</strong> la venta descuenta exactamente este lote. Pago, cartera, impuestos y margen todavía no están modelados.</div>
+    {feedback&&<p role="alert" className="mt-4 rounded-lg bg-[var(--red-soft)] p-3 text-sm font-semibold text-[var(--red)]">{feedback}</p>}
+    <div className="mt-6 flex justify-end"><button className="button primary" type="button" onClick={save} disabled={!availableLots.length}>Guardar venta y descontar inventario</button></div>
+  </section>;
+}

--- a/src/components/sales-view.tsx
+++ b/src/components/sales-view.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import { useCommercialStore } from "@/components/commercial-store";
+import { grossBillingCop, soldQuantityByUnit } from "@/lib/commercial-domain";
+
+const cop=new Intl.NumberFormat("es-CO",{style:"currency",currency:"COP",maximumFractionDigits:0});
+const dateFmt=new Intl.DateTimeFormat("es-CO",{dateStyle:"medium",timeStyle:"short",timeZone:"America/Bogota"});
+
+export function SalesView(){
+  const {sales,customers,resetCommercialDemo}=useCommercialStore();
+  const billed=grossBillingCop(sales);
+  const quantities=soldQuantityByUnit(sales);
+
+  return <>
+    <header className="page-header"><div><p className="eyebrow">Comercial · facturación bruta</p><h1>Ventas</h1><p className="lede">Cada venta está ligada a un lote físico y descuenta inventario. Facturación bruta no equivale a recaudo ni utilidad.</p></div><div className="header-actions"><Link className="button secondary" href="/inventory">Ver inventario</Link><Link className="button primary" href="/sales/new">Registrar venta</Link></div></header>
+
+    <section className="metrics-grid" aria-label="Indicadores de ventas"><div className="metric-block"><span>Facturación bruta</span><strong>{cop.format(billed)}</strong><small>{sales.length} venta{sales.length===1?"":"s"} registrada{sales.length===1?"":"s"}</small></div><div className="metric-block"><span>Clientes</span><strong>{customers.length}</strong><small>maestro normalizado</small></div>{quantities.map((item)=><div className="metric-block" key={item.unit}><span>Vendido · {item.unit}</span><strong>{item.quantity.toLocaleString("es-CO",{maximumFractionDigits:2})}</strong><small>cantidad física separada</small></div>)}</section>
+
+    <section className="panel"><div className="section-head"><div><p className="eyebrow">Historial comercial</p><h2>Ventas registradas</h2></div><div className="flex items-center gap-3"><span className="quiet">Más recientes primero</span><button className="text-xs font-semibold text-[var(--green)] underline underline-offset-4" type="button" onClick={resetCommercialDemo}>Restablecer ventas</button></div></div>
+      {sales.length?<div className="grid gap-3">{sales.map((sale)=><article className="rounded-xl border border-[var(--line)] p-4" key={sale.id}><div className="flex flex-wrap items-start justify-between gap-3"><div><strong className="text-sm">{sale.customerName}</strong><span className="mt-1 block text-xs text-[var(--muted)]">{sale.productName} · {sale.lotCode} · {sale.plant}</span></div><div className="text-right"><strong className="block text-lg">{cop.format(sale.totalCop)}</strong><span className="text-[11px] text-[var(--muted)]">{dateFmt.format(new Date(sale.soldAt))}</span></div></div><div className="mt-4 grid gap-3 border-t border-[var(--line)] pt-3 text-xs sm:grid-cols-4"><div><span className="quiet">Cantidad</span><strong className="mt-1 block">{sale.quantity.toLocaleString("es-CO")} {sale.unit}</strong></div><div><span className="quiet">Precio unitario</span><strong className="mt-1 block">{cop.format(sale.unitPriceCop)} / {sale.unit}</strong></div><div><span className="quiet">Movimiento inventario</span><strong className="mt-1 block">{sale.inventoryMovementId.slice(0,8)}…</strong></div><div><span className="quiet">Estado financiero</span><strong className="mt-1 block">Venta registrada · pago no modelado</strong></div></div>{sale.note&&<p className="mt-3 rounded-lg bg-[var(--surface-soft)] p-3 text-xs text-[var(--muted)]">{sale.note}</p>}</article>)}</div>:<div className="rounded-xl border border-dashed border-[var(--line)] p-8 text-center"><strong className="block text-sm">Aún no hay ventas registradas</strong><p className="quiet mt-2">Primero debe existir stock por lote. La venta descontará ese lote en la misma acción.</p><Link className="button primary mt-4 inline-flex" href="/sales/new">Registrar la primera venta</Link></div>}
+    </section>
+  </>;
+}

--- a/src/lib/commercial-domain.test.ts
+++ b/src/lib/commercial-domain.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { customerIdFromKey, grossBillingCop, normalizeCustomerKey, saleTotalCop, soldQuantityByUnit, type SaleRecord } from "./commercial-domain";
+
+const sales: SaleRecord[] = [
+  { id:"s1",plantId:"tamesis",plant:"Támesis",customerId:"c1",customerName:"Cliente Uno",productId:"solid",productName:"Wondergreen sólido",unit:"kg",lotCode:"L1",quantity:60,unitPriceCop:2000,totalCop:120000,soldAt:"2026-08-11T10:00:00-05:00",inventoryMovementId:"m1" },
+  { id:"s2",plantId:"tamesis",plant:"Támesis",customerId:"c2",customerName:"Cliente Dos",productId:"liquid",productName:"Wondergreen líquido",unit:"L",lotCode:"L2",quantity:40,unitPriceCop:3100,totalCop:124000,soldAt:"2026-08-11T11:00:00-05:00",inventoryMovementId:"m2" },
+  { id:"s3",plantId:"tamesis",plant:"Támesis",customerId:"c1",customerName:"Cliente Uno",productId:"solid",productName:"Wondergreen sólido",unit:"kg",lotCode:"L3",quantity:20,unitPriceCop:2200,totalCop:44000,soldAt:"2026-08-11T12:00:00-05:00",inventoryMovementId:"m3" },
+];
+
+describe("commercial domain", () => {
+  it("normalizes equivalent customer names without losing display name", () => {
+    expect(normalizeCustomerKey("  Café   José S.A.S. ")).toBe("cafe jose sas");
+    expect(normalizeCustomerKey("CAFE JOSE SAS")).toBe("cafe jose sas");
+    expect(customerIdFromKey("cafe jose sas")).toBe("customer-cafe-jose-sas");
+  });
+
+  it("derives sale total instead of accepting an editable total", () => {
+    expect(saleTotalCop(60,2000)).toBe(120000);
+    expect(saleTotalCop(0,2000)).toBe(0);
+  });
+
+  it("sums gross billing in COP but keeps sold quantities separated by unit", () => {
+    expect(grossBillingCop(sales)).toBe(288000);
+    expect(soldQuantityByUnit(sales)).toEqual([{unit:"kg",quantity:80},{unit:"L",quantity:40}]);
+  });
+});

--- a/src/lib/commercial-domain.ts
+++ b/src/lib/commercial-domain.ts
@@ -1,0 +1,59 @@
+import type { InventoryUnit } from "@/lib/inventory-domain";
+
+export type CustomerRecord = {
+  id: string;
+  name: string;
+  normalizedKey: string;
+  createdAt: string;
+};
+
+export type SaleRecord = {
+  id: string;
+  plantId: string;
+  plant: string;
+  customerId: string;
+  customerName: string;
+  productId: string;
+  productName: string;
+  unit: InventoryUnit;
+  lotCode: string;
+  quantity: number;
+  unitPriceCop: number;
+  totalCop: number;
+  soldAt: string;
+  inventoryMovementId: string;
+  note?: string;
+};
+
+export function normalizeCustomerKey(value: string) {
+  return value
+    .trim()
+    .replace(/\s+/g, " ")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase("es-CO")
+    .replace(/[^a-z0-9 ]+/g, "")
+    .trim();
+}
+
+export function customerIdFromKey(key: string) {
+  return `customer-${key.replace(/\s+/g, "-") || "sin-nombre"}`;
+}
+
+export function saleTotalCop(quantity: number, unitPriceCop: number) {
+  if (!Number.isFinite(quantity) || quantity <= 0) return 0;
+  if (!Number.isFinite(unitPriceCop) || unitPriceCop <= 0) return 0;
+  return quantity * unitPriceCop;
+}
+
+export function soldQuantityByUnit(sales: SaleRecord[]) {
+  const totals = new Map<InventoryUnit, number>();
+  for (const sale of sales) totals.set(sale.unit, (totals.get(sale.unit) ?? 0) + sale.quantity);
+  return (["kg", "L", "unidades"] as InventoryUnit[])
+    .filter((unit) => totals.has(unit))
+    .map((unit) => ({ unit, quantity: totals.get(unit) ?? 0 }));
+}
+
+export function grossBillingCop(sales: SaleRecord[]) {
+  return sales.reduce((sum, sale) => sum + sale.totalCop, 0);
+}

--- a/supabase/migrations/0010_sales.sql
+++ b/supabase/migrations/0010_sales.sql
@@ -1,0 +1,124 @@
+create or replace function private.normalize_customer_name(value text)
+returns text
+language sql
+immutable
+set search_path = ''
+as $$
+  select btrim(
+    regexp_replace(
+      lower(translate(btrim(value), 'ÁÉÍÓÚÜÑáéíóúüñ', 'AEIOUUNaeiouun')),
+      '[^a-z0-9]+',
+      ' ',
+      'g'
+    )
+  );
+$$;
+
+create table if not exists customers (
+  id uuid primary key default gen_random_uuid(),
+  name text not null check (btrim(name) <> ''),
+  normalized_key text generated always as (private.normalize_customer_name(name)) stored,
+  created_by uuid references auth.users(id) default auth.uid(),
+  created_at timestamptz not null default now()
+);
+
+create unique index if not exists customers_normalized_key_uidx on customers(normalized_key);
+
+create table if not exists sales (
+  id uuid primary key default gen_random_uuid(),
+  plant_id uuid not null references plants(id),
+  customer_id uuid not null references customers(id),
+  product_id uuid not null references inventory_products(id),
+  lot_code text not null,
+  quantity numeric not null check (quantity > 0),
+  unit_price_cop numeric not null check (unit_price_cop > 0),
+  total_cop numeric generated always as (quantity * unit_price_cop) stored,
+  sold_at timestamptz not null default now(),
+  note text,
+  created_by uuid references auth.users(id) default auth.uid(),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists sales_plant_sold_idx on sales(plant_id, sold_at desc);
+create index if not exists sales_customer_sold_idx on sales(customer_id, sold_at desc);
+create index if not exists sales_product_lot_idx on sales(plant_id, product_id, lot_code);
+
+create or replace function private.sale_to_inventory()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  customer_name text;
+begin
+  select c.name into customer_name
+  from public.customers c
+  where c.id = new.customer_id;
+
+  if customer_name is null then
+    raise exception 'Cliente % no existe', new.customer_id using errcode = '23503';
+  end if;
+
+  insert into public.inventory_movements (
+    plant_id,
+    product_id,
+    lot_code,
+    kind,
+    quantity,
+    reference_id,
+    destination,
+    note,
+    occurred_at,
+    created_by
+  ) values (
+    new.plant_id,
+    new.product_id,
+    new.lot_code,
+    'dispatch',
+    new.quantity,
+    new.id,
+    customer_name,
+    new.note,
+    new.sold_at,
+    new.created_by
+  );
+
+  return new;
+end;
+$$;
+
+revoke all on function private.normalize_customer_name(text) from public;
+revoke all on function private.sale_to_inventory() from public;
+grant execute on function private.normalize_customer_name(text) to authenticated;
+
+drop trigger if exists sale_inventory_dispatch on sales;
+create trigger sale_inventory_dispatch
+after insert on sales
+for each row execute function private.sale_to_inventory();
+
+alter table customers enable row level security;
+alter table sales enable row level security;
+
+create policy "customers_member_select" on customers for select to authenticated
+using (exists (
+  select 1 from public.plant_memberships pm
+  where pm.user_id = (select auth.uid()) and pm.active
+));
+
+create policy "customers_member_insert" on customers for insert to authenticated
+with check (exists (
+  select 1 from public.plant_memberships pm
+  where pm.user_id = (select auth.uid()) and pm.active
+));
+
+create policy "sales_member_select" on sales for select to authenticated
+using ((select private.has_plant_access(plant_id)));
+
+create policy "sales_operator_insert" on sales for insert to authenticated
+with check ((select private.has_plant_role(plant_id, array['operator','supervisor','technical','admin','director'])));
+
+-- No UPDATE/DELETE policies in the operational MVP.
+-- Commercial corrections will be explicit reversal/adjustment transactions, preserving auditability.
+-- The AFTER INSERT trigger is atomic with the sale: if the inventory outflow guard raises for insufficient stock,
+-- the sale insert is rolled back by PostgreSQL in the same transaction.


### PR DESCRIPTION
Closes #27

## Qué cambia
- maestro ligero de clientes con normalización determinística;
- venta por planta + producto + lote + cantidad + precio unitario COP;
- total COP derivado, no editable;
- venta local solo nace si la salida de inventario se aprueba;
- movimiento comercial conserva `referenceId = sale.id` y la venta conserva `inventoryMovementId`;
- `/sales` y `/sales/new`;
- facturación bruta COP separada explícitamente de recaudo/utilidad;
- cantidades vendidas separadas por kg/L/unidades;
- PostgreSQL `customers` + `sales` con trigger venta→dispatch;
- el guard concurrente de inventario existente aborta también la venta si no hay stock;
- customer normalization alineada entre app y PostgreSQL;
- E2E: producir → vender parcial → stock baja → sobreventa falla sin crear venta → maestro de cliente reutiliza nombres equivalentes.

## Integridad
No se modelan todavía pagos, cartera, impuestos, costos ni margen. Una salida interna sigue siendo distinta de una venta comercial.