### PR TITLE
CORE-005A · Puente documental SharePoint read-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,11 @@ APP_BASE_URL=
 # Optional server-only escape hatch for a LOCAL `next start` demo.
 # It is ignored on Vercel and must never be configured in a deployment.
 GREENATICS_OPS_LOCAL_BYPASS=false
+
+# Optional read-only SharePoint document source.
+# These identifiers describe private tenant structure: keep real values in server-side environment configuration,
+# never in NEXT_PUBLIC_* variables or committed source files.
+SHAREPOINT_SITE_HOSTNAME=
+SHAREPOINT_SITE_PATH=
+SHAREPOINT_DRIVE_ID=
+SHAREPOINT_DOCUMENT_ROOT=

--- a/docs/integrations/SHAREPOINT_READONLY_BRIDGE.md
+++ b/docs/integrations/SHAREPOINT_READONLY_BRIDGE.md
@@ -1,0 +1,70 @@
+# GREENATICS OPS · SharePoint read-only bridge
+
+## Decisión
+GREENATICS OPS mantiene la operación diaria y sus transacciones como fuente canónica. SharePoint permanece como repositorio documental e histórico. La integración une ambos mundos mediante **referencias**, no copiando la lógica operativa de vuelta a documentos o listas.
+
+## Privacidad del repositorio
+Este repositorio es público. Por tanto, no se versionan:
+- hostname real del tenant;
+- site ID;
+- drive ID;
+- item IDs;
+- rutas internas reales;
+- client IDs, secrets, tokens o credenciales.
+
+La estructura documental real se inventariará y auditará fuera de Git, y sus identificadores se inyectan únicamente como configuración server-side.
+
+## Configuración
+El contrato inicial usa:
+
+```text
+SHAREPOINT_SITE_HOSTNAME=
+SHAREPOINT_SITE_PATH=
+SHAREPOINT_DRIVE_ID=
+SHAREPOINT_DOCUMENT_ROOT=
+```
+
+Ninguna variable documental usa el prefijo `NEXT_PUBLIC_`.
+
+## Identidad estable
+Una referencia SharePoint se identifica por:
+
+```text
+sharepoint:<driveId>:<itemId>
+```
+
+`webUrl` es un enlace de navegación para personas; no es la identidad primaria porque nombres, carpetas o URLs pueden cambiar.
+
+## Contrato de referencia
+Campos V0:
+- `provider = sharepoint`;
+- `driveId`;
+- `itemId`;
+- `title`;
+- `webUrl` HTTPS de SharePoint;
+- `mimeType` opcional;
+- `modifiedAt` opcional.
+
+El contrato no contiene binarios ni credenciales.
+
+## Frontera read-only de CORE-005A
+Este slice **no** implementa OAuth de Microsoft Graph desde el runtime, uploads, renombres, movimientos, borrados ni sincronización automática. Tampoco usa SharePoint como fallback cuando Supabase falla.
+
+La siguiente fase puede añadir un adapter server-side de lectura Graph con permisos mínimos y cache controlada. Solo después de certificar ese adapter se habilitarán vistas de documentos/evidencias en OPS.
+
+## Reglas de integridad
+1. Una transacción OPS no desaparece si un documento externo cambia de nombre o carpeta.
+2. Una referencia documental rota se reporta como tal; no se elimina silenciosamente.
+3. SharePoint no decide autorización operacional por planta: esa frontera sigue en Supabase/RLS.
+4. El navegador nunca recibe credenciales Graph.
+5. No se persisten URLs temporales de descarga como identidad canónica.
+6. No se inventan carpetas o IDs cuando falta configuración.
+
+## Gate para CORE-005B
+Antes de lectura remota real:
+- definir mecanismo OAuth/App Registration y permisos mínimos;
+- confirmar si la autenticación será app-only o delegada;
+- mantener secretos solo server-side;
+- añadir pruebas contractuales con fixture Graph sanitizado;
+- definir política de cache/revalidación y límites;
+- validar que el repo público no filtra metadata interna del tenant.

