### PR TITLE
Public Web v0.6 · Servicios gobernados + navegación real

### DIFF
--- a/e2e/public-services.spec.ts
+++ b/e2e/public-services.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+test("services page exposes governed capabilities and audience paths", async ({ page }) => {
+  await page.goto("/servicios");
+
+  await expect(page.getByRole("heading", { name: "Del residuo al sistema que puede operar." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Municipios y ESP", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Empresas y grandes generadores", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Diagnóstico y caracterización de residuos orgánicos" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Diseño e implementación de plantas de aprovechamiento" })).toBeVisible();
+  await expect(page.getByText("Alcance gobernado:", { exact: true })).toBeVisible();
+});
+
+test("public home routes Soluciones and Conocimiento to real pages", async ({ page }) => {
+  await page.goto("/");
+
+  const nav = page.getByRole("navigation", { name: "Navegación pública" });
+  await expect(nav.getByRole("link", { name: "Soluciones" })).toHaveAttribute("href", "/servicios");
+  await expect(nav.getByRole("link", { name: "Conocimiento" })).toHaveAttribute("href", "/biblioteca");
+
+  await nav.getByRole("link", { name: "Soluciones" }).click();
+  await expect(page).toHaveURL(/\/servicios$/);
+  await expect(page.getByRole("heading", { name: "Del residuo al sistema que puede operar." })).toBeVisible();
+});
+
+test("public home routes territorial and company doors into service audiences", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("link", { name: /Explorar soluciones/i }).first()).toHaveAttribute("href", "/servicios#municipios");
+  await expect(page.getByRole("link", { name: /Explorar soluciones/i }).nth(1)).toHaveAttribute("href", "/servicios#empresas");
+});
+
+test("services page keeps knowledge and OPS bridges visible", async ({ page }) => {
+  await page.goto("/servicios");
+
+  await expect(page.getByRole("link", { name: "Biblioteca", exact: true })).toHaveAttribute("href", "/biblioteca");
+  await expect(page.getByRole("link", { name: "Acceder a Greenatics" })).toHaveAttribute("href", "/app");
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,28 +13,28 @@ const doors = [
     kicker: "Producto agrícola",
     title: "Wondergreen",
     copy: "Fertilizantes organominerales sólidos y líquidos, compost, bioinsumos, guías por cultivo y acompañamiento técnico.",
-    href: "#wondergreen",
+    href: "/wondergreen",
     cta: "Conocer Wondergreen",
   },
   {
     kicker: "Territorios",
     title: "Municipios y ESP",
     copy: "Diagnóstico, rutas selectivas, plantas, rehabilitación, operación y trazabilidad para convertir planeación en capacidad real.",
-    href: "#soluciones",
+    href: "/servicios#municipios",
     cta: "Explorar soluciones",
   },
   {
     kicker: "Generadores",
     title: "Empresas",
     copy: "Caracterización, separación, recolección, tratamiento, infraestructura y evidencia para corrientes orgánicas empresariales.",
-    href: "#soluciones",
+    href: "/servicios#empresas",
     cta: "Explorar soluciones",
   },
   {
     kicker: "Ingeniería + biología",
     title: "Plantas y tecnología",
     copy: "Compostaje, digestión anaerobia, biogás, biol, fertilizantes y operación basada en parámetros, mantenimiento y datos.",
-    href: "#tecnologia",
+    href: "/servicios#infraestructura",
     cta: "Entender la tecnología",
   },
 ];
@@ -65,9 +65,9 @@ const techSteps = [
 ];
 
 const knowledge = [
-  ["Guías por cultivo", "Café, cacao, aguacate, limón Tahití y pastos ya cuentan con conocimiento técnico que estamos llevando a la web."],
-  ["Deficiencias nutricionales", "Lectura de síntomas, posibles confundidores y comprobaciones antes de asumir que todo se resuelve aplicando fertilizante."],
-  ["Uso Wondergreen", "Etapa, objetivo, formato, complemento, aplicación, seguimiento y ajuste como una ruta técnica, no una receta automática."],
+  ["Guías por cultivo", "Café, cacao, aguacate, limón Tahití y pastos ya cuentan con programas web orientativos por etapa y contexto.", "/wondergreen/cultivos"],
+  ["Deficiencias nutricionales", "Lectura de síntomas, posibles confundidores y comprobaciones antes de asumir que todo se resuelve aplicando fertilizante.", "/biblioteca/guia-deficiencias"],
+  ["Uso Wondergreen", "Etapa, objetivo, formato, complemento, aplicación, seguimiento y ajuste como una ruta técnica, no una receta automática.", "/biblioteca"],
 ];
 
 export default function Home() {
@@ -79,10 +79,10 @@ export default function Home() {
             <img className={styles.brandLogo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
           </Link>
           <nav className={styles.nav} aria-label="Navegación pública">
-            <a href="#soluciones">Soluciones</a>
-            <a href="#wondergreen">Wondergreen</a>
+            <Link href="/servicios">Soluciones</Link>
+            <Link href="/wondergreen">Wondergreen</Link>
             <a href="#tecnologia">Tecnología</a>
-            <a href="#conocimiento">Conocimiento</a>
+            <Link href="/biblioteca">Conocimiento</Link>
             <a href="#impacto">Impacto</a>
           </nav>
           <div className={styles.headerActions}>
@@ -107,8 +107,8 @@ export default function Home() {
                 Greenatics conecta planeación, aprovechamiento, plantas, biotecnología, operación, Wondergreen y datos. No trabajamos una etapa aislada: diseñamos cómo el residuo entra, se transforma, se controla y vuelve al ciclo productivo.
               </p>
               <div className={styles.buttonRow}>
-                <a className={`${styles.button} ${styles.buttonPrimary}`} href="#wondergreen">Descubrir Wondergreen</a>
-                <a className={`${styles.button} ${styles.buttonGhost}`} href="#soluciones">Conocer nuestras soluciones</a>
+                <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/wondergreen">Descubrir Wondergreen</Link>
+                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/servicios">Conocer nuestras soluciones</Link>
               </div>
             </div>
 
@@ -135,7 +135,7 @@ export default function Home() {
               <p>
                 No somos únicamente una empresa de fertilizantes y tampoco únicamente una empresa de residuos. Greenatics une ambas puntas: gestionar biomasa residual de manera técnicamente controlada y convertir parte de ese proceso en recursos que puedan retornar a sistemas productivos, con información suficiente para operar, medir y aprender.
               </p>
-              <a className={styles.inlineLink} href="#soluciones">Ver cómo cerramos el ciclo →</a>
+              <Link className={styles.inlineLink} href="/servicios">Ver cómo cerramos el ciclo →</Link>
             </div>
           </div>
         </section>
@@ -152,7 +152,7 @@ export default function Home() {
                   <span className={styles.eyebrow}>{item.kicker}</span>
                   <h3>{item.title}</h3>
                   <p>{item.copy}</p>
-                  <a href={item.href}>{item.cta} →</a>
+                  <Link href={item.href}>{item.cta} →</Link>
                 </article>
               ))}
             </div>
@@ -212,7 +212,7 @@ export default function Home() {
             </div>
             <div className={styles.buttonRow}>
               <Link className={`${styles.button} ${styles.buttonLight}`} href="/wondergreen">Explorar Wondergreen</Link>
-              <a className={`${styles.button} ${styles.buttonOutlineLight}`} href="#conocimiento">Ver conocimiento por cultivo</a>
+              <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/wondergreen/cultivos">Ver conocimiento por cultivo</Link>
             </div>
           </div>
         </section>
@@ -241,12 +241,12 @@ export default function Home() {
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Conocimiento que se usa</span>
               <h2>Las guías dejan de vivir escondidas en un PDF.</h2>
-              <p>El conocimiento ya construido en Greenatics Marketing Studio se convertirá progresivamente en rutas web conectadas a cultivos, productos, síntomas y acompañamiento.</p>
+              <p>El conocimiento ya construido en Greenatics Marketing Studio ya se convierte en rutas web conectadas a cultivos, productos, síntomas y acompañamiento.</p>
             </div>
             <div className={styles.knowledgeGrid}>
-              {knowledge.map(([title, copy]) => (
+              {knowledge.map(([title, copy, href]) => (
                 <article className={styles.knowledgeCard} key={title}>
-                  <span className={styles.eyebrow}>Biblioteca Wondergreen</span><h3>{title}</h3><p>{copy}</p><a href="#contacto">Quiero conocer más →</a>
+                  <span className={styles.eyebrow}>Biblioteca Wondergreen</span><h3>{title}</h3><p>{copy}</p><Link href={href}>Abrir recurso →</Link>
                 </article>
               ))}
             </div>
@@ -291,7 +291,7 @@ export default function Home() {
           </div>
           <div className={styles.footerLinks}>
             <strong>Explorar</strong>
-            <a href="#soluciones">Soluciones</a><a href="#wondergreen">Wondergreen</a><a href="#tecnologia">Tecnología</a><a href="#conocimiento">Conocimiento</a>
+            <Link href="/servicios">Soluciones</Link><Link href="/wondergreen">Wondergreen</Link><a href="#tecnologia">Tecnología</a><Link href="/biblioteca">Conocimiento</Link>
           </div>
           <div className={styles.footerLinks}>
             <strong>Plataforma</strong>

--- a/src/app/public-home.module.css
+++ b/src/app/public-home.module.css
@@ -192,7 +192,19 @@
 .footerBottom { margin-top: 34px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,.12); color: #809087; font-size: .82rem; }
 
 @media (max-width: 980px) {
-  .nav { display: none; }
+  .headerInner { flex-wrap: wrap; gap: 10px 18px; padding-top: 8px; }
+  .nav {
+    order: 3;
+    width: 100%;
+    gap: 18px;
+    overflow-x: auto;
+    padding: 0 0 9px;
+    font-size: .84rem;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .nav::-webkit-scrollbar { display: none; }
+  .nav a { flex: 0 0 auto; min-height: 40px; display: inline-flex; align-items: center; }
   .heroGrid, .definitionGrid, .wgIntro, .techGrid, .impactGrid { grid-template-columns: 1fr; }
   .cycleVisual { margin: 10px auto 0; width: min(520px, 86vw); }
   .doorGrid { grid-template-columns: repeat(2, 1fr); }
@@ -204,10 +216,11 @@
 
 @media (max-width: 680px) {
   .container { width: min(100% - 28px, 1180px); }
-  .headerInner { min-height: 68px; gap: 10px; }
+  .headerInner { min-height: 68px; gap: 8px 10px; }
   .brandLogo { width: 146px; }
   .headerActions .buttonGhost { display: none; }
   .headerActions .button { min-height: 42px; padding: 0 14px; font-size: .82rem; }
+  .nav { gap: 15px; padding-bottom: 8px; }
   .hero { min-height: auto; }
   .heroGrid { padding: 58px 0 72px; gap: 42px; }
   .publicSite h1 { font-size: clamp(2.65rem, 13vw, 4.2rem); }

--- a/src/app/servicios/page.tsx
+++ b/src/app/servicios/page.tsx
@@ -1,0 +1,155 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { environmentalParkModules, publicServices, serviceCategories } from "@/data/public-services";
+import styles from "./services.module.css";
+
+export const metadata: Metadata = {
+  title: "Servicios | Greenatics",
+  description: "Diagnóstico, planeación, rutas selectivas, plantas, rehabilitación, operación y trazabilidad para sistemas de aprovechamiento de residuos orgánicos.",
+};
+
+const audiencePaths = [
+  {
+    id: "municipios",
+    title: "Municipios y ESP",
+    copy: "Planeación, rutas selectivas, prefactibilidad, infraestructura, operación e indicadores para convertir metas territoriales en capacidad operativa.",
+    cta: "Ver servicios para territorio",
+  },
+  {
+    id: "empresas",
+    title: "Empresas y grandes generadores",
+    copy: "Diagnóstico, PMIRS, recolección, tratamiento, evidencia y trazabilidad para ordenar la corriente orgánica desde el origen hasta su aprovechamiento.",
+    cta: "Ver servicios para empresas",
+  },
+];
+
+export default function ServicesPage() {
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className={`${styles.container} ${styles.headerInner}`}>
+          <Link href="/" aria-label="Greenatics">
+            <img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
+          </Link>
+          <nav className={styles.nav} aria-label="Navegación de servicios">
+            <a href="#catalogo">Catálogo</a>
+            <a href="#parque-ambiental">Sistema integrado</a>
+            <Link href="/biblioteca">Biblioteca</Link>
+            <Link href="/wondergreen">Wondergreen</Link>
+          </nav>
+          <Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link>
+        </div>
+      </header>
+
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Greenatics · soluciones</span>
+              <h1>Del residuo al sistema que puede operar.</h1>
+              <p className={styles.lead}>Greenatics acompaña la cadena completa: entender la corriente, diseñar la logística, madurar la infraestructura, ponerla en marcha, operar y convertir la información diaria en trazabilidad y mejora.</p>
+            </div>
+            <aside className={styles.heroAside}>
+              <strong>No empezamos por la máquina.</strong>
+              <p>La tecnología se selecciona después de entender generación, calidad del residuo, logística, capacidad institucional, salida de productos y modelo operativo.</p>
+            </aside>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.white}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Dos rutas de entrada</span>
+              <h2>El problema cambia según quién genera y quién debe operar.</h2>
+            </div>
+            <div className={styles.audienceGrid}>
+              {audiencePaths.map((path) => (
+                <article className={styles.audienceCard} id={path.id} key={path.id}>
+                  <span className={styles.eyebrow}>{path.title}</span>
+                  <h3>{path.title}</h3>
+                  <p>{path.copy}</p>
+                  <a href="#catalogo">{path.cta} →</a>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section} id="catalogo">
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Catálogo de capacidades</span>
+              <h2>No son servicios aislados: son fases que pueden conectarse.</h2>
+              <p>El alcance real se define caso por caso. La web explica qué resuelve cada capacidad, qué suele incluir y qué tipo de entregable puede producir.</p>
+            </div>
+            <div className={styles.categoryNav} aria-label="Categorías de servicios">
+              {serviceCategories.map((category) => <a href={`#${category.toLowerCase().replace(/ó/g, "o").replace(/í/g, "i").replace(/ /g, "-")}`} key={category}>{category}</a>)}
+            </div>
+
+            {serviceCategories.map((category) => {
+              const id = category.toLowerCase().replace(/ó/g, "o").replace(/í/g, "i").replace(/ /g, "-");
+              const services = publicServices.filter((service) => service.category === category);
+              return (
+                <section className={styles.categorySection} id={id} key={category}>
+                  <div className={styles.categoryHead}><h2>{category}</h2><span>{services.length} capacidades</span></div>
+                  <div className={styles.serviceGrid}>
+                    {services.map((service) => (
+                      <article className={styles.serviceCard} id={service.slug} key={service.slug}>
+                        <div className={styles.serviceMeta}><span className={styles.badge}>{service.category}</span><span className={styles.badge}>{service.audience}</span></div>
+                        <h3>{service.name}</h3>
+                        <p>{service.summary}</p>
+                        <div className={styles.serviceDetail}>
+                          <div className={styles.detailBlock}><strong>Qué ayuda a resolver</strong><p>{service.solves}</p></div>
+                          <div className={styles.detailBlock}><strong>Puede incluir</strong><ul>{service.includes.slice(0, 4).map((item) => <li key={item}>{item}</li>)}</ul></div>
+                        </div>
+                        <a className={styles.serviceCta} href="/#contacto">{service.cta} →</a>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+            <div className={styles.truth}><strong>Alcance gobernado:</strong> cada propuesta concreta define actividades, entregables, responsabilidades, cronograma, supuestos y exclusiones. La descripción web no reemplaza el alcance contractual ni afirma que todos los módulos apliquen a todos los proyectos.</div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.dark}`} id="parque-ambiental">
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={`${styles.eyebrow} ${styles.lightEyebrow}`}>Cuando la solución es un sistema</span>
+              <h2>Un parque ambiental no es una planta aislada.</h2>
+              <p>Puede integrar educación, logística, recepción, tratamiento, producto, energía, formación y datos. La combinación final depende de la caracterización y del territorio.</p>
+            </div>
+            <div className={styles.parkGrid}>
+              {environmentalParkModules.map(([title, copy], index) => (
+                <article className={styles.parkCard} key={title}><span>{String(index + 1).padStart(2, "0")}</span><h3>{title}</h3><p>{copy}</p></article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Conocimiento + operación</span>
+              <h2>La ingeniería mejora cuando aprende de la operación.</h2>
+              <p>La Biblioteca Greenatics organiza guías y criterios técnicos; GREENATICS OPS captura lo que ocurre en planta. La arquitectura futura conecta ambas capas mediante publicación gobernada, no exponiendo datos internos directamente.</p>
+            </div>
+            <div><Link className={`${styles.button} ${styles.ghost}`} href="/biblioteca">Explorar Biblioteca</Link></div>
+          </div>
+        </section>
+
+        <section className={styles.closing}>
+          <div className={`${styles.container} ${styles.closingInner}`}>
+            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>¿Tienes un residuo, una planta o un proyecto por estructurar?</h2></div>
+            <a className={`${styles.button} ${styles.primary}`} href="/#contacto">Hablar con Greenatics</a>
+          </div>
+        </section>
+      </main>
+
+      <footer className={styles.footer}>
+        <div className={`${styles.container} ${styles.footerInner}`}><span>© Greenatics S.A.S. · Servicios</span><Link href="/">Volver a Greenatics</Link></div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/servicios/page.tsx
+++ b/src/app/servicios/page.tsx
@@ -102,7 +102,7 @@ export default function ServicesPage() {
                           <div className={styles.detailBlock}><strong>Qué ayuda a resolver</strong><p>{service.solves}</p></div>
                           <div className={styles.detailBlock}><strong>Puede incluir</strong><ul>{service.includes.slice(0, 4).map((item) => <li key={item}>{item}</li>)}</ul></div>
                         </div>
-                        <a className={styles.serviceCta} href="/#contacto">{service.cta} →</a>
+                        <Link className={styles.serviceCta} href="/#contacto">{service.cta} →</Link>
                       </article>
                     ))}
                   </div>
@@ -142,7 +142,7 @@ export default function ServicesPage() {
         <section className={styles.closing}>
           <div className={`${styles.container} ${styles.closingInner}`}>
             <div><span className={styles.eyebrow}>Siguiente paso</span><h2>¿Tienes un residuo, una planta o un proyecto por estructurar?</h2></div>
-            <a className={`${styles.button} ${styles.primary}`} href="/#contacto">Hablar con Greenatics</a>
+            <Link className={`${styles.button} ${styles.primary}`} href="/#contacto">Hablar con Greenatics</Link>
           </div>
         </section>
       </main>

--- a/src/app/servicios/services.module.css
+++ b/src/app/servicios/services.module.css
@@ -80,8 +80,20 @@
 }
 @media (max-width: 680px) {
   .container { width: min(100% - 28px,1180px); }
+  .headerInner { flex-wrap: wrap; gap: 8px 12px; padding-top: 8px; }
   .logo { width: 142px; }
-  .nav { display: none; }
+  .nav {
+    order: 3;
+    width: 100%;
+    gap: 16px;
+    overflow-x: auto;
+    padding: 0 0 8px;
+    font-size: .82rem;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .nav::-webkit-scrollbar { display: none; }
+  .nav a { flex: 0 0 auto; min-height: 40px; display: inline-flex; align-items: center; }
   .audienceGrid, .serviceDetail, .parkGrid { grid-template-columns: 1fr; }
   .categoryHead, .closingInner, .footerInner { flex-direction: column; align-items: flex-start; }
   .serviceCard { padding: 22px 18px; }

--- a/src/app/servicios/services.module.css
+++ b/src/app/servicios/services.module.css
@@ -1,0 +1,88 @@
+.page {
+  --green950: #14352c;
+  --green800: #006b45;
+  --green700: #008b4c;
+  --lime400: #98cf4f;
+  --yellow400: #f4d944;
+  --ink: #17201c;
+  --muted: #647068;
+  --paper: #f7f8f3;
+  --line: #dfe5dc;
+  color: var(--ink);
+  background: var(--paper);
+  min-height: 100vh;
+  font-family: Arial, Helvetica, sans-serif;
+}
+.page *, .page *::before, .page *::after { box-sizing: border-box; }
+.page a { color: inherit; text-decoration: none; }
+.container { width: min(1180px, calc(100% - 40px)); margin: 0 auto; }
+.header { position: sticky; top: 0; z-index: 30; border-bottom: 1px solid var(--line); background: rgba(247,248,243,.95); backdrop-filter: blur(14px); }
+.headerInner { min-height: 72px; display: flex; align-items: center; gap: 22px; }
+.logo { width: 170px; height: auto; margin-right: auto; }
+.nav { display: flex; gap: 20px; font-size: .9rem; font-weight: 800; }
+.nav a:hover { color: var(--green700); }
+.button { display: inline-flex; min-height: 44px; padding: 0 18px; align-items: center; justify-content: center; border-radius: 999px; border: 1px solid var(--line); font-weight: 900; }
+.primary { background: var(--green800); color: white !important; border-color: var(--green800); }
+.ghost { background: transparent; }
+.eyebrow { display: inline-block; margin-bottom: 12px; color: var(--green700); font-size: .72rem; font-weight: 900; text-transform: uppercase; letter-spacing: .11em; }
+.lightEyebrow { color: #d8ffbe; }
+.page h1, .page h2, .page h3 { margin: 0; font-family: "Arial Rounded MT", "Arial Rounded MT Bold", Arial, sans-serif; line-height: 1.05; letter-spacing: -.032em; }
+.page h1 { font-size: clamp(2.8rem, 6vw, 5.4rem); }
+.page h2 { font-size: clamp(2rem, 4vw, 3.5rem); }
+.page h3 { font-size: 1.35rem; }
+.lead { max-width: 780px; color: #526058; font-size: 1.16rem; }
+.hero { padding: 86px 0 100px; background: radial-gradient(circle at 82% 20%, rgba(152,207,79,.24), transparent 28%), linear-gradient(135deg, #fbfcf7, #eaf3e4); }
+.heroGrid { display: grid; grid-template-columns: 1fr .76fr; gap: 66px; align-items: end; }
+.heroAside { padding: 26px; border-radius: 26px; background: white; border: 1px solid var(--line); }
+.heroAside strong { display: block; font-size: 1.08rem; }
+.heroAside p { color: var(--muted); margin-bottom: 0; }
+.section { padding: 96px 0; }
+.white { background: white; }
+.soft { background: #eef4eb; }
+.dark { background: var(--green950); color: white; }
+.sectionHeading { max-width: 820px; margin-bottom: 36px; }
+.sectionHeading p { color: var(--muted); font-size: 1.04rem; }
+.dark .sectionHeading p { color: #bdcbc4; }
+.audienceGrid { display: grid; grid-template-columns: repeat(2,1fr); gap: 16px; }
+.audienceCard { min-height: 250px; padding: 28px; border-radius: 26px; border: 1px solid var(--line); background: white; display: flex; flex-direction: column; }
+.audienceCard p { color: var(--muted); }
+.audienceCard a { margin-top: auto; color: var(--green700); font-weight: 900; }
+.categoryNav { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 34px; }
+.categoryNav a { display: inline-flex; min-height: 42px; align-items: center; padding: 0 14px; border-radius: 999px; border: 1px solid var(--line); background: white; font-size: .82rem; font-weight: 900; color: var(--green800); }
+.categorySection { scroll-margin-top: 90px; }
+.categorySection + .categorySection { margin-top: 58px; }
+.categoryHead { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin-bottom: 20px; padding-bottom: 14px; border-bottom: 1px solid var(--line); }
+.categoryHead span { color: var(--muted); font-size: .9rem; }
+.serviceGrid { display: grid; grid-template-columns: repeat(2,1fr); gap: 16px; }
+.serviceCard { padding: 26px; border-radius: 24px; border: 1px solid var(--line); background: white; }
+.serviceMeta { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 14px; }
+.badge { display: inline-flex; padding: 6px 9px; border-radius: 999px; background: #e8f3e3; color: var(--green800); font-size: .68rem; font-weight: 900; text-transform: uppercase; letter-spacing: .04em; }
+.serviceCard > p { color: var(--muted); }
+.serviceDetail { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 20px; }
+.detailBlock { padding-top: 14px; border-top: 1px solid var(--line); }
+.detailBlock strong { display: block; font-size: .82rem; margin-bottom: 8px; }
+.detailBlock ul { margin: 0; padding-left: 18px; color: var(--muted); font-size: .88rem; }
+.detailBlock li + li { margin-top: 6px; }
+.serviceCta { display: inline-flex; margin-top: 20px; color: var(--green700) !important; font-weight: 900; }
+.parkGrid { display: grid; grid-template-columns: repeat(4,1fr); gap: 12px; }
+.parkCard { min-height: 190px; padding: 20px; border-radius: 20px; border: 1px solid rgba(255,255,255,.14); background: rgba(255,255,255,.07); }
+.parkCard span { color: #d8ffbe; font-size: .7rem; font-weight: 900; }
+.parkCard p { color: #c3d1ca; font-size: .9rem; }
+.truth { margin-top: 28px; padding: 20px 22px; border-radius: 18px; background: #fffdf0; border-left: 4px solid var(--yellow400); color: #59635e; }
+.closing { padding: 76px 0; background: var(--lime400); }
+.closingInner { display: flex; align-items: end; justify-content: space-between; gap: 30px; }
+.footer { padding: 34px 0; background: #0d241d; color: #b9c8c0; }
+.footerInner { display: flex; justify-content: space-between; gap: 24px; align-items: center; }
+@media (max-width: 900px) {
+  .heroGrid { grid-template-columns: 1fr; }
+  .serviceGrid { grid-template-columns: 1fr; }
+  .parkGrid { grid-template-columns: repeat(2,1fr); }
+}
+@media (max-width: 680px) {
+  .container { width: min(100% - 28px,1180px); }
+  .logo { width: 142px; }
+  .nav { display: none; }
+  .audienceGrid, .serviceDetail, .parkGrid { grid-template-columns: 1fr; }
+  .categoryHead, .closingInner, .footerInner { flex-direction: column; align-items: flex-start; }
+  .serviceCard { padding: 22px 18px; }
+}

--- a/src/data/public-services.test.ts
+++ b/src/data/public-services.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { companyServices, municipalServices, publicServices, serviceCategories } from "@/data/public-services";
+
+describe("Greenatics public services", () => {
+  it("keeps unique slugs and all service categories represented", () => {
+    expect(new Set(publicServices.map((service) => service.slug)).size).toBe(publicServices.length);
+    const represented = new Set(publicServices.map((service) => service.category));
+    for (const category of serviceCategories) expect(represented.has(category)).toBe(true);
+  });
+
+  it("keeps audience routing honest", () => {
+    expect(municipalServices.some((service) => service.slug === "pgirs")).toBe(true);
+    expect(companyServices.some((service) => service.slug === "pgirs")).toBe(false);
+    expect(companyServices.some((service) => service.slug === "pmirs")).toBe(true);
+    expect(municipalServices.some((service) => service.slug === "pmirs")).toBe(false);
+    expect(companyServices.some((service) => service.slug === "recoleccion-tratamiento")).toBe(true);
+  });
+
+  it("requires enough substance for every published capability", () => {
+    for (const service of publicServices) {
+      expect(service.summary.length).toBeGreaterThan(35);
+      expect(service.solves.length).toBeGreaterThan(45);
+      expect(service.includes.length).toBeGreaterThanOrEqual(4);
+      expect(service.deliverables.length).toBeGreaterThanOrEqual(4);
+      expect(service.cta.length).toBeGreaterThan(5);
+    }
+  });
+
+  it("keeps GREENATICS OPS as a data capability rather than a public data source", () => {
+    const dataService = publicServices.find((service) => service.slug === "trazabilidad-datos");
+    expect(dataService?.category).toBe("Datos");
+    expect(dataService?.includes).toContain("indicadores publicables bajo aprobación");
+  });
+});

--- a/src/data/public-services.ts
+++ b/src/data/public-services.ts
@@ -1,0 +1,175 @@
+export type PublicServiceAudience = "Municipios y ESP" | "Empresas" | "Ambos";
+export type PublicServiceCategory = "Planeación" | "Recolección" | "Infraestructura" | "Operación" | "Datos";
+
+export type PublicService = {
+  slug: string;
+  name: string;
+  category: PublicServiceCategory;
+  audience: PublicServiceAudience;
+  summary: string;
+  solves: string;
+  includes: string[];
+  deliverables: string[];
+  cta: string;
+};
+
+export const publicServices: PublicService[] = [
+  {
+    slug: "diagnostico-caracterizacion",
+    name: "Diagnóstico y caracterización de residuos orgánicos",
+    category: "Planeación",
+    audience: "Ambos",
+    summary: "Construimos la línea base antes de decidir rutas, equipos o infraestructura.",
+    solves: "Reduce el riesgo de dimensionar una solución con supuestos incompletos sobre cantidad, calidad, frecuencia, impropios, origen y destino de las corrientes.",
+    includes: ["levantamiento de generadores y corrientes", "aforos y caracterización", "frecuencias y puntos de generación", "infraestructura disponible", "brechas operativas y logísticas", "alternativas preliminares de aprovechamiento"],
+    deliverables: ["línea base", "mapa de flujos", "matriz de brechas", "recomendación de siguiente fase"],
+    cta: "Solicitar diagnóstico",
+  },
+  {
+    slug: "pgirs",
+    name: "PGIRS · formulación, actualización y fortalecimiento operativo",
+    category: "Planeación",
+    audience: "Municipios y ESP",
+    summary: "Conectamos la planeación territorial con decisiones implementables de separación, recolección selectiva, aprovechamiento e indicadores.",
+    solves: "Ayuda a traducir programas y metas en proyectos, rutas y capacidades que puedan ejecutarse y medirse dentro del alcance contratado.",
+    includes: ["revisión de línea base y programas", "componente de aprovechamiento de orgánicos", "metas e indicadores", "rutas selectivas y actores", "necesidades de infraestructura", "hoja de ruta de implementación"],
+    deliverables: ["documentos técnicos según alcance", "matrices de programas y metas", "portafolio de proyectos", "plan de implementación y seguimiento"],
+    cta: "Revisar mi PGIRS",
+  },
+  {
+    slug: "pmirs",
+    name: "PMIRS · gestión para organizaciones y grandes generadores",
+    category: "Planeación",
+    audience: "Empresas",
+    summary: "Ordenamos la gestión interna desde la generación hasta el aprovechamiento y la evidencia de ejecución.",
+    solves: "Ayuda a pasar de prácticas dispersas a un sistema documentado con separación, almacenamiento, rutas, responsables, gestores e indicadores.",
+    includes: ["diagnóstico del generador", "inventario de corrientes", "procedimientos de separación y almacenamiento", "rutas internas y externas", "roles y responsabilidades", "indicadores y evidencias"],
+    deliverables: ["plan según alcance aplicable", "protocolos operativos", "matriz de indicadores", "ruta de mejora"],
+    cta: "Evaluar PMIRS",
+  },
+  {
+    slug: "prefactibilidad",
+    name: "Prefactibilidad de plantas y sistemas de aprovechamiento",
+    category: "Planeación",
+    audience: "Ambos",
+    summary: "Validamos si existe una base razonable para avanzar antes de comprometer inversión en ingeniería o construcción.",
+    solves: "Reduce el riesgo de seleccionar tecnología sin validar generación, suministro, localización, logística, salidas de producto y modelo operativo.",
+    includes: ["oferta de residuos", "alternativas tecnológicas", "dimensionamiento preliminar", "implantación y servicios requeridos", "modelo operativo", "estimaciones preliminares según alcance", "riesgos y ruta de maduración"],
+    deliverables: ["informe de prefactibilidad", "alternativas comparadas", "esquema conceptual", "hoja de ruta hacia factibilidad"],
+    cta: "Solicitar prefactibilidad",
+  },
+  {
+    slug: "factibilidad-ingenieria",
+    name: "Factibilidad e ingeniería de detalle",
+    category: "Infraestructura",
+    audience: "Ambos",
+    summary: "Maduramos el proyecto hasta el nivel técnico, económico y operativo definido en cada alcance.",
+    solves: "Convierte una alternativa conceptual en un proyecto con capacidades, equipos, implantación, cantidades y criterios de operación mejor definidos.",
+    includes: ["balances de masa", "ingeniería de proceso", "dimensionamiento de equipos", "implantación", "cantidades y análisis de costos cuando aplique", "servicios auxiliares", "seguridad y operación", "documentación de estructuración según alcance"],
+    deliverables: ["memorias y planos contratados", "presupuesto y análisis aplicables", "especificaciones", "bases operativas", "cronograma de implementación"],
+    cta: "Madurar un proyecto",
+  },
+  {
+    slug: "rutas-selectivas",
+    name: "Diseño e implementación de rutas selectivas y microrrutas",
+    category: "Recolección",
+    audience: "Ambos",
+    summary: "Diseñamos la logística que conecta al generador con el sistema de aprovechamiento sin perder calidad del material.",
+    solves: "Una planta necesita suministro separado, frecuencias realistas, puntos de recolección y disciplina operativa para sostener el proceso.",
+    includes: ["censo y priorización de generadores", "georreferenciación", "frecuencias", "microrrutas", "protocolos de entrega y recepción", "sensibilización", "captura de datos de ruta"],
+    deliverables: ["diseño de ruta", "mapa de generadores", "frecuencias y secuencias", "protocolos", "tablero básico de seguimiento"],
+    cta: "Diseñar ruta selectiva",
+  },
+  {
+    slug: "piloto-recoleccion",
+    name: "Pilotos de recolección selectiva y toma de datos",
+    category: "Recolección",
+    audience: "Ambos",
+    summary: "Probamos, medimos y ajustamos microrrutas antes de escalar la logística.",
+    solves: "Permite validar en operación tiempos, volúmenes, generadores, frecuencias, impropios y condiciones reales de una ruta.",
+    includes: ["ruta piloto según alcance", "registro de puntos y tiempos", "medición de material", "observaciones de separación y calidad", "ajustes de recorrido"],
+    deliverables: ["bitácora de ruta", "base de generadores atendidos", "datos de operación", "recomendaciones de escalamiento"],
+    cta: "Evaluar un piloto",
+  },
+  {
+    slug: "plantas-nuevas",
+    name: "Diseño e implementación de plantas de aprovechamiento",
+    category: "Infraestructura",
+    audience: "Ambos",
+    summary: "Integramos recepción, tratamiento biológico, manejo de productos, servicios auxiliares y lógica operacional en una solución dimensionada para cada proyecto.",
+    solves: "Evita tratar la planta como una suma de máquinas: los módulos se definen alrededor del residuo, territorio, salidas de producto y capacidad real de operación.",
+    includes: ["recepción y pretratamiento", "compostaje cuando aplica", "digestión anaerobia cuando aplica", "manejo de biogás y efluentes", "maduración y acondicionamiento", "zonas de producto", "instrumentación y control", "puesta en marcha"],
+    deliverables: ["infraestructura según contrato", "protocolos", "capacitación", "manuales", "plan de arranque y estabilización"],
+    cta: "Diseñar una planta",
+  },
+  {
+    slug: "rehabilitacion",
+    name: "Diagnóstico, rehabilitación y puesta en marcha de infraestructura existente",
+    category: "Infraestructura",
+    audience: "Ambos",
+    summary: "Revisamos plantas, composteras o sistemas subutilizados antes de recomendar reemplazarlos.",
+    solves: "Permite separar fallas de infraestructura, proceso, personal, suministro y gestión para intervenir donde realmente hace falta.",
+    includes: ["auditoría técnica y operacional", "inventario de activos", "brechas de proceso", "plan de adecuaciones", "rehabilitación según alcance", "protocolos", "capacitación y arranque"],
+    deliverables: ["diagnóstico", "plan de intervención", "adecuaciones contratadas", "manuales y puesta en marcha"],
+    cta: "Revisar infraestructura existente",
+  },
+  {
+    slug: "direccion-operacion",
+    name: "Dirección técnica y coordinación de operación",
+    category: "Operación",
+    audience: "Ambos",
+    summary: "Acompañamos la planta como sistema: proceso, personas, mantenimiento, calidad, administración, comercialización y reporte.",
+    solves: "Cierra la brecha entre tener infraestructura y sostener una operación disciplinada, documentada y con responsabilidades claras.",
+    includes: ["parámetros y protocolos", "roles y perfiles", "programación", "mantenimiento", "control de calidad", "inventarios", "informes", "acompañamiento transversal según alcance"],
+    deliverables: ["modelo de operación", "manuales y procedimientos", "programación", "informes de seguimiento", "plan de mejora"],
+    cta: "Fortalecer mi operación",
+  },
+  {
+    slug: "operacion-integral",
+    name: "Operación integral de plantas",
+    category: "Operación",
+    audience: "Ambos",
+    summary: "Podemos asumir un alcance integral cuando el proyecto requiere personal, coordinación y gestión bajo un solo modelo.",
+    solves: "Reduce fragmentación entre operación física, mantenimiento, administración, control, producto y seguimiento.",
+    includes: ["estructura de personal según contrato", "coordinación operacional", "mantenimiento", "seguridad y procedimientos", "control de ingreso y proceso", "producto e inventarios", "reportes e indicadores"],
+    deliverables: ["operación bajo alcance contractual", "informes", "indicadores", "registro de novedades", "planes de mejora"],
+    cta: "Evaluar modelo de operación",
+  },
+  {
+    slug: "recoleccion-tratamiento",
+    name: "Recolección, trazabilidad y tratamiento de residuos orgánicos",
+    category: "Operación",
+    audience: "Empresas",
+    summary: "Servicio para generadores que necesitan separar, entregar y aprovechar su corriente orgánica con evidencia del proceso.",
+    solves: "Integra logística y tratamiento para evitar que la gestión termine en una simple recolección sin trazabilidad del destino.",
+    includes: ["diagnóstico de generación", "programación de recolección", "criterios de aceptación", "registro de recepción", "tratamiento", "trazabilidad de la corriente", "evidencia o reporte según alcance"],
+    deliverables: ["registro de servicios", "evidencia de recepción/tratamiento", "consolidado periódico según contrato", "recomendaciones de separación"],
+    cta: "Cotizar gestión de orgánicos",
+  },
+  {
+    slug: "trazabilidad-datos",
+    name: "Trazabilidad digital, indicadores y GREENATICS OPS",
+    category: "Datos",
+    audience: "Ambos",
+    summary: "Conectamos generador, ruta, recepción, proceso, producto, inventario y destino para que la operación pueda entenderse y auditarse.",
+    solves: "Evita reprocesar hojas aisladas y permite que la información nazca en la actividad operacional que la produce.",
+    includes: ["registros operativos", "lotes y evidencias", "actividades y tiempos", "mantenimiento", "inventarios", "alertas", "dashboard día/mes/histórico", "indicadores publicables bajo aprobación"],
+    deliverables: ["modelo de datos según alcance", "tableros", "trazabilidad", "reportes", "contratos de publicación de indicadores cuando aplique"],
+    cta: "Conocer la capa digital",
+  },
+];
+
+export const serviceCategories: PublicServiceCategory[] = ["Planeación", "Recolección", "Infraestructura", "Operación", "Datos"];
+export const municipalServices = publicServices.filter((service) => service.audience !== "Empresas");
+export const companyServices = publicServices.filter((service) => service.audience !== "Municipios y ESP");
+
+export const environmentalParkModules = [
+  ["Separación y educación", "Generadores, cultura de separación, protocolos y activación territorial."],
+  ["Recolección selectiva", "Rutas, microrrutas y datos desde el origen."],
+  ["Recepción y control", "Pesaje, inspección, impropios, lotes y evidencia."],
+  ["Aprovechamiento biológico", "Compostaje y/o digestión anaerobia según caracterización y escala."],
+  ["Biofábrica y productos", "Maduración, acondicionamiento y rutas de fertilizantes, biol y otros productos validados."],
+  ["Biogás y energía", "Recuperación energética cuando el balance técnico y económico lo justifica."],
+  ["Formación y demostración", "Capacitación, transferencia de conocimiento y apropiación territorial."],
+  ["Datos e impacto", "Operación trazable, indicadores, mantenimiento y mejora continua mediante GREENATICS OPS."],
+] as const;


### PR DESCRIPTION
## Objetivo
Recuperar selectivamente el catálogo público de servicios de Greenatics y conectar la HOME existente con rutas públicas reales, sin rediseñar la landing ni tocar GREENATICS OPS.

## Alcance
- `/servicios` con catálogo gobernado por categoría: Planeación, Recolección, Infraestructura, Operación y Datos.
- Rutas de entrada para Municipios/ESP y Empresas/grandes generadores.
- Capacidades: diagnóstico, PGIRS, PMIRS, prefactibilidad, ingeniería, rutas, pilotos, plantas, rehabilitación, dirección/operación, tratamiento y trazabilidad digital.
- Módulos de sistema/parque ambiental presentados como combinación posible, no como paquete obligatorio.
- Truth lock contractual: la descripción web no sustituye alcance, entregables, responsabilidades, cronograma, supuestos ni exclusiones de una propuesta concreta.
- HOME conserva composición y estilo; solo se reemplazan anchors temporales por rutas reales:
  - Soluciones → `/servicios`
  - Conocimiento → `/biblioteca`
  - Wondergreen → `/wondergreen`
  - Municipios → `/servicios#municipios`
  - Empresas → `/servicios#empresas`
  - Guías/deficiencias → rutas reales de Biblioteca/Wondergreen.

## QA añadido
- Unit: slugs únicos, 5 categorías representadas, routing honesto de audiencias y contenido mínimo por capacidad.
- Unit: GREENATICS OPS permanece como capacidad de datos con publicación bajo aprobación.
- E2E: `/servicios`, capacidades principales, navegación HOME→Servicios/Biblioteca, puertas Municipios/Empresas y puente a OPS.

## Base
PR apilado sobre `feat/wondergreen-knowledge-v0.5`. Diff deliberadamente pequeño: 6 archivos y cero cambios en OPS.
