### PR TITLE
Security v0.11 · Aislamiento público + gate GREENATICS OPS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,12 @@
 # Local is the safe default for development, CI and isolated demos.
 NEXT_PUBLIC_DATA_MODE=local
 
-# Required only when NEXT_PUBLIC_DATA_MODE=supabase.
+# Required when NEXT_PUBLIC_DATA_MODE=supabase.
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+
+# Optional server-only escape hatch for a LOCAL `next start` demo.
+# It is ignored on Vercel and must never be configured in a deployment.
+GREENATICS_OPS_LOCAL_BYPASS=false
 
 # Never expose a service_role key through NEXT_PUBLIC_* variables or commit it.

--- a/docs/architecture/ADR-0007-public-ops-access-gate.md
+++ b/docs/architecture/ADR-0007-public-ops-access-gate.md
@@ -1,0 +1,29 @@
+# ADR-0007 · Frontera de acceso entre web pública y GREENATICS OPS
+
+## Estado
+Aceptado para v0.11.
+
+## Contexto
+`GTCS-WEB` sirve en el mismo runtime la web pública y GREENATICS OPS. `robots.txt` evita indexación accidental, pero no es un mecanismo de autorización. Además, el `RootLayout` histórico montaba los stores de OPS en todas las rutas, incluso en páginas públicas.
+
+## Decisión
+1. Mantener URLs públicas e internas estables; no mover todavía todo el árbol a route groups.
+2. Definir explícitamente las familias de rutas protegidas de OPS.
+3. En desarrollo/CI con modo `local`, permitir el adapter local para QA y demos aisladas.
+4. En runtime de producción, el modo local queda bloqueado por defecto. Un bypass local solo puede habilitarse explícitamente fuera de Vercel.
+5. En modo `supabase`, usar `proxy.ts` de Next.js 16 para refrescar/validar claims antes de las rutas protegidas.
+6. Revalidar server-side antes de renderizar cada árbol OPS: claim válido, perfil activo y al menos una membresía de planta activa.
+7. Mantener RLS como autorización de datos y roles dentro de PostgreSQL; el proxy y el guard de página no sustituyen RLS.
+8. Montar los providers/stores OPS únicamente en rutas internas; la web pública no inicializa ni persiste el adapter operativo.
+9. Mantener las rutas protegidas como `force-dynamic` para que la decisión de sesión no se prerenderice ni se comparta por caché.
+10. El login exitoso entra a `/app`; un usuario no autenticado o un deployment mal configurado no puede usar el modo local como fallback silencioso.
+
+## Consecuencias
+- Un visitante público puede navegar la web sin inicializar stores operativos.
+- Conocer una URL interna no concede acceso a OPS.
+- Preview/producción requieren configuración Supabase para usar OPS.
+- CI y desarrollo local conservan los flujos existentes sin credenciales remotas.
+- La autorización queda en profundidad: frontera de request + render server-side + RLS.
+
+## Siguiente paso
+Después de certificar v0.11, crear un preview de runtime Next.js y verificar variables de entorno, cookies, autenticación, navegación pública y rutas OPS antes de asociar el dominio productivo.