--- a/src/lib/document-source-contract.test.ts
+++ b/src/lib/document-source-contract.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  documentReferenceKey,
+  parseSharePointSourceConfig,
+  validateSharePointDocumentReference,
+} from "@/lib/document-source-contract";
+
+describe("SharePoint document source contract", () => {
+  it("normalizes a complete private source configuration", () => {
+    const result = parseSharePointSourceConfig({
+      SHAREPOINT_SITE_HOSTNAME: " Tenant.SharePoint.com ",
+      SHAREPOINT_SITE_PATH: "sites/Operations/",
+      SHAREPOINT_DRIVE_ID: "b!Drive_123",
+      SHAREPOINT_DOCUMENT_ROOT: "Company / Operations / Evidence",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        provider: "sharepoint",
+        hostname: "tenant.sharepoint.com",
+        sitePath: "/sites/Operations",
+        driveId: "b!Drive_123",
+        documentRoot: "Company/Operations/Evidence",
+      },
+    });
+  });
+
+  it("fails explicitly when configuration is incomplete or unsafe", () => {
+    expect(parseSharePointSourceConfig({}).ok).toBe(false);
+    expect(parseSharePointSourceConfig({
+      SHAREPOINT_SITE_HOSTNAME: "https://tenant.sharepoint.com/sites/Operations",
+      SHAREPOINT_SITE_PATH: "/sites/Operations",
+      SHAREPOINT_DRIVE_ID: "b!Drive_123",
+      SHAREPOINT_DOCUMENT_ROOT: "Company/Operations",
+    }).ok).toBe(false);
+    expect(parseSharePointSourceConfig({
+      SHAREPOINT_SITE_HOSTNAME: "tenant.sharepoint.com",
+      SHAREPOINT_SITE_PATH: "/sites/Operations",
+      SHAREPOINT_DRIVE_ID: "b!Drive_123",
+      SHAREPOINT_DOCUMENT_ROOT: "Company/../Secrets",
+    }).ok).toBe(false);
+  });
+
+  it("validates SharePoint references and creates a stable provider/drive/item key", () => {
+    const result = validateSharePointDocumentReference({
+      provider: "sharepoint",
+      driveId: "b!Drive_123",
+      itemId: "01ITEM_ABC",
+      title: "Daily operations evidence.pdf",
+      webUrl: "https://tenant.sharepoint.com/sites/Operations/Shared%20Documents/evidence.pdf?web=1",
+      mimeType: "application/pdf",
+      modifiedAt: "2026-08-12T10:15:00-05:00",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(documentReferenceKey(result.value)).toBe("sharepoint:b!Drive_123:01ITEM_ABC");
+    expect(result.value.modifiedAt).toBe("2026-08-12T15:15:00.000Z");
+  });
+
+  it("rejects insecure, non-SharePoint or malformed document references", () => {
+    for (const webUrl of [
+      "http://tenant.sharepoint.com/file.pdf",
+      "https://example.com/file.pdf",
+      "not-a-url",
+    ]) {
+      expect(validateSharePointDocumentReference({
+        provider: "sharepoint",
+        driveId: "b!Drive_123",
+        itemId: "01ITEM_ABC",
+        title: "Evidence",
+        webUrl,
+      }).ok).toBe(false);
+    }
+
+    expect(() => documentReferenceKey({ provider: "sharepoint", driveId: "bad:id", itemId: "01ITEM_ABC" })).toThrow();
+  });
+});

--- a/src/lib/document-source-contract.ts
+++ b/src/lib/document-source-contract.ts
@@ -1,0 +1,121 @@
+export type DocumentProvider = "sharepoint";
+
+export type SharePointSourceConfig = Readonly<{
+  provider: "sharepoint";
+  hostname: string;
+  sitePath: string;
+  driveId: string;
+  documentRoot: string;
+}>;
+
+export type SharePointDocumentReference = Readonly<{
+  provider: "sharepoint";
+  driveId: string;
+  itemId: string;
+  title: string;
+  webUrl: string;
+  mimeType?: string;
+  modifiedAt?: string;
+}>;
+
+export type ContractResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+const GRAPH_ID = /^[A-Za-z0-9!._-]{3,512}$/;
+
+function clean(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function validGraphId(value: string) {
+  return GRAPH_ID.test(value);
+}
+
+function normalizeSharePointHostname(value: string) {
+  const hostname = value.toLowerCase();
+  if (!hostname || hostname.includes("://") || hostname.includes("/") || hostname.includes("?") || hostname.includes("#")) {
+    return null;
+  }
+  return hostname.endsWith(".sharepoint.com") ? hostname : null;
+}
+
+function normalizeSitePath(value: string) {
+  if (!value || value.includes("?") || value.includes("#") || value.includes("..")) return null;
+  const withLeadingSlash = value.startsWith("/") ? value : `/${value}`;
+  const normalized = withLeadingSlash.replace(/\/+$/g, "");
+  return normalized.startsWith("/sites/") || normalized.startsWith("/teams/") ? normalized : null;
+}
+
+function normalizeDocumentRoot(value: string) {
+  if (!value || value.startsWith("/") || value.includes("?") || value.includes("#")) return null;
+  const segments = value.split("/").map((segment) => segment.trim());
+  if (segments.some((segment) => !segment || segment === "." || segment === "..")) return null;
+  return segments.join("/");
+}
+
+function normalizeSharePointWebUrl(value: string) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password || !url.hostname.toLowerCase().endsWith(".sharepoint.com")) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function parseSharePointSourceConfig(env: Record<string, string | undefined>): ContractResult<SharePointSourceConfig> {
+  const hostname = normalizeSharePointHostname(clean(env.SHAREPOINT_SITE_HOSTNAME));
+  const sitePath = normalizeSitePath(clean(env.SHAREPOINT_SITE_PATH));
+  const driveId = clean(env.SHAREPOINT_DRIVE_ID);
+  const documentRoot = normalizeDocumentRoot(clean(env.SHAREPOINT_DOCUMENT_ROOT));
+
+  if (!hostname) return { ok: false, error: "SHAREPOINT_SITE_HOSTNAME debe ser un hostname *.sharepoint.com sin protocolo ni ruta." };
+  if (!sitePath) return { ok: false, error: "SHAREPOINT_SITE_PATH debe ser una ruta /sites/... o /teams/... válida." };
+  if (!validGraphId(driveId)) return { ok: false, error: "SHAREPOINT_DRIVE_ID falta o no tiene un formato Graph válido." };
+  if (!documentRoot) return { ok: false, error: "SHAREPOINT_DOCUMENT_ROOT debe ser una ruta relativa válida dentro de la biblioteca." };
+
+  return {
+    ok: true,
+    value: { provider: "sharepoint", hostname, sitePath, driveId, documentRoot },
+  };
+}
+
+export function validateSharePointDocumentReference(input: unknown): ContractResult<SharePointDocumentReference> {
+  if (!input || typeof input !== "object") return { ok: false, error: "La referencia documental debe ser un objeto." };
+  const row = input as Record<string, unknown>;
+  if (row.provider !== "sharepoint") return { ok: false, error: "Proveedor documental no soportado." };
+
+  const driveId = clean(row.driveId);
+  const itemId = clean(row.itemId);
+  const title = clean(row.title);
+  const webUrl = normalizeSharePointWebUrl(clean(row.webUrl));
+  const mimeType = clean(row.mimeType);
+  const modifiedAt = clean(row.modifiedAt);
+
+  if (!validGraphId(driveId) || !validGraphId(itemId)) return { ok: false, error: "driveId/itemId no tienen un formato Graph válido." };
+  if (!title || title.length > 300) return { ok: false, error: "El título documental es obligatorio y debe tener máximo 300 caracteres." };
+  if (!webUrl) return { ok: false, error: "webUrl debe ser una URL HTTPS de SharePoint." };
+  if (mimeType && mimeType.length > 200) return { ok: false, error: "mimeType excede la longitud permitida." };
+  if (modifiedAt && Number.isNaN(Date.parse(modifiedAt))) return { ok: false, error: "modifiedAt debe ser una fecha válida." };
+
+  return {
+    ok: true,
+    value: {
+      provider: "sharepoint",
+      driveId,
+      itemId,
+      title,
+      webUrl,
+      ...(mimeType ? { mimeType } : {}),
+      ...(modifiedAt ? { modifiedAt: new Date(modifiedAt).toISOString() } : {}),
+    },
+  };
+}
+
+export function documentReferenceKey(reference: Pick<SharePointDocumentReference, "provider" | "driveId" | "itemId">) {
+  if (reference.provider !== "sharepoint" || !validGraphId(reference.driveId) || !validGraphId(reference.itemId)) {
+    throw new Error("No se puede construir una clave para una referencia documental inválida.");
+  }
+  return `${reference.provider}:${reference.driveId}:${reference.itemId}`;
+}


### PR DESCRIPTION
Cierra el primer slice de #62 sin introducir OAuth ni escrituras remotas.

## Incluye
- contrato tipado para fuente documental SharePoint;
- identidad estable `provider + driveId + itemId`;
- validación de URLs HTTPS SharePoint, IDs Graph y metadata opcional;
- parser explícito de configuración server-side;
- variables documentales sin `NEXT_PUBLIC_`;
- tests unitarios de normalización, seguridad y claves estables;
- guía de arquitectura read-only.

## Privacidad
El repositorio es público: no se versiona ningún hostname, siteId, driveId, itemId ni ruta real del tenant descubierto. Los valores reales quedan exclusivamente en configuración privada del entorno.

## Fuera de alcance
OAuth Microsoft Graph, lectura remota de runtime, sincronización, upload/move/delete y binarios.

Mantener draft hasta gate `quality` verde.