### PR TITLE
Wondergreen v0.5 · Biblioteca + guía de deficiencias gobernada

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -3,6 +3,9 @@ import { test, expect } from "@playwright/test";
 test("dashboard changes horizon and plant without changing metric semantics", async ({ page }) => {
   await page.goto("/dashboard");
   await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+
+  // Keep this contract independent from the wall-clock day so CI does not flip at midnight.
+  await page.getByLabel("Fecha").fill("2026-08-11");
   await expect(page.getByLabel("Indicadores operativos").getByText("3.94 t", { exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Semana" }).click();
   await expect(page.getByText(/10 de ago|11 de ago/i).first()).toBeVisible();

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -21,7 +21,12 @@ test("deficiency guide prevents symptom-only diagnosis and links to crop program
 
 test("deficiency guide can continue into the cacao Wondergreen program", async ({ page }) => {
   await page.goto("/biblioteca/guia-deficiencias");
-  await page.getByRole("link", { name: /Ver programa Wondergreen para Cacao/i }).click();
+
+  const cacaoBlock = page.locator("#cacao");
+  const cacaoLink = cacaoBlock.getByRole("link", { name: /Ver programa Wondergreen para Cacao/i });
+  await cacaoBlock.scrollIntoViewIfNeeded();
+  await expect(cacaoLink).toBeVisible();
+  await cacaoLink.click();
 
   await expect(page).toHaveURL(/\/wondergreen\/cultivos\/cacao$/);
   await expect(page.getByText(/01 · Establecimiento/)).toBeVisible();

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test("public library exposes live Wondergreen knowledge resources", async ({ page }) => {
+  await page.goto("/biblioteca");
+
+  await expect(page.getByRole("heading", { name: /La biblioteca no es un archivo/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Programas Wondergreen por cultivo" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Guía práctica de deficiencias nutricionales" })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Abrir guía/i })).toHaveAttribute("href", "/biblioteca/guia-deficiencias");
+});
+
+test("deficiency guide prevents symptom-only diagnosis and links to crop programs", async ({ page }) => {
+  await page.goto("/biblioteca/guia-deficiencias");
+
+  await expect(page.getByRole("heading", { name: "Una hoja amarilla no es un diagnóstico." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Cuatro preguntas antes del producto" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Cacao", exact: true })).toBeVisible();
+  await expect(page.getByText("Hojas viejas", { exact: true }).first()).toBeVisible();
+  await expect(page.getByRole("link", { name: /Ver programa Wondergreen para Cacao/i })).toHaveAttribute("href", "/wondergreen/cultivos/cacao");
+});
+
+test("deficiency guide can continue into the cacao Wondergreen program", async ({ page }) => {
+  await page.goto("/biblioteca/guia-deficiencias");
+  await page.getByRole("link", { name: /Ver programa Wondergreen para Cacao/i }).click();
+
+  await expect(page).toHaveURL(/\/wondergreen\/cultivos\/cacao$/);
+  await expect(page.getByText(/01 · Establecimiento/)).toBeVisible();
+});

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -24,7 +24,8 @@ test("deficiency guide can continue into the cacao Wondergreen program", async (
 
   const cacaoBlock = page.locator("#cacao");
   const cacaoLink = cacaoBlock.getByRole("link", { name: /Ver programa Wondergreen para Cacao/i });
-  await cacaoBlock.scrollIntoViewIfNeeded();
+  await cacaoLink.evaluate((element) => element.scrollIntoView({ block: "center", inline: "nearest" }));
+  await expect(cacaoLink).toBeInViewport();
   await expect(cacaoLink).toBeVisible();
   await cacaoLink.click();
 

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -13,7 +13,7 @@ test("deficiency guide prevents symptom-only diagnosis and links to crop program
   await page.goto("/biblioteca/guia-deficiencias");
 
   await expect(page.getByRole("heading", { name: "Una hoja amarilla no es un diagnóstico." })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Cuatro preguntas antes del producto" })).toBeVisible();
+  await expect(page.getByText("Cuatro preguntas antes del producto", { exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Cacao", exact: true })).toBeVisible();
   await expect(page.getByText("Hojas viejas", { exact: true }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: /Ver programa Wondergreen para Cacao/i })).toHaveAttribute("href", "/wondergreen/cultivos/cacao");

--- a/src/app/biblioteca/guia-deficiencias/page.tsx
+++ b/src/app/biblioteca/guia-deficiencias/page.tsx
@@ -1,0 +1,124 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { deficiencyCrops, deficiencyQuickRules } from "@/data/wondergreen-knowledge";
+import styles from "../library.module.css";
+
+export const metadata: Metadata = {
+  title: "Guía de deficiencias nutricionales | Wondergreen",
+  description: "Lectura visual orientativa de deficiencias nutricionales por cultivo, con reglas de campo y advertencias para evitar diagnósticos automáticos.",
+};
+
+export default function DeficiencyGuidePage() {
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className={`${styles.container} ${styles.headerInner}`}>
+          <Link href="/" aria-label="Greenatics">
+            <img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
+          </Link>
+          <Link className={styles.headerLink} href="/biblioteca">Biblioteca</Link>
+          <Link className={styles.headerLink} href="/wondergreen/cultivos">Cultivos</Link>
+          <Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link>
+        </div>
+      </header>
+
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Wondergreen · diagnóstico orientativo</span>
+              <h1>Una hoja amarilla no es un diagnóstico.</h1>
+              <p className={styles.lead}>La lectura visual sirve para formular hipótesis, no para saltar directamente a un producto. Primero ubicamos el tejido, el patrón del lote y el contexto; después decidimos qué vale la pena comprobar.</p>
+            </div>
+            <aside className={styles.warning}>
+              <strong>Regla de uso</strong>
+              <p>La guía no sustituye análisis de suelo, análisis foliar, revisión de raíces ni diagnóstico sanitario. Si las señales son ambiguas, la salida correcta es confirmar antes de corregir.</p>
+            </aside>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Cuatro preguntas antes del producto</span>
+              <h2>Lee la planta y el lote en contexto.</h2>
+            </div>
+            <div className={styles.ruleGrid}>
+              {deficiencyQuickRules.map((rule, index) => (
+                <article className={styles.ruleCard} key={rule.title}>
+                  <span>{String(index + 1).padStart(2, "0")}</span>
+                  <h3>{rule.title}</h3>
+                  <p>{rule.copy}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.white}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Lectura por cultivo</span>
+              <h2>El mismo nutriente no siempre se ve igual.</h2>
+              <p>Estas tablas son una capa de orientación y mantienen visibles los principales confundidores antes de convertir un síntoma en una recomendación.</p>
+            </div>
+            <div className={styles.deficiencyStack}>
+              {deficiencyCrops.map((crop) => (
+                <article className={styles.cropBlock} key={crop.slug} id={crop.slug}>
+                  <div className={styles.cropHead}>
+                    <div>
+                      <span className={styles.eyebrow}>Guía · {crop.name}</span>
+                      <h2>{crop.name}</h2>
+                    </div>
+                    <p>{crop.intro}</p>
+                  </div>
+                  <div className={styles.tableWrap}>
+                    <table className={styles.table}>
+                      <thead><tr><th>Nutriente</th><th>Dónde empieza</th><th>Señal orientativa</th><th>Qué revisar</th></tr></thead>
+                      <tbody>
+                        {crop.rows.map((row) => (
+                          <tr key={`${crop.slug}-${row.nutrient}`}>
+                            <td><strong>{row.nutrient}</strong></td>
+                            <td>{row.starts}</td>
+                            <td>{row.symptom}</td>
+                            <td>{row.interpretation}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  <div className={styles.notes}>{crop.fieldNotes.map((note) => <div className={styles.note} key={note}>{note}</div>)}</div>
+                  <Link className={styles.inlineLink} href={`/wondergreen/cultivos/${crop.cropSlug}`}>Ver programa Wondergreen para {crop.name} →</Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.dark}`}>
+          <div className={`${styles.container} ${styles.sourceGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Cómo usar esta información</span>
+              <h2>Hipótesis → comprobación → decisión.</h2>
+            </div>
+            <div>
+              <p>Si la lectura visual apunta a una posible carencia, la siguiente pregunta no es “¿qué producto aplico?”, sino “¿qué otra causa puede producir este patrón y qué evidencia puedo obtener?”. Solo después se conecta la necesidad con una familia Wondergreen y con su versión técnica vigente.</p>
+              <Link href="/wondergreen#portafolio">Consultar Product Master →</Link>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.closing}>
+          <div className={`${styles.container} ${styles.closingInner}`}>
+            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>¿Quieres revisar un caso de campo con contexto?</h2></div>
+            <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen#contacto">Hablar con equipo técnico</Link>
+          </div>
+        </section>
+      </main>
+
+      <footer className={styles.footer}>
+        <div className={`${styles.container} ${styles.footerInner}`}><span>© Greenatics S.A.S. · Wondergreen · Guía de deficiencias</span><Link href="/biblioteca">Volver a Biblioteca</Link></div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/biblioteca/guia-deficiencias/page.tsx
+++ b/src/app/biblioteca/guia-deficiencias/page.tsx
@@ -78,10 +78,10 @@ export default function DeficiencyGuidePage() {
                       <tbody>
                         {crop.rows.map((row) => (
                           <tr key={`${crop.slug}-${row.nutrient}`}>
-                            <td><strong>{row.nutrient}</strong></td>
-                            <td>{row.starts}</td>
-                            <td>{row.symptom}</td>
-                            <td>{row.interpretation}</td>
+                            <td data-label="Nutriente"><strong>{row.nutrient}</strong></td>
+                            <td data-label="Dónde empieza">{row.starts}</td>
+                            <td data-label="Señal orientativa">{row.symptom}</td>
+                            <td data-label="Qué revisar">{row.interpretation}</td>
                           </tr>
                         ))}
                       </tbody>

--- a/src/app/biblioteca/guia-deficiencias/page.tsx
+++ b/src/app/biblioteca/guia-deficiencias/page.tsx
@@ -88,7 +88,12 @@ export default function DeficiencyGuidePage() {
                     </table>
                   </div>
                   <div className={styles.notes}>{crop.fieldNotes.map((note) => <div className={styles.note} key={note}>{note}</div>)}</div>
-                  <Link className={styles.inlineLink} href={`/wondergreen/cultivos/${crop.cropSlug}`}>Ver programa Wondergreen para {crop.name} →</Link>
+                  <div className={styles.cropActions}>
+                    <Link className={styles.cropCta} href={`/wondergreen/cultivos/${crop.cropSlug}`}>
+                      <span>Ver programa Wondergreen para {crop.name}</span>
+                      <span aria-hidden="true">→</span>
+                    </Link>
+                  </div>
                 </article>
               ))}
             </div>

--- a/src/app/biblioteca/library.module.css
+++ b/src/app/biblioteca/library.module.css
@@ -50,7 +50,7 @@
 .ruleCard > span { color: var(--green700); font-size: .72rem; font-weight: 900; }
 .ruleCard p { color: var(--muted); font-size: .9rem; }
 .deficiencyStack { display: grid; gap: 22px; }
-.cropBlock { padding: 28px; border-radius: 26px; background: white; border: 1px solid var(--line); }
+.cropBlock { position: relative; isolation: isolate; scroll-margin-top: 88px; padding: 28px; border-radius: 26px; background: white; border: 1px solid var(--line); }
 .cropHead { display: grid; grid-template-columns: .6fr 1.4fr; gap: 30px; align-items: start; margin-bottom: 22px; }
 .cropHead p { margin: 0; color: var(--muted); }
 .tableWrap { overflow-x: auto; border-radius: 18px; border: 1px solid var(--line); }
@@ -61,7 +61,7 @@
 .table tr:last-child td { border-bottom: 0; }
 .notes { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; margin-top: 16px; }
 .note { padding: 13px 14px; border-radius: 14px; background: #f4f7f1; color: #5b6760; font-size: .84rem; }
-.inlineLink { display: inline-flex; margin-top: 18px; color: var(--green700) !important; font-weight: 900; }
+.inlineLink { position: relative; z-index: 2; display: inline-flex; align-items: center; min-height: 44px; margin-top: 14px; padding: 6px 0; color: var(--green700) !important; font-weight: 900; touch-action: manipulation; }
 .sourceGrid { display: grid; grid-template-columns: .8fr 1.2fr; gap: 50px; align-items: start; }
 .sourceGrid p { color: #c0cec7; }
 .sourceGrid a { color: #d8ffbe; font-weight: 900; }
@@ -80,5 +80,7 @@
   .logo { width: 142px; }
   .headerLink { display: none; }
   .libraryGrid, .ruleGrid { grid-template-columns: 1fr; }
+  .cropBlock { scroll-margin-top: 78px; padding: 22px 18px; }
+  .inlineLink { width: 100%; padding: 10px 0; }
   .closingInner, .footerInner { flex-direction: column; align-items: flex-start; }
 }

--- a/src/app/biblioteca/library.module.css
+++ b/src/app/biblioteca/library.module.css
@@ -84,6 +84,15 @@
   .headerLink { display: none; }
   .libraryGrid, .ruleGrid { grid-template-columns: 1fr; }
   .cropBlock { scroll-margin-top: 78px; padding: 22px 18px; }
+  .tableWrap { overflow: visible; border: 0; border-radius: 0; }
+  .table { display: block; width: 100%; min-width: 0; border-collapse: separate; background: transparent; }
+  .table thead { display: none; }
+  .table tbody { display: grid; gap: 10px; }
+  .table tr { display: block; overflow: hidden; width: 100%; border: 1px solid var(--line); border-radius: 16px; background: white; }
+  .table td { display: grid; grid-template-columns: minmax(98px, .72fr) minmax(0, 1.28fr); gap: 10px; width: 100%; padding: 10px 12px; border-bottom: 1px solid var(--line); font-size: .88rem; }
+  .table td::before { content: attr(data-label); color: var(--green800); font-size: .68rem; font-weight: 900; letter-spacing: .04em; text-transform: uppercase; }
+  .table tr td:last-child { border-bottom: 0; }
+  .notes { margin-top: 14px; }
   .cropActions { margin-top: 20px; }
   .cropCta { min-height: 54px; padding: 14px 16px; }
   .closingInner, .footerInner { flex-direction: column; align-items: flex-start; }

--- a/src/app/biblioteca/library.module.css
+++ b/src/app/biblioteca/library.module.css
@@ -1,0 +1,84 @@
+.page {
+  --green950: #14352c;
+  --green800: #006b45;
+  --green700: #008b4c;
+  --lime400: #98cf4f;
+  --yellow400: #f4d944;
+  --ink: #17201c;
+  --muted: #647068;
+  --paper: #f7f8f3;
+  --line: #dfe5dc;
+  color: var(--ink);
+  background: var(--paper);
+  min-height: 100vh;
+  font-family: Arial, Helvetica, sans-serif;
+}
+.page *, .page *::before, .page *::after { box-sizing: border-box; }
+.page a { color: inherit; text-decoration: none; }
+.container { width: min(1120px, calc(100% - 40px)); margin: 0 auto; }
+.header { position: sticky; top: 0; z-index: 30; background: rgba(247,248,243,.95); border-bottom: 1px solid var(--line); backdrop-filter: blur(14px); }
+.headerInner { min-height: 72px; display: flex; align-items: center; gap: 20px; }
+.logo { width: 170px; height: auto; margin-right: auto; }
+.headerLink { color: var(--green800) !important; font-weight: 800; font-size: .9rem; }
+.button { display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 0 18px; border-radius: 999px; border: 1px solid var(--line); font-weight: 800; }
+.primary { background: var(--green800); color: white !important; border-color: var(--green800); }
+.eyebrow { display: inline-block; color: var(--green700); font-size: .72rem; font-weight: 900; text-transform: uppercase; letter-spacing: .11em; margin-bottom: 12px; }
+.page h1, .page h2, .page h3 { margin: 0; font-family: "Arial Rounded MT", "Arial Rounded MT Bold", Arial, sans-serif; line-height: 1.06; letter-spacing: -.03em; }
+.page h1 { font-size: clamp(2.8rem, 6vw, 5.1rem); }
+.page h2 { font-size: clamp(2rem, 4vw, 3.3rem); }
+.page h3 { font-size: 1.3rem; }
+.lead { max-width: 790px; color: #506058; font-size: 1.16rem; }
+.hero { padding: 82px 0 92px; background: linear-gradient(135deg, #f9faef, #e7f2df); }
+.heroGrid { display: grid; grid-template-columns: 1fr .7fr; gap: 60px; align-items: end; }
+.warning { padding: 24px; border-radius: 24px; background: white; border: 1px solid var(--line); }
+.warning strong { display: block; font-size: 1.06rem; }
+.warning p { margin-bottom: 0; color: var(--muted); }
+.section { padding: 92px 0; }
+.white { background: white; }
+.soft { background: #eef4eb; }
+.dark { background: var(--green950); color: white; }
+.sectionHeading { max-width: 800px; margin-bottom: 34px; }
+.sectionHeading p { color: var(--muted); }
+.dark .sectionHeading p { color: #c0cec7; }
+.libraryGrid { display: grid; grid-template-columns: repeat(3,1fr); gap: 16px; }
+.libraryCard { min-height: 260px; padding: 26px; border-radius: 24px; border: 1px solid var(--line); background: white; display: flex; flex-direction: column; }
+.libraryCard p { color: var(--muted); }
+.libraryCard a { margin-top: auto; color: var(--green700); font-weight: 900; }
+.status { display: inline-flex; width: fit-content; padding: 6px 9px; border-radius: 999px; background: #e8f3e3; color: var(--green800); font-size: .68rem; font-weight: 900; text-transform: uppercase; letter-spacing: .05em; margin-bottom: 14px; }
+.ruleGrid { display: grid; grid-template-columns: repeat(4,1fr); gap: 12px; }
+.ruleCard { padding: 20px; border-radius: 20px; border: 1px solid var(--line); background: white; }
+.ruleCard > span { color: var(--green700); font-size: .72rem; font-weight: 900; }
+.ruleCard p { color: var(--muted); font-size: .9rem; }
+.deficiencyStack { display: grid; gap: 22px; }
+.cropBlock { padding: 28px; border-radius: 26px; background: white; border: 1px solid var(--line); }
+.cropHead { display: grid; grid-template-columns: .6fr 1.4fr; gap: 30px; align-items: start; margin-bottom: 22px; }
+.cropHead p { margin: 0; color: var(--muted); }
+.tableWrap { overflow-x: auto; border-radius: 18px; border: 1px solid var(--line); }
+.table { width: 100%; min-width: 760px; border-collapse: collapse; background: white; }
+.table th, .table td { padding: 14px 16px; text-align: left; vertical-align: top; border-bottom: 1px solid var(--line); }
+.table th { background: #f2f6ee; color: #526058; font-size: .76rem; text-transform: uppercase; letter-spacing: .06em; }
+.table td { font-size: .9rem; }
+.table tr:last-child td { border-bottom: 0; }
+.notes { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; margin-top: 16px; }
+.note { padding: 13px 14px; border-radius: 14px; background: #f4f7f1; color: #5b6760; font-size: .84rem; }
+.inlineLink { display: inline-flex; margin-top: 18px; color: var(--green700) !important; font-weight: 900; }
+.sourceGrid { display: grid; grid-template-columns: .8fr 1.2fr; gap: 50px; align-items: start; }
+.sourceGrid p { color: #c0cec7; }
+.sourceGrid a { color: #d8ffbe; font-weight: 900; }
+.closing { padding: 70px 0; background: var(--lime400); }
+.closingInner { display: flex; align-items: end; justify-content: space-between; gap: 28px; }
+.footer { padding: 32px 0; background: #0d241d; color: #b9c8c0; }
+.footerInner { display: flex; justify-content: space-between; gap: 24px; }
+@media (max-width: 900px) {
+  .heroGrid, .cropHead, .sourceGrid { grid-template-columns: 1fr; }
+  .libraryGrid { grid-template-columns: repeat(2,1fr); }
+  .ruleGrid { grid-template-columns: repeat(2,1fr); }
+  .notes { grid-template-columns: 1fr; }
+}
+@media (max-width: 640px) {
+  .container { width: min(100% - 28px,1120px); }
+  .logo { width: 142px; }
+  .headerLink { display: none; }
+  .libraryGrid, .ruleGrid { grid-template-columns: 1fr; }
+  .closingInner, .footerInner { flex-direction: column; align-items: flex-start; }
+}

--- a/src/app/biblioteca/library.module.css
+++ b/src/app/biblioteca/library.module.css
@@ -50,7 +50,7 @@
 .ruleCard > span { color: var(--green700); font-size: .72rem; font-weight: 900; }
 .ruleCard p { color: var(--muted); font-size: .9rem; }
 .deficiencyStack { display: grid; gap: 22px; }
-.cropBlock { position: relative; isolation: isolate; scroll-margin-top: 88px; padding: 28px; border-radius: 26px; background: white; border: 1px solid var(--line); }
+.cropBlock { position: relative; scroll-margin-top: 88px; padding: 28px; border-radius: 26px; background: white; border: 1px solid var(--line); }
 .cropHead { display: grid; grid-template-columns: .6fr 1.4fr; gap: 30px; align-items: start; margin-bottom: 22px; }
 .cropHead p { margin: 0; color: var(--muted); }
 .tableWrap { overflow-x: auto; border-radius: 18px; border: 1px solid var(--line); }
@@ -61,7 +61,10 @@
 .table tr:last-child td { border-bottom: 0; }
 .notes { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; margin-top: 16px; }
 .note { padding: 13px 14px; border-radius: 14px; background: #f4f7f1; color: #5b6760; font-size: .84rem; }
-.inlineLink { position: relative; z-index: 2; display: inline-flex; align-items: center; min-height: 44px; scroll-margin-top: 92px; margin-top: 14px; padding: 6px 0; color: var(--green700) !important; font-weight: 900; touch-action: manipulation; }
+.cropActions { position: relative; z-index: 4; margin-top: 18px; padding-top: 4px; }
+.cropCta { display: flex; width: 100%; min-height: 52px; align-items: center; justify-content: space-between; gap: 16px; padding: 13px 18px; border-radius: 16px; background: var(--green800); color: white !important; font-weight: 900; box-shadow: 0 8px 22px rgba(0,107,69,.14); touch-action: manipulation; }
+.cropCta:hover { background: var(--green700); }
+.cropCta:focus-visible { outline: 3px solid var(--yellow400); outline-offset: 3px; }
 .sourceGrid { display: grid; grid-template-columns: .8fr 1.2fr; gap: 50px; align-items: start; }
 .sourceGrid p { color: #c0cec7; }
 .sourceGrid a { color: #d8ffbe; font-weight: 900; }
@@ -81,6 +84,7 @@
   .headerLink { display: none; }
   .libraryGrid, .ruleGrid { grid-template-columns: 1fr; }
   .cropBlock { scroll-margin-top: 78px; padding: 22px 18px; }
-  .inlineLink { width: 100%; min-height: 48px; scroll-margin-top: 82px; padding: 10px 0; }
+  .cropActions { margin-top: 20px; }
+  .cropCta { min-height: 54px; padding: 14px 16px; }
   .closingInner, .footerInner { flex-direction: column; align-items: flex-start; }
 }

--- a/src/app/biblioteca/library.module.css
+++ b/src/app/biblioteca/library.module.css
@@ -61,7 +61,7 @@
 .table tr:last-child td { border-bottom: 0; }
 .notes { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; margin-top: 16px; }
 .note { padding: 13px 14px; border-radius: 14px; background: #f4f7f1; color: #5b6760; font-size: .84rem; }
-.inlineLink { position: relative; z-index: 2; display: inline-flex; align-items: center; min-height: 44px; margin-top: 14px; padding: 6px 0; color: var(--green700) !important; font-weight: 900; touch-action: manipulation; }
+.inlineLink { position: relative; z-index: 2; display: inline-flex; align-items: center; min-height: 44px; scroll-margin-top: 92px; margin-top: 14px; padding: 6px 0; color: var(--green700) !important; font-weight: 900; touch-action: manipulation; }
 .sourceGrid { display: grid; grid-template-columns: .8fr 1.2fr; gap: 50px; align-items: start; }
 .sourceGrid p { color: #c0cec7; }
 .sourceGrid a { color: #d8ffbe; font-weight: 900; }
@@ -81,6 +81,6 @@
   .headerLink { display: none; }
   .libraryGrid, .ruleGrid { grid-template-columns: 1fr; }
   .cropBlock { scroll-margin-top: 78px; padding: 22px 18px; }
-  .inlineLink { width: 100%; padding: 10px 0; }
+  .inlineLink { width: 100%; min-height: 48px; scroll-margin-top: 82px; padding: 10px 0; }
   .closingInner, .footerInner { flex-direction: column; align-items: flex-start; }
 }

--- a/src/app/biblioteca/page.tsx
+++ b/src/app/biblioteca/page.tsx
@@ -1,0 +1,116 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import styles from "./library.module.css";
+
+export const metadata: Metadata = {
+  title: "Biblioteca | Greenatics",
+  description: "Guías, programas por cultivo y herramientas técnicas de Greenatics y Wondergreen convertidas en conocimiento navegable.",
+};
+
+const resources = [
+  {
+    status: "Disponible",
+    title: "Programas Wondergreen por cultivo",
+    copy: "Café, cacao, aguacate, limón Tahití y pastos con lectura por etapa, cautelas, alertas y seguimiento.",
+    href: "/wondergreen/cultivos",
+    cta: "Explorar cultivos",
+  },
+  {
+    status: "Disponible",
+    title: "Guía práctica de deficiencias nutricionales",
+    copy: "Una herramienta de lectura visual inicial que obliga a revisar tejido, patrón del lote y contexto antes de recomendar.",
+    href: "/biblioteca/guia-deficiencias",
+    cta: "Abrir guía",
+  },
+  {
+    status: "Integrado en Wondergreen",
+    title: "Más que NPK",
+    copy: "Matriz orgánica, formulación, oclusión y peletizado explicados con un claim gate que separa característica técnica de promesa agronómica.",
+    href: "/wondergreen#tecnologia",
+    cta: "Ver tecnología",
+  },
+  {
+    status: "En consolidación",
+    title: "Manual de uso Wondergreen",
+    copy: "Criterios comunes de aplicación, agua, compatibilidad, registro de eventos y seguimiento. Se publicará por versiones, no como receta universal.",
+    href: "/wondergreen/cultivos",
+    cta: "Ver criterios en cultivo",
+  },
+  {
+    status: "En consolidación",
+    title: "Catálogo técnico gobernado",
+    copy: "Productos, formatos, presentaciones, estados comerciales y documentación vinculados al Product Master público.",
+    href: "/wondergreen#portafolio",
+    cta: "Ver Product Master",
+  },
+  {
+    status: "Próxima capa",
+    title: "Diagnóstico orientativo",
+    copy: "Cultivo + etapa + necesidad + problema + contexto. El resultado será una ruta potencial, no una prescripción automática.",
+    href: "/wondergreen#finder",
+    cta: "Conocer el Finder",
+  },
+];
+
+export default function LibraryPage() {
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className={`${styles.container} ${styles.headerInner}`}>
+          <Link href="/" aria-label="Greenatics">
+            <img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
+          </Link>
+          <Link className={styles.headerLink} href="/wondergreen">Wondergreen</Link>
+          <Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link>
+        </div>
+      </header>
+
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Greenatics · conocimiento aplicado</span>
+              <h1>La biblioteca no es un archivo. Es parte de la decisión.</h1>
+              <p className={styles.lead}>Convertimos guías, manuales y conocimiento técnico ya construido en rutas web conectadas con cultivos, productos, síntomas, evidencia y acompañamiento.</p>
+            </div>
+            <aside className={styles.warning}>
+              <strong>Conocimiento antes que recomendación.</strong>
+              <p>Una página técnica debe ayudar a formular mejores preguntas. Cuando la información no alcanza, la salida correcta es pedir análisis o escalar a un asesor.</p>
+            </aside>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.white}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Recursos</span>
+              <h2>De PDF aislado a sistema de conocimiento.</h2>
+              <p>Cada recurso tendrá estado, fuente y relación explícita con el Product Master o con una ruta técnica.</p>
+            </div>
+            <div className={styles.libraryGrid}>
+              {resources.map((resource) => (
+                <article className={styles.libraryCard} key={resource.title}>
+                  <span className={styles.status}>{resource.status}</span>
+                  <h3>{resource.title}</h3>
+                  <p>{resource.copy}</p>
+                  <Link href={resource.href}>{resource.cta} →</Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.closing}>
+          <div className={`${styles.container} ${styles.closingInner}`}>
+            <div><span className={styles.eyebrow}>Biblioteca Greenatics</span><h2>¿Buscas una guía para un cultivo específico?</h2></div>
+            <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen/cultivos">Ver cultivos</Link>
+          </div>
+        </section>
+      </main>
+
+      <footer className={styles.footer}>
+        <div className={`${styles.container} ${styles.footerInner}`}><span>© Greenatics S.A.S. · Biblioteca</span><Link href="/">Volver a Greenatics</Link></div>
+      </footer>
+    </div>
+  );
+}

--- a/src/data/wondergreen-knowledge.test.ts
+++ b/src/data/wondergreen-knowledge.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { wondergreenCrops } from "@/data/wondergreen-crops";
+import { deficiencyCrops, deficiencyQuickRules } from "@/data/wondergreen-knowledge";
+
+describe("Wondergreen deficiency knowledge", () => {
+  it("keeps four diagnostic questions before product selection", () => {
+    expect(deficiencyQuickRules).toHaveLength(4);
+    expect(deficiencyQuickRules.map((rule) => rule.title)).toEqual([
+      "Hojas viejas",
+      "Hojas nuevas",
+      "Patrón del lote",
+      "Antes de corregir",
+    ]);
+  });
+
+  it("covers the five initial crops", () => {
+    expect(deficiencyCrops).toHaveLength(5);
+    expect(new Set(deficiencyCrops.map((crop) => crop.slug)).size).toBe(5);
+  });
+
+  it("links every deficiency crop to an existing Wondergreen crop program", () => {
+    const cropSlugs = new Set(wondergreenCrops.map((crop) => crop.slug));
+    for (const crop of deficiencyCrops) {
+      expect(cropSlugs.has(crop.cropSlug), `Missing crop program for ${crop.name}`).toBe(true);
+    }
+  });
+
+  it("keeps interpretation context instead of symptom-only rows", () => {
+    for (const crop of deficiencyCrops) {
+      expect(crop.rows.length).toBeGreaterThanOrEqual(5);
+      expect(crop.fieldNotes.length).toBeGreaterThanOrEqual(3);
+      for (const row of crop.rows) {
+        expect(row.interpretation.length).toBeGreaterThan(20);
+      }
+    }
+  });
+});

--- a/src/data/wondergreen-knowledge.ts
+++ b/src/data/wondergreen-knowledge.ts
@@ -1,0 +1,99 @@
+export type DeficiencyRow = {
+  nutrient: string;
+  starts: string;
+  symptom: string;
+  interpretation: string;
+};
+
+export type DeficiencyCrop = {
+  slug: string;
+  cropSlug: string;
+  name: string;
+  intro: string;
+  rows: DeficiencyRow[];
+  fieldNotes: string[];
+};
+
+export const deficiencyQuickRules = [
+  { title: "Hojas viejas", copy: "Revisar primero nutrientes móviles como N, P, K y Mg, sin asumir que el síntoma es exclusivamente nutricional." },
+  { title: "Hojas nuevas", copy: "Revisar primero Ca, S, B, Fe, Zn y Mn, junto con raíz, pH y condición hídrica." },
+  { title: "Patrón del lote", copy: "Distinguir planta aislada, manchón, zona baja, ladera, cabecera de riego o afectación general." },
+  { title: "Antes de corregir", copy: "Cruzar fertilización previa, pH, textura, drenaje, humedad, raíces, carga productiva y síntomas sanitarios." },
+] as const;
+
+export const deficiencyCrops: DeficiencyCrop[] = [
+  {
+    slug: "aguacate",
+    cropSlug: "aguacate",
+    name: "Aguacate",
+    intro: "La lectura visual debe contrastarse con análisis foliar y condiciones de suelo: pH alto, asfixia radicular, salinidad y desbalances pueden producir síntomas parecidos.",
+    rows: [
+      { nutrient: "N", starts: "Hojas viejas", symptom: "Pérdida de vigor, hojas pequeñas y verde pálido.", interpretation: "Revisar vigor general, brotación y manejo previo." },
+      { nutrient: "K", starts: "Hojas viejas", symptom: "Clorosis y necrosis desde punta y bordes; posible fruta pequeña.", interpretation: "Puede confundirse con salinidad o cloruros." },
+      { nutrient: "Zn", starts: "Hojas nuevas", symptom: "Moteado amarillo, entrenudos cortos y hojas pequeñas.", interpretation: "Frecuente con pH alto o fósforo elevado." },
+      { nutrient: "Fe", starts: "Hojas nuevas", symptom: "Clorosis intervenal con nervaduras verdes.", interpretation: "Sospechar especialmente en condiciones alcalinas." },
+      { nutrient: "B", starts: "Brotes", symptom: "Corrugación, necrosis marginal y deformación de brotes o fruto.", interpretation: "Diferenciar de calcio y daños del crecimiento." },
+    ],
+    fieldNotes: ["Si el problema se concentra en sectores de pH alto, revisar Fe y Zn.", "Hojas pequeñas + entrenudos cortos + moteado orientan primero a Zn.", "Deformación fuerte de brotes y fruto exige revisar B y condición radicular."],
+  },
+  {
+    slug: "cacao",
+    cropSlug: "cacao",
+    name: "Cacao",
+    intro: "La sintomatología visual es orientativa y debe confirmarse con análisis foliar y de suelo, especialmente en lotes viejos o de alta extracción.",
+    rows: [
+      { nutrient: "N", starts: "Hojas viejas / planta", symptom: "Follaje verde pálido, crecimiento lento y menor vigor.", interpretation: "Puede confundirse con baja materia orgánica o lavado." },
+      { nutrient: "K", starts: "Hojas viejas", symptom: "Amarillamiento marginal que progresa a necrosis.", interpretation: "Revisar junto con estrés hídrico y carga productiva." },
+      { nutrient: "Mg", starts: "Hojas viejas", symptom: "Clorosis intervenal conservando nervaduras más verdes.", interpretation: "Puede agravarse con exceso relativo de K." },
+      { nutrient: "Fe / Zn", starts: "Hojas nuevas", symptom: "Clorosis intervenal; con Zn pueden aparecer hojas pequeñas.", interpretation: "Confirmar porque los patrones pueden superponerse." },
+      { nutrient: "B", starts: "Brotes", symptom: "Deformación y mala expansión foliar; problemas de cuajado.", interpretation: "Revisar junto con Ca y estrés hídrico." },
+    ],
+    fieldNotes: ["Hoja adulta con clorosis intervenal: revisar Mg primero.", "Hoja nueva con clorosis intervenal: revisar Fe o Zn.", "En lotes de alta extracción, K y Mg merecen revisión prioritaria."],
+  },
+  {
+    slug: "cafe",
+    cropSlug: "cafe",
+    name: "Café",
+    intro: "El diagnóstico visual tiene buena base técnica en Colombia, pero debe cruzarse con suelo, estado foliar, época de muestreo y carga productiva.",
+    rows: [
+      { nutrient: "N", starts: "Hojas viejas", symptom: "Clorosis; en casos severos paloteo y pérdida de vigor.", interpretation: "Revisar alta carga y fertilización previa." },
+      { nutrient: "K", starts: "Hojas viejas", symptom: "Necrosis en punta y bordes; defoliación en casos severos.", interpretation: "Muy relevante durante producción." },
+      { nutrient: "Mg", starts: "Hojas viejas", symptom: "Clorosis intervenal y defoliación en ramas productivas.", interpretation: "Puede coexistir con niveles altos de K." },
+      { nutrient: "B", starts: "Brotes", symptom: "Muerte de yemas, rebrote lateral y tejido corchoso.", interpretation: "La V invertida y los signos corchosos son pistas útiles." },
+      { nutrient: "Zn", starts: "Hojas nuevas", symptom: "Hojas pequeñas, lanceoladas y entrenudos cortos.", interpretation: "No confundir con sequía o sombra intensa." },
+    ],
+    fieldNotes: ["N y K son macronutrientes de alta demanda en producción.", "Una V invertida o signos corchosos orientan a revisar B.", "La época de muestreo y la carga cambian la lectura del síntoma."],
+  },
+  {
+    slug: "pastos",
+    cropSlug: "pastos-gramineas",
+    name: "Pastos y gramíneas",
+    intro: "Primero se lee el patrón del potrero y después la hoja. Corte, pastoreo, humedad, compactación y fertilización reciente cambian completamente la interpretación.",
+    rows: [
+      { nutrient: "N", starts: "Hojas viejas", symptom: "Clorosis general y pérdida progresiva de color.", interpretation: "Es frecuente, pero no debe diagnosticarse sin revisar manejo." },
+      { nutrient: "P", starts: "Plantas jóvenes / hojas bajas", symptom: "Rebrote lento, enanismo y tonos rojizos o púrpura.", interpretation: "Puede confundirse con compactación, frío o encharcamiento." },
+      { nutrient: "K", starts: "Hojas viejas", symptom: "Estrías amarillas y quemado de puntas.", interpretation: "Revisar especialmente después de cortes repetidos." },
+      { nutrient: "Mg", starts: "Hojas viejas", symptom: "Clorosis intervenal y bordes café rojizo.", interpretation: "Frecuente en suelos ácidos, arenosos o con K alto." },
+      { nutrient: "S", starts: "Hojas nuevas", symptom: "Verde pálido a amarillo en tejido joven.", interpretation: "Se parece a N, pero comienza en tejido más nuevo." },
+    ],
+    fieldNotes: ["Después del segundo o tercer corte, revisar K si aparecen síntomas.", "Una pradera rala no equivale automáticamente a deficiencia.", "Estrés hídrico puede simular deficiencia; revisar humedad primero."],
+  },
+  {
+    slug: "limon-tahiti",
+    cropSlug: "limon-tahiti",
+    name: "Limón Tahití",
+    intro: "En cítricos es crítico diferenciar nutrición de problemas sanitarios, daño radicular, pH alto y anegamiento. El fruto también aporta pistas de diagnóstico.",
+    rows: [
+      { nutrient: "N", starts: "Hojas viejas", symptom: "Canopia menos verde, amarillamiento general y menor crecimiento.", interpretation: "Diferenciar de senescencia o sombra." },
+      { nutrient: "P", starts: "Fruto y hojas", symptom: "Cáscara más gruesa, menor jugo y posible follaje bronceado.", interpretation: "El fruto orienta parte de la lectura." },
+      { nutrient: "K", starts: "Fruto / hojas viejas", symptom: "Frutos pequeños y cambios en cáscara; posible caída.", interpretation: "Revisar carga y condición química del suelo." },
+      { nutrient: "Mg", starts: "Hojas viejas", symptom: "Patrón amarillo-verdoso y V invertida verde característica.", interpretation: "Uno de los patrones útiles en cítricos." },
+      { nutrient: "Fe", starts: "Hojas nuevas", symptom: "Clorosis intervenal intensa con nervaduras verdes.", interpretation: "Frecuente con pH alto o limitación radicular." },
+    ],
+    fieldNotes: ["No asumir Zn o Mn sin descartar causas sanitarias cuando el patrón es irregular.", "El estado del fruto complementa la lectura foliar.", "Antes de corregir, revisar drenaje, raíces, pH y agua."],
+  },
+];
+
+export function getDeficiencyCrop(slug: string) {
+  return deficiencyCrops.find((crop) => crop.slug === slug);
+}


### PR DESCRIPTION
## Objetivo
Recuperar el conocimiento técnico ya construido en Greenatics Marketing Studio y convertirlo en una biblioteca pública navegable, sin transformar una lectura visual en diagnóstico o prescripción automática.

## Alcance
- `/biblioteca` como centro público de conocimiento aplicado.
- `/biblioteca/guia-deficiencias` con lectura por cultivo.
- 5 cultivos: aguacate, cacao, café, pastos/gramíneas y limón Tahití.
- Regla explícita: una hoja amarilla no es un diagnóstico.
- Cuatro filtros antes de seleccionar producto: tejido viejo/nuevo, patrón del lote y contexto antes de corregir.
- Tablas con nutriente, tejido donde inicia, señal orientativa y qué revisar.
- Confundidores y notas de campo visibles.
- Enlaces desde cada bloque de deficiencias al programa Wondergreen correspondiente.
- Biblioteca que distingue recursos disponibles, integrados, en consolidación y próxima capa.

## Truth lock
- La guía no sustituye análisis de suelo, foliar, raíces ni diagnóstico sanitario.
- Un síntoma genera hipótesis; no dispara automáticamente una recomendación Wondergreen.
- La conexión con producto ocurre después de comprobar contexto y consultar la versión técnica vigente.

## QA
- Unit: cuatro reglas de diagnóstico, cinco cultivos y enlaces válidos a programas existentes.
- Unit: todas las filas mantienen interpretación/contexto, no solo síntoma.
- E2E: Biblioteca, guía, principio anti-diagnóstico automático y navegación a programa de cacao.

## Base
PR apilado sobre `feat/wondergreen-product-master-v0.4` para mantener el diff limitado a conocimiento público. No modifica OPS.