--- a/e2e/ops-access-isolation.spec.ts
+++ b/e2e/ops-access-isolation.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+
+const OPS_STORAGE_KEY = "greenatics-ops-mvp-001";
+
+test("public routes do not mount or persist the local OPS store", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: /Convertimos residuos orgánicos/i })).toBeVisible();
+  await page.waitForTimeout(100);
+  await expect.poll(() => page.evaluate((key) => window.localStorage.getItem(key), OPS_STORAGE_KEY)).toBeNull();
+});
+
+test("local development keeps OPS available for isolated QA", async ({ page }) => {
+  await page.goto("/app");
+  await expect(page.getByRole("heading", { name: "Operación de hoy" })).toBeVisible();
+  await expect.poll(() => page.evaluate((key) => window.localStorage.getItem(key), OPS_STORAGE_KEY)).not.toBeNull();
+});
+
+test("login explains that local mode is a development boundary", async ({ page }) => {
+  await page.goto("/login");
+  await expect(page.getByRole("heading", { name: "Acceso interno" })).toBeVisible();
+  await expect(page.getByText("Modo local de desarrollo.", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Ingresar" })).toBeDisabled();
+});

--- a/e2e/public-solutions.spec.ts
+++ b/e2e/public-solutions.spec.ts
@@ -24,5 +24,5 @@ test("public solutions route keeps the bridge to OPS", async ({ page }) => {
   await page.goto("/soluciones");
   await page.getByRole("banner").getByRole("link", { name: "Acceder a Greenatics" }).click();
   await expect(page).toHaveURL(/\/app$/);
-  await expect(page.getByText("GREENATICS OPS", { exact: true }).first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Operación de hoy" })).toBeVisible();
 });

--- a/src/app/activities/layout.tsx
+++ b/src/app/activities/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/activities/layout.tsx
+++ b/src/app/activities/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/calendar/layout.tsx
+++ b/src/app/calendar/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/calendar/layout.tsx
+++ b/src/app/calendar/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/cash/layout.tsx
+++ b/src/app/cash/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/cash/layout.tsx
+++ b/src/app/cash/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/compost/layout.tsx
+++ b/src/app/compost/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/compost/layout.tsx
+++ b/src/app/compost/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/equipment/layout.tsx
+++ b/src/app/equipment/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/equipment/layout.tsx
+++ b/src/app/equipment/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/expenses/layout.tsx
+++ b/src/app/expenses/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/expenses/layout.tsx
+++ b/src/app/expenses/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/finance/layout.tsx
+++ b/src/app/finance/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/finance/layout.tsx
+++ b/src/app/finance/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/imports/layout.tsx
+++ b/src/app/imports/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/imports/layout.tsx
+++ b/src/app/imports/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/inventory/layout.tsx
+++ b/src/app/inventory/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/inventory/layout.tsx
+++ b/src/app/inventory/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,5 @@
 import type { Metadata } from "next";
-import { OpsStoreProvider } from "@/components/ops-store";
-import { MaintenanceStoreProvider } from "@/components/maintenance-store";
-import { CompostStoreProvider } from "@/components/compost-store";
-import { InventoryStoreProvider } from "@/components/inventory-store";
-import { CommercialStoreProvider } from "@/components/commercial-store";
-import { ExpenseStoreProvider } from "@/components/expense-store";
-import { SupplyStoreProvider } from "@/components/supply-store";
-import { PurchaseRequestStoreProvider } from "@/components/purchase-request-store";
-import { SettlementStoreProvider } from "@/components/settlement-store";
+import { RuntimeProviders } from "@/components/runtime-providers";
 import { publicSite } from "@/data/public-site";
 import "./globals.css";
 
@@ -20,25 +12,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="es">
-      <body>
-        <OpsStoreProvider>
-          <MaintenanceStoreProvider>
-            <CompostStoreProvider>
-              <InventoryStoreProvider>
-                <CommercialStoreProvider>
-                  <ExpenseStoreProvider>
-                    <SupplyStoreProvider>
-                      <PurchaseRequestStoreProvider>
-                        <SettlementStoreProvider>{children}</SettlementStoreProvider>
-                      </PurchaseRequestStoreProvider>
-                    </SupplyStoreProvider>
-                  </ExpenseStoreProvider>
-                </CommercialStoreProvider>
-              </InventoryStoreProvider>
-            </CompostStoreProvider>
-          </MaintenanceStoreProvider>
-        </OpsStoreProvider>
-      </body>
+      <body><RuntimeProviders>{children}</RuntimeProviders></body>
     </html>
   );
 }

--- a/src/app/production/layout.tsx
+++ b/src/app/production/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/production/layout.tsx
+++ b/src/app/production/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/purchases/layout.tsx
+++ b/src/app/purchases/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/purchases/layout.tsx
+++ b/src/app/purchases/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/receptions/layout.tsx
+++ b/src/app/receptions/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/receptions/layout.tsx
+++ b/src/app/receptions/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/sales/layout.tsx
+++ b/src/app/sales/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/sales/layout.tsx
+++ b/src/app/sales/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/app/supplies/layout.tsx
+++ b/src/app/supplies/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { OpsRouteGuard } from "@/components/ops-route-guard";
+
+export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
+  return <OpsRouteGuard>{children}</OpsRouteGuard>;
+}

--- a/src/app/supplies/layout.tsx
+++ b/src/app/supplies/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { OpsRouteGuard } from "@/components/ops-route-guard";
 
