### PR TITLE
Deployment v0.12 · Headers + login mode + preview gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -35,6 +35,37 @@ jobs:
           npm run lint
           npm test
           npm run build
+      - name: Production private-header gate
+        run: |
+          set -euo pipefail
+          PORT=3101 npm run start > /tmp/greenatics-next-start.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+
+          ready=0
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:3101/ >/dev/null 2>&1; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "$ready" -ne 1 ]; then
+            cat /tmp/greenatics-next-start.log
+            exit 1
+          fi
+
+          check_private_headers() {
+            path="$1"
+            headers="$(curl -sS -D - -o /dev/null "http://127.0.0.1:3101${path}" | tr -d '\r')"
+            printf '%s\n' "$headers" | grep -Eiq '^x-robots-tag: noindex, nofollow, noarchive$'
+            printf '%s\n' "$headers" | grep -Eiq '^cache-control: .*no-store'
+            printf '%s\n' "$headers" | grep -Eiq '^pragma: no-cache$'
+          }
+
+          check_private_headers /login
+          check_private_headers /app
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:

--- a/docs/deployment/PREVIEW-GATE.md
+++ b/docs/deployment/PREVIEW-GATE.md
@@ -1,0 +1,50 @@
+# GREENATICS · Preview Gate
+
+## Propósito
+Definir el mínimo verificable antes de asociar `greenatics.com.co` a un deployment de `GTCS-WEB`.
+
+## Estado de partida
+- La web pública y GREENATICS OPS comparten artefacto Next.js.
+- La web pública no monta stores OPS.
+- OPS está protegido por proxy de request, guard server-side y RLS.
+- Un deployment sin Supabase puede servir la web pública, pero debe bloquear las rutas OPS y llevarlas a `/login?reason=configuration`.
+- `robots.txt` y `X-Robots-Tag` complementan la seguridad; no sustituyen autenticación.
+
+## Variables de entorno
+### Preview público sin OPS remoto
+No activar un bypass local. En Vercel, el gate de v0.11 bloquea OPS si no existe configuración Supabase completa.
+
+### Preview con OPS remoto
+Configurar únicamente:
+- `NEXT_PUBLIC_DATA_MODE=supabase`
+- `NEXT_PUBLIC_SUPABASE_URL=<project-url>`
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<publishable-key>`
+
+Nunca configurar `GREENATICS_OPS_LOCAL_BYPASS` en Vercel.
+Nunca exponer `service_role` mediante variables `NEXT_PUBLIC_*`.
+
+## Gate funcional del preview
+1. `/` responde y muestra HOME pública.
+2. `/wondergreen`, `/soluciones`, `/proyectos`, `/impacto`, `/biblioteca`, `/nosotros` y `/contacto` responden sin inicializar stores OPS.
+3. `/sitemap.xml` contiene exclusivamente rutas públicas gobernadas.
+4. `/robots.txt` bloquea rutas internas y `/api/`.
+5. Respuestas públicas incluyen `nosniff`, `DENY` para framing, política de referrer y permisos restringidos.
+6. `/app` y demás familias OPS incluyen `private, no-store` y `X-Robots-Tag: noindex, nofollow, noarchive`.
+7. Preview sin Supabase: `/app` redirige a `/login?reason=configuration` y no muestra datos OPS.
+8. Preview con Supabase: usuario sin sesión va a login; usuario válido necesita perfil activo y membresía activa de planta.
+9. Un usuario autorizado entra a `/app`; RLS conserva aislamiento por planta/rol.
+10. Salir de OPS hacia la web pública y entrar desde la web pública a OPS cruza una frontera documental, no depende de preservar el árbol de providers del cliente.
+
+## Gate de observabilidad
+- Revisar build logs sin errores.
+- Revisar runtime errors del preview.
+- Probar desktop y móvil.
+- No asociar el dominio si existen 5xx, bucles de redirect, datos OPS visibles sin sesión o headers internos ausentes.
+
+## Dominio
+`greenatics.com.co` se asocia únicamente después de aprobar el preview. El cambio de DNS/dominio no debe utilizarse como mecanismo de prueba.
+
+## Después del dominio
+- Verificar canonical, sitemap y robots en el hostname definitivo.
+- Verificar login/redirects desde el dominio definitivo.
+- Revisar Search Console/analítica solo cuando la capa pública esté estable.

--- a/e2e/deployment-readiness.spec.ts
+++ b/e2e/deployment-readiness.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+function expectDevelopmentNonCacheable(cacheControl: string | undefined) {
+  expect(cacheControl).toBeTruthy();
+  expect(cacheControl).toMatch(/no-store|no-cache/);
+}
+
+test("public responses expose baseline security headers without internal noindex", async ({ request }) => {
+  const response = await request.get("/");
+  expect(response.ok()).toBe(true);
+  const headers = response.headers();
+
+  expect(headers["x-content-type-options"]).toBe("nosniff");
+  expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+  expect(headers["x-frame-options"]).toBe("DENY");
+  expect(headers["permissions-policy"]).toContain("camera=()");
+  expect(headers["x-robots-tag"]).toBeUndefined();
+});
+
+test("OPS responses are non-indexable and non-cacheable in the development E2E server", async ({ request }) => {
+  const response = await request.get("/app");
+  expect(response.ok()).toBe(true);
+  const headers = response.headers();
+
+  expect(headers["x-robots-tag"]).toBe("noindex, nofollow, noarchive");
+  expectDevelopmentNonCacheable(headers["cache-control"]);
+  expect(headers["pragma"]).toBe("no-cache");
+});
+
+test("login is private and excluded from indexing in the development E2E server", async ({ request }) => {
+  const response = await request.get("/login");
+  expect(response.ok()).toBe(true);
+  const headers = response.headers();
+
+  expect(headers["x-robots-tag"]).toBe("noindex, nofollow, noarchive");
+  expectDevelopmentNonCacheable(headers["cache-control"]);
+});
+
+test("HOME content CTA crosses the public-to-OPS document boundary", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("link", { name: "Entrar a GREENATICS OPS" }).click();
+  await expect(page).toHaveURL(/\/app$/);
+  await expect(page.getByRole("heading", { name: "Operación de hoy" })).toBeVisible();
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,11 @@
 import type { NextConfig } from "next";
+import { deploymentHeadersConfig } from "./src/lib/http-security";
 
-const nextConfig: NextConfig = { reactStrictMode: true };
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  async headers() {
+    return deploymentHeadersConfig();
+  },
+};
 
 export default nextConfig;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,4 +1,7 @@
 import { LoginForm } from "@/components/login-form";
+import { getOpsAccessMode } from "@/lib/ops-access-policy";
+
+export const dynamic = "force-dynamic";
 
 function authFeedback(authError?: string, reason?: string) {
   if (authError === "invalid-or-expired-link") return "El enlace de invitación es inválido o venció. Solicita una nueva invitación.";
@@ -10,5 +13,5 @@ function authFeedback(authError?: string, reason?: string) {
 
 export default async function LoginPage({ searchParams }: { searchParams: Promise<{ auth_error?: string; reason?: string }> }) {
   const params = await searchParams;
-  return <main className="min-h-screen bg-[var(--canvas)] px-4 py-12"><LoginForm initialFeedback={authFeedback(params.auth_error, params.reason)} /></main>;
+  return <main className="min-h-screen bg-[var(--canvas)] px-4 py-12"><LoginForm accessMode={getOpsAccessMode()} initialFeedback={authFeedback(params.auth_error, params.reason)} /></main>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -246,7 +246,7 @@ export default function Home() {
               </p>
               <div className={styles.buttonRow}>
                 <Link className={`${styles.button} ${styles.buttonGhost}`} href="/impacto">Ver impacto público</Link>
-                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/app">Entrar a GREENATICS OPS</Link>
+                <a className={`${styles.button} ${styles.buttonGhost}`} href="/app">Entrar a GREENATICS OPS</a>
               </div>
             </div>
             <div className={styles.console}>
@@ -263,7 +263,7 @@ export default function Home() {
             <div><span className={styles.eyebrow}>Greenatics</span><h2>¿Tienes un residuo, un cultivo, una planta o un territorio por transformar?</h2></div>
             <div className={styles.buttonRow}>
               <Link className={`${styles.button} ${styles.buttonDark}`} href="/contacto">Contactar a Greenatics</Link>
-              <Link className={`${styles.button} ${styles.buttonGhost}`} href="/app">Acceder a la app interna</Link>
+              <a className={`${styles.button} ${styles.buttonGhost}`} href="/app">Acceder a la app interna</a>
             </div>
           </div>
         </section>

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -3,21 +3,24 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { getDataMode, isSupabaseConfigured } from "@/lib/data-mode";
+import type { OpsAccessMode } from "@/lib/ops-access-policy";
+import { isSupabaseConfigured } from "@/lib/data-mode";
 import { safeOpsNext } from "@/lib/ops-routes";
 import { createClient } from "@/lib/supabase/client";
 
-export function LoginForm({ initialFeedback = "" }: { initialFeedback?: string }) {
+export function LoginForm({ accessMode, initialFeedback = "" }: { accessMode: OpsAccessMode; initialFeedback?: string }) {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [feedback, setFeedback] = useState(initialFeedback);
   const [busy, setBusy] = useState(false);
-  const supabaseMode = getDataMode() === "supabase";
-  const configured = isSupabaseConfigured();
+  const localBypass = accessMode === "local-bypass";
+  const remoteAuth = accessMode === "supabase-auth";
+  const configurationBlocked = accessMode === "configuration-block";
+  const configured = remoteAuth && isSupabaseConfigured();
 
   const submit = async () => {
-    if (!supabaseMode || !configured) return setFeedback("El acceso remoto de GREENATICS OPS no está configurado en este entorno.");
+    if (!remoteAuth || !configured) return setFeedback("El acceso remoto de GREENATICS OPS no está configurado en este entorno.");
     if (!email.trim() || !password) return setFeedback("Ingresa correo y contraseña.");
     setBusy(true);
     setFeedback("");
@@ -35,13 +38,14 @@ export function LoginForm({ initialFeedback = "" }: { initialFeedback?: string }
 
   return <section className="panel mx-auto max-w-md">
     <div className="mb-6"><p className="eyebrow">GREENATICS OPS</p><h1 className="text-3xl">Acceso interno</h1><p className="lede">Ingreso del equipo operativo y administrativo.</p></div>
-    {!supabaseMode && <div className="mb-5 rounded-xl bg-[var(--green-soft)] p-4 text-sm text-[var(--green-dark)]"><strong>Modo local de desarrollo.</strong><span className="mt-1 block">El acceso local solo se habilita en desarrollo, CI o demos aisladas autorizadas; no funciona como fallback de producción.</span></div>}
-    {supabaseMode && !configured && <div className="mb-5 rounded-xl bg-[var(--amber-soft)] p-4 text-sm text-[var(--amber)]"><strong>Acceso remoto pendiente de configuración.</strong><span className="mt-1 block">Faltan URL y publishable key del proyecto Supabase.</span></div>}
+    {localBypass && <div className="mb-5 rounded-xl bg-[var(--green-soft)] p-4 text-sm text-[var(--green-dark)]"><strong>Modo local de desarrollo.</strong><span className="mt-1 block">El acceso local solo se habilita en desarrollo, CI o demos aisladas autorizadas; no funciona como fallback de producción.</span></div>}
+    {configurationBlocked && <div className="mb-5 rounded-xl bg-[var(--amber-soft)] p-4 text-sm text-[var(--amber)]" role="status"><strong>OPS está protegido en este deployment.</strong><span className="mt-1 block">La web pública puede funcionar, pero el acceso interno permanece bloqueado hasta configurar Supabase Auth para este entorno.</span></div>}
+    {remoteAuth && !configured && <div className="mb-5 rounded-xl bg-[var(--amber-soft)] p-4 text-sm text-[var(--amber)]"><strong>Acceso remoto pendiente de configuración.</strong><span className="mt-1 block">Faltan URL y publishable key del proyecto Supabase en el cliente.</span></div>}
     <div className="grid gap-4">
       <label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Correo<input className="min-h-11 rounded-lg border border-[var(--line)] px-3 text-base text-[var(--ink)]" autoComplete="email" type="email" value={email} onChange={(event) => setEmail(event.target.value)} /></label>
       <label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Contraseña<input className="min-h-11 rounded-lg border border-[var(--line)] px-3 text-base text-[var(--ink)]" autoComplete="current-password" type="password" value={password} onChange={(event) => setPassword(event.target.value)} /></label>
     </div>
     {feedback && <p className="mt-4 rounded-lg bg-[var(--red-soft)] p-3 text-sm font-semibold text-[var(--red)]" role="alert">{feedback}</p>}
-    <div className="mt-6 flex items-center justify-between gap-3"><Link className="button secondary" href="/">Volver al sitio</Link><button className="button primary" disabled={busy || !supabaseMode || !configured} type="button" onClick={submit}>{busy ? "Ingresando…" : "Ingresar"}</button></div>
+    <div className="mt-6 flex items-center justify-between gap-3"><Link className="button secondary" href="/">Volver al sitio</Link><button className="button primary" disabled={busy || !remoteAuth || !configured} type="button" onClick={submit}>{busy ? "Ingresando…" : "Ingresar"}</button></div>
   </section>;
 }

--- a/src/lib/http-security.test.ts
+++ b/src/lib/http-security.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { protectedOpsRoutePrefixes } from "./ops-access-policy";
+import {
+  baselineSecurityHeaders,
+  deploymentHeadersConfig,
+  internalHeaderRoutePrefixes,
+  internalResponseHeaders,
+} from "./http-security";
+
+function headerValue(headers: { key: string; value: string }[], key: string) {
+  return headers.find((header) => header.key === key)?.value;
+}
+
+describe("deployment response headers", () => {
+  it("applies defensive headers to every route", () => {
+    expect(headerValue(baselineSecurityHeaders, "X-Content-Type-Options")).toBe("nosniff");
+    expect(headerValue(baselineSecurityHeaders, "Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    expect(headerValue(baselineSecurityHeaders, "X-Frame-Options")).toBe("DENY");
+    expect(headerValue(baselineSecurityHeaders, "Permissions-Policy")).toContain("camera=()");
+  });
+
+  it("marks internal responses private, non-cacheable and non-indexable", () => {
+    expect(headerValue(internalResponseHeaders, "Cache-Control")).toContain("no-store");
+    expect(headerValue(internalResponseHeaders, "X-Robots-Tag")).toBe("noindex, nofollow, noarchive");
+    expect(headerValue(internalResponseHeaders, "Pragma")).toBe("no-cache");
+  });
+
+  it("covers every protected OPS family plus login and API", () => {
+    for (const prefix of protectedOpsRoutePrefixes) expect(internalHeaderRoutePrefixes).toContain(prefix);
+    expect(internalHeaderRoutePrefixes).toContain("/login");
+    expect(internalHeaderRoutePrefixes).toContain("/api");
+  });
+
+  it("generates one baseline rule plus one private rule per internal prefix", () => {
+    const config = deploymentHeadersConfig();
+    expect(config).toHaveLength(1 + internalHeaderRoutePrefixes.length);
+    expect(config[0]).toEqual({ source: "/:path*", headers: baselineSecurityHeaders });
+    expect(config.some((rule) => rule.source === "/app/:path*")).toBe(true);
+    expect(config.some((rule) => rule.source === "/login/:path*")).toBe(true);
+    expect(config.some((rule) => rule.source === "/api/:path*")).toBe(true);
+  });
+});

--- a/src/lib/http-security.ts
+++ b/src/lib/http-security.ts
@@ -1,0 +1,32 @@
+import { protectedOpsRoutePrefixes } from "./ops-access-policy";
+
+export type SecurityHeader = { key: string; value: string };
+
+export const baselineSecurityHeaders: SecurityHeader[] = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+
+export const internalResponseHeaders: SecurityHeader[] = [
+  { key: "Cache-Control", value: "private, no-store, max-age=0" },
+  { key: "Pragma", value: "no-cache" },
+  { key: "X-Robots-Tag", value: "noindex, nofollow, noarchive" },
+];
+
+export const internalHeaderRoutePrefixes = [
+  ...protectedOpsRoutePrefixes,
+  "/login",
+  "/api",
+] as const;
+
+export function deploymentHeadersConfig() {
+  return [
+    { source: "/:path*", headers: baselineSecurityHeaders },
+    ...internalHeaderRoutePrefixes.map((prefix) => ({
+      source: `${prefix}/:path*`,
+      headers: internalResponseHeaders,
+    })),
+  ];
+}


### PR DESCRIPTION
## Objetivo
Dejar el artefacto listo para un primer preview público seguro antes de asociar dominio productivo.

## Cambios
- Login renderiza desde el modo real calculado en servidor: local-bypass, supabase-auth o configuration-block.
- Un deployment sin Supabase muestra explícitamente que OPS está protegido, no “modo local de desarrollo”.
- Headers defensivos globales: nosniff, referrer policy, deny framing y permisos restringidos.
- `/login`, `/api` y todas las familias OPS reciben además `private, no-store`, `Pragma: no-cache` y `X-Robots-Tag: noindex, nofollow, noarchive`.
- HOME normaliza sus dos CTAs directos a OPS como navegación documental.
- `docs/deployment/PREVIEW-GATE.md` define variables, QA, observabilidad y prohibición de tocar DNS antes de aprobar preview.

## Preservación
- No cambia autenticación, RLS, esquema, stores ni datos.
- No añade CSP todavía para evitar romper Next/Supabase sin una política probada.
- No crea ni asocia dominio Vercel.

## QA nuevo
- Unit del contrato de headers.
- E2E de headers públicos vs internos.
- E2E del CTA HOME → OPS real.