+export const dynamic = "force-dynamic";
+
 export default function OpsProtectedLayout({ children }: { children: ReactNode }) {
   return <OpsRouteGuard>{children}</OpsRouteGuard>;
 }

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -16,7 +16,7 @@ export function LoginForm() {
   const configured = isSupabaseConfigured();
 
   const submit = async () => {
-    if (!supabaseMode || !configured) return setFeedback("Este entorno está en modo local; no requiere autenticación remota.");
+    if (!supabaseMode || !configured) return setFeedback("El acceso remoto de GREENATICS OPS no está configurado en este entorno.");
     if (!email.trim() || !password) return setFeedback("Ingresa correo y contraseña.");
     setBusy(true);
     setFeedback("");
@@ -24,7 +24,7 @@ export function LoginForm() {
       const supabase = createClient();
       const { error } = await supabase.auth.signInWithPassword({ email: email.trim(), password });
       if (error) return setFeedback("No fue posible iniciar sesión. Verifica las credenciales.");
-      router.replace("/");
+      router.replace("/app");
       router.refresh();
     } finally {
       setBusy(false);
@@ -33,13 +33,13 @@ export function LoginForm() {
 
   return <section className="panel mx-auto max-w-md">
     <div className="mb-6"><p className="eyebrow">GREENATICS OPS</p><h1 className="text-3xl">Acceso interno</h1><p className="lede">Ingreso del equipo operativo y administrativo.</p></div>
-    {!supabaseMode && <div className="mb-5 rounded-xl bg-[var(--green-soft)] p-4 text-sm text-[var(--green-dark)]"><strong>Modo local activo.</strong><span className="mt-1 block">CI y demos aisladas no envían información fuera del navegador.</span></div>}
-    {supabaseMode && !configured && <div className="mb-5 rounded-xl bg-[var(--amber-soft)] p-4 text-sm text-[var(--amber)]"><strong>Supabase pendiente de configuración.</strong><span className="mt-1 block">Faltan URL y publishable key del proyecto.</span></div>}
+    {!supabaseMode && <div className="mb-5 rounded-xl bg-[var(--green-soft)] p-4 text-sm text-[var(--green-dark)]"><strong>Modo local de desarrollo.</strong><span className="mt-1 block">El acceso local solo se habilita en desarrollo, CI o demos aisladas autorizadas; no funciona como fallback de producción.</span></div>}
+    {supabaseMode && !configured && <div className="mb-5 rounded-xl bg-[var(--amber-soft)] p-4 text-sm text-[var(--amber)]"><strong>Acceso remoto pendiente de configuración.</strong><span className="mt-1 block">Faltan URL y publishable key del proyecto Supabase.</span></div>}
     <div className="grid gap-4">
       <label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Correo<input className="min-h-11 rounded-lg border border-[var(--line)] px-3 text-base text-[var(--ink)]" autoComplete="email" type="email" value={email} onChange={(event)=>setEmail(event.target.value)}/></label>
       <label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Contraseña<input className="min-h-11 rounded-lg border border-[var(--line)] px-3 text-base text-[var(--ink)]" autoComplete="current-password" type="password" value={password} onChange={(event)=>setPassword(event.target.value)}/></label>
     </div>
     {feedback && <p className="mt-4 rounded-lg bg-[var(--red-soft)] p-3 text-sm font-semibold text-[var(--red)]" role="alert">{feedback}</p>}
-    <div className="mt-6 flex items-center justify-between gap-3"><Link className="button secondary" href="/">Volver</Link><button className="button primary" disabled={busy || !supabaseMode || !configured} type="button" onClick={submit}>{busy ? "Ingresando…" : "Ingresar"}</button></div>
+    <div className="mt-6 flex items-center justify-between gap-3"><Link className="button secondary" href="/">Volver al sitio</Link><button className="button primary" disabled={busy || !supabaseMode || !configured} type="button" onClick={submit}>{busy ? "Ingresando…" : "Ingresar"}</button></div>
   </section>;
 }

--- a/src/components/ops-route-guard.tsx
+++ b/src/components/ops-route-guard.tsx
@@ -10,8 +10,17 @@ export async function OpsRouteGuard({ children }: { children: ReactNode }) {
   if (mode === "configuration-block") redirect("/login?reason=configuration");
 
   const supabase = await createClient();
-  const { data, error } = await supabase.auth.getClaims();
-  if (error || !data?.claims?.sub) redirect("/login");
+  const { data: claimsData, error: claimsError } = await supabase.auth.getClaims();
+  const userId = claimsData?.claims?.sub;
+  if (claimsError || !userId) redirect("/login");
+
+  const [{ data: profile, error: profileError }, { data: membership, error: membershipError }] = await Promise.all([
+    supabase.from("profiles").select("active").eq("id", userId).maybeSingle(),
+    supabase.from("plant_memberships").select("plant_id").eq("user_id", userId).eq("active", true).limit(1).maybeSingle(),
+  ]);
+
+  if (profileError || !profile?.active) redirect("/login?reason=inactive-profile");
+  if (membershipError || !membership) redirect("/login?reason=no-plant-access");
 
   return children;
 }

--- a/src/components/ops-route-guard.tsx
+++ b/src/components/ops-route-guard.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+import type { ReactNode } from "react";
+import { getOpsAccessMode } from "@/lib/ops-access-policy";
+import { createClient } from "@/lib/supabase/server";
+
+export async function OpsRouteGuard({ children }: { children: ReactNode }) {
+  const mode = getOpsAccessMode();
+
+  if (mode === "local-bypass") return children;
+  if (mode === "configuration-block") redirect("/login?reason=configuration");
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getClaims();
+  if (error || !data?.claims?.sub) redirect("/login");
+
+  return children;
+}

--- a/src/components/public-shell.tsx
+++ b/src/components/public-shell.tsx
@@ -22,7 +22,7 @@ export function PublicShell({ children }: { children: React.ReactNode }) {
 
           <div className={styles.actions}>
             <Link className={styles.contact} href="/contacto">Contacto</Link>
-            <Link className={styles.ops} href="/app">Acceder a Greenatics</Link>
+            <a className={styles.ops} href="/app">Acceder a Greenatics</a>
           </div>
         </div>
       </header>
@@ -47,7 +47,11 @@ export function PublicShell({ children }: { children: React.ReactNode }) {
             <div className={styles.footerLinks} key={group.title}>
               <strong>{group.title}</strong>
               {group.links.map((link) => (
-                <Link href={link.href} key={link.href}>{link.label}</Link>
+                link.href === "/app" ? (
+                  <a href={link.href} key={link.href}>{link.label}</a>
+                ) : (
+                  <Link href={link.href} key={link.href}>{link.label}</Link>
+                )
               ))}
             </div>
           ))}

--- a/src/components/runtime-providers.tsx
+++ b/src/components/runtime-providers.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import { CommercialStoreProvider } from "@/components/commercial-store";
+import { CompostStoreProvider } from "@/components/compost-store";
+import { ExpenseStoreProvider } from "@/components/expense-store";
+import { InventoryStoreProvider } from "@/components/inventory-store";
+import { MaintenanceStoreProvider } from "@/components/maintenance-store";
+import { OpsStoreProvider } from "@/components/ops-store";
+import { PurchaseRequestStoreProvider } from "@/components/purchase-request-store";
+import { SettlementStoreProvider } from "@/components/settlement-store";
+import { SupplyStoreProvider } from "@/components/supply-store";
+import { isProtectedOpsPath } from "@/lib/ops-access-policy";
+
+export function RuntimeProviders({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+
+  if (!isProtectedOpsPath(pathname)) return children;
+
+  return (
+    <OpsStoreProvider>
+      <MaintenanceStoreProvider>
+        <CompostStoreProvider>
+          <InventoryStoreProvider>
+            <CommercialStoreProvider>
+              <ExpenseStoreProvider>
+                <SupplyStoreProvider>
+                  <PurchaseRequestStoreProvider>
+                    <SettlementStoreProvider>{children}</SettlementStoreProvider>
+                  </PurchaseRequestStoreProvider>
+                </SupplyStoreProvider>
+              </ExpenseStoreProvider>
+            </CommercialStoreProvider>
+          </InventoryStoreProvider>
+        </CompostStoreProvider>
+      </MaintenanceStoreProvider>
+    </OpsStoreProvider>
+  );
+}

--- a/src/lib/ops-access-policy.test.ts
+++ b/src/lib/ops-access-policy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { getOpsAccessMode, isLocalOpsBypassAllowed, isProtectedOpsPath } from "./ops-access-policy";
+
+const base = {
+  NODE_ENV: "production",
+  VERCEL_ENV: undefined,
+  NEXT_PUBLIC_DATA_MODE: "local",
+  NEXT_PUBLIC_SUPABASE_URL: undefined,
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: undefined,
+  GREENATICS_OPS_LOCAL_BYPASS: undefined,
+} as NodeJS.ProcessEnv;
+
+describe("OPS access policy", () => {
+  it("recognizes every protected route family without swallowing public routes", () => {
+    for (const path of ["/app", "/activities/new", "/compost/abc", "/dashboard", "/receptions/new", "/sales", "/supplies/consume"]) {
+      expect(isProtectedOpsPath(path)).toBe(true);
+    }
+    for (const path of ["/", "/wondergreen", "/soluciones", "/proyectos/yarumal", "/contacto", "/login"]) {
+      expect(isProtectedOpsPath(path)).toBe(false);
+    }
+  });
+
+  it("allows local OPS automatically only outside production", () => {
+    expect(isLocalOpsBypassAllowed({ ...base, NODE_ENV: "development" })).toBe(true);
+    expect(isLocalOpsBypassAllowed({ ...base, NODE_ENV: "test" })).toBe(true);
+    expect(isLocalOpsBypassAllowed(base)).toBe(false);
+  });
+
+  it("can explicitly allow a local production-runtime demo only off Vercel", () => {
+    expect(isLocalOpsBypassAllowed({ ...base, GREENATICS_OPS_LOCAL_BYPASS: "true" })).toBe(true);
+    expect(isLocalOpsBypassAllowed({ ...base, GREENATICS_OPS_LOCAL_BYPASS: "true", VERCEL_ENV: "preview" })).toBe(false);
+    expect(isLocalOpsBypassAllowed({ ...base, GREENATICS_OPS_LOCAL_BYPASS: "true", VERCEL_ENV: "production" })).toBe(false);
+  });
+
+  it("blocks production when remote auth is not configured", () => {
+    expect(getOpsAccessMode(base)).toBe("configuration-block");
+    expect(getOpsAccessMode({ ...base, NEXT_PUBLIC_DATA_MODE: "supabase" })).toBe("configuration-block");
+  });
+
+  it("requires Supabase auth when production remote configuration is complete", () => {
+    expect(getOpsAccessMode({
+      ...base,
+      NEXT_PUBLIC_DATA_MODE: "supabase",
+      NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_example",
+    })).toBe("supabase-auth");
+  });
+
+  it("never treats supabase mode as a local bypass", () => {
+    expect(isLocalOpsBypassAllowed({
+      ...base,
+      NODE_ENV: "development",
+      NEXT_PUBLIC_DATA_MODE: "supabase",
+      NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_example",
+    })).toBe(false);
+  });
+});

--- a/src/lib/ops-access-policy.ts
+++ b/src/lib/ops-access-policy.ts
@@ -17,15 +17,14 @@ export const protectedOpsRoutePrefixes = [
   "/supplies",
 ] as const;
 
-type AccessEnv = Pick<
-  NodeJS.ProcessEnv,
-  | "NODE_ENV"
-  | "VERCEL_ENV"
-  | "NEXT_PUBLIC_DATA_MODE"
-  | "NEXT_PUBLIC_SUPABASE_URL"
-  | "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"
-  | "GREENATICS_OPS_LOCAL_BYPASS"
->;
+type AccessEnv = {
+  NODE_ENV?: "development" | "production" | "test" | string;
+  VERCEL_ENV?: string;
+  NEXT_PUBLIC_DATA_MODE?: string;
+  NEXT_PUBLIC_SUPABASE_URL?: string;
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY?: string;
+  GREENATICS_OPS_LOCAL_BYPASS?: string;
+};
 
 export type OpsAccessMode = "local-bypass" | "supabase-auth" | "configuration-block";
 

--- a/src/lib/ops-access-policy.ts
+++ b/src/lib/ops-access-policy.ts
@@ -1,0 +1,56 @@
+export const protectedOpsRoutePrefixes = [
+  "/app",
+  "/activities",
+  "/calendar",
+  "/cash",
+  "/compost",
+  "/dashboard",
+  "/equipment",
+  "/expenses",
+  "/finance",
+  "/imports",
+  "/inventory",
+  "/production",
+  "/purchases",
+  "/receptions",
+  "/sales",
+  "/supplies",
+] as const;
+
+type AccessEnv = Pick<
+  NodeJS.ProcessEnv,
+  | "NODE_ENV"
+  | "VERCEL_ENV"
+  | "NEXT_PUBLIC_DATA_MODE"
+  | "NEXT_PUBLIC_SUPABASE_URL"
+  | "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"
+  | "GREENATICS_OPS_LOCAL_BYPASS"
+>;
+
+export type OpsAccessMode = "local-bypass" | "supabase-auth" | "configuration-block";
+
+export function isProtectedOpsPath(pathname: string) {
+  return protectedOpsRoutePrefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+export function isLocalOpsBypassAllowed(env: AccessEnv = process.env) {
+  const localDataMode = env.NEXT_PUBLIC_DATA_MODE !== "supabase";
+  if (!localDataMode) return false;
+
+  const developmentRuntime = env.NODE_ENV !== "production";
+  if (developmentRuntime) return true;
+
+  const explicitLocalRuntime = env.GREENATICS_OPS_LOCAL_BYPASS === "true" && !env.VERCEL_ENV;
+  return explicitLocalRuntime;
+}
+
+export function getOpsAccessMode(env: AccessEnv = process.env): OpsAccessMode {
+  if (isLocalOpsBypassAllowed(env)) return "local-bypass";
+
+  const remoteConfigured =
+    env.NEXT_PUBLIC_DATA_MODE === "supabase" &&
+    Boolean(env.NEXT_PUBLIC_SUPABASE_URL) &&
+    Boolean(env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY);
+
+  return remoteConfigured ? "supabase-auth" : "configuration-block";
+}

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -2,6 +2,20 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 import { shouldUseSupabase } from "@/lib/data-mode";
 
+function redirectWithSession(request: NextRequest, response: NextResponse, pathname: string) {
+  const url = request.nextUrl.clone();
+  url.pathname = pathname;
+  const redirect = NextResponse.redirect(url);
+
+  response.cookies.getAll().forEach((cookie) => redirect.cookies.set(cookie));
+  for (const header of ["cache-control", "expires", "pragma"]) {
+    const value = response.headers.get(header);
+    if (value) redirect.headers.set(header, value);
+  }
+
+  return redirect;
+}
+
 export async function updateSession(request: NextRequest) {
   if (!shouldUseSupabase()) return NextResponse.next({ request });
 
@@ -15,10 +29,11 @@ export async function updateSession(request: NextRequest) {
         getAll() {
           return request.cookies.getAll();
         },
-        setAll(cookiesToSet) {
+        setAll(cookiesToSet, headers) {
           cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
           response = NextResponse.next({ request });
           cookiesToSet.forEach(({ name, value, options }) => response.cookies.set(name, value, options));
+          Object.entries(headers ?? {}).forEach(([key, value]) => response.headers.set(key, value));
         },
       },
     },
@@ -29,15 +44,13 @@ export async function updateSession(request: NextRequest) {
   const isLogin = request.nextUrl.pathname === "/login";
 
   if (!isAuthenticated && !isLogin) {
-    const url = request.nextUrl.clone();
-    url.pathname = "/login";
-    return NextResponse.redirect(url);
+    const redirect = redirectWithSession(request, response, "/login");
+    redirect.nextUrl.searchParams.set("next", `${request.nextUrl.pathname}${request.nextUrl.search}`);
+    return redirect;
   }
 
   if (isAuthenticated && isLogin) {
-    const url = request.nextUrl.clone();
-    url.pathname = "/";
-    return NextResponse.redirect(url);
+    return redirectWithSession(request, response, "/app");
   }
 
   return response;

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -2,11 +2,18 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 import { shouldUseSupabase } from "@/lib/data-mode";
 
-function redirectWithSession(request: NextRequest, response: NextResponse, pathname: string) {
+function redirectWithSession(
+  request: NextRequest,
+  response: NextResponse,
+  pathname: string,
+  searchParams?: Record<string, string>,
+) {
   const url = request.nextUrl.clone();
   url.pathname = pathname;
-  const redirect = NextResponse.redirect(url);
+  url.search = "";
+  Object.entries(searchParams ?? {}).forEach(([key, value]) => url.searchParams.set(key, value));
 
+  const redirect = NextResponse.redirect(url);
   response.cookies.getAll().forEach((cookie) => redirect.cookies.set(cookie));
   for (const header of ["cache-control", "expires", "pragma"]) {
     const value = response.headers.get(header);
@@ -44,9 +51,9 @@ export async function updateSession(request: NextRequest) {
   const isLogin = request.nextUrl.pathname === "/login";
 
   if (!isAuthenticated && !isLogin) {
-    const redirect = redirectWithSession(request, response, "/login");
-    redirect.nextUrl.searchParams.set("next", `${request.nextUrl.pathname}${request.nextUrl.search}`);
-    return redirect;
+    return redirectWithSession(request, response, "/login", {
+      next: `${request.nextUrl.pathname}${request.nextUrl.search}`,
+    });
   }
 
   if (isAuthenticated && isLogin) {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy } from "./proxy";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function request(pathname: string) {
+  return new NextRequest(`https://greenatics.com.co${pathname}`);
+}
+
+describe("OPS request boundary", () => {
+  it("keeps public routes outside the auth boundary", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MODE", "local");
+
+    const response = await proxy(request("/wondergreen"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("keeps local OPS available during development", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MODE", "local");
+
+    const response = await proxy(request("/app"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("blocks production OPS when remote auth is not configured", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MODE", "local");
+
+    const response = await proxy(request("/app"));
+    expect(response.status).toBeGreaterThanOrEqual(300);
+    expect(response.status).toBeLessThan(400);
+    expect(response.headers.get("location")).toContain("/login?reason=configuration");
+    expect(response.headers.get("location")).toContain("next=%2Fapp");
+  });
+
+  it("blocks deployed previews even if a local bypass flag is present", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MODE", "local");
+    vi.stubEnv("GREENATICS_OPS_LOCAL_BYPASS", "true");
+
+    const response = await proxy(request("/dashboard"));
+    expect(response.headers.get("location")).toContain("/login?reason=configuration");
+  });
+
+  it("leaves the login screen reachable when remote configuration is missing", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MODE", "local");
+
+    const response = await proxy(request("/login"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getOpsAccessMode, isProtectedOpsPath } from "@/lib/ops-access-policy";
+import { updateSession } from "@/lib/supabase/proxy";
+
+export async function proxy(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+  const isLogin = pathname === "/login";
+  const isProtected = isProtectedOpsPath(pathname);
+
+  if (!isLogin && !isProtected) return NextResponse.next({ request });
+
+  const mode = getOpsAccessMode();
+  if (mode === "local-bypass") return NextResponse.next({ request });
+
+  if (mode === "configuration-block") {
+    if (isLogin) return NextResponse.next({ request });
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    url.searchParams.set("reason", "configuration");
+    url.searchParams.set("next", `${pathname}${request.nextUrl.search}`);
+    return NextResponse.redirect(url);
+  }
+
+  return updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    "/login",
+    "/app/:path*",
+    "/activities/:path*",
+    "/calendar/:path*",
+    "/cash/:path*",
+    "/compost/:path*",
+    "/dashboard/:path*",
+    "/equipment/:path*",
+    "/expenses/:path*",
+    "/finance/:path*",
+    "/imports/:path*",
+    "/inventory/:path*",
+    "/production/:path*",
+    "/purchases/:path*",
+    "/receptions/:path*",
+    "/sales/:path*",
+    "/supplies/:path*",
+  ],
+};


### PR DESCRIPTION
## Objetivo
Cerrar la frontera de seguridad entre la web pública y GREENATICS OPS antes de crear un deployment público.

## Cambios
- Política explícita de rutas OPS protegidas.
- `proxy.ts` Next 16 para login/rutas internas y refresh de sesión Supabase.
- Claims validados con `getClaims()`; redirects preservan cookies de sesión.
- Guard server-side por árbol OPS: claim válido + perfil activo + membresía activa de planta.
- Rutas OPS `force-dynamic` para evitar decisiones de sesión prerenderizadas/caché.
- Stores/providers OPS se montan únicamente en rutas internas, no en HOME/Wondergreen/etc.
- Modo local automático solo en desarrollo/CI; producción queda bloqueada sin Supabase.
- Escape local explícito solo fuera de Vercel para demos aisladas con `next start`.
- Login exitoso redirige a `/app`.
- ADR-0007 documenta la frontera.

## Seguridad en profundidad
Proxy/request boundary → guard de servidor → Supabase Auth → perfil/membresía → RLS PostgreSQL.
`robots.txt` sigue siendo solo control de indexación y no se considera autorización.

## Preservación
- URLs existentes intactas.
- Sin cambios de esquema ni políticas RLS.
- Desarrollo/CI local conserva acceso directo a OPS para la suite existente.

## QA nuevo
- Unit de política producción/local/Vercel.
- Unit del `proxy.ts` real para rutas públicas, desarrollo y bloqueo de producción.
- E2E demuestra que HOME no monta/persiste el store OPS y que desarrollo local sí conserva `/app`.
