### PR TITLE
Deployment v0.13.1 · Vercel Git preview contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 SUPABASE_SECRET_KEY=
 
 # Canonical public origin used for auth redirects, for example https://greenatics.com.co.
-# Hosted environments must configure it explicitly; server code does not trust the request Host header.
+# Production must configure it explicitly; server code never trusts the request Host header.
+# On Vercel Preview only, if this is absent, the server may use the trusted system VERCEL_BRANCH_URL over HTTPS.
 APP_BASE_URL=
 
 # Optional server-only escape hatch for a LOCAL `next start` demo.

--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,11 @@ APP_BASE_URL=
 # Optional server-only escape hatch for a LOCAL `next start` demo.
 # It is ignored on Vercel and must never be configured in a deployment.
 GREENATICS_OPS_LOCAL_BYPASS=false
+
+# Optional read-only SharePoint document source.
+# These identifiers describe private tenant structure: keep real values in server-side environment configuration,
+# never in NEXT_PUBLIC_* variables or committed source files.
+SHAREPOINT_SITE_HOSTNAME=
+SHAREPOINT_SITE_PATH=
+SHAREPOINT_DRIVE_ID=
+SHAREPOINT_DOCUMENT_ROOT=

--- a/docs/deployment/PREVIEW-GATE.md
+++ b/docs/deployment/PREVIEW-GATE.md
@@ -9,37 +9,45 @@ Definir el mínimo verificable antes de asociar `greenatics.com.co` a un deploym
 - OPS está protegido por proxy de request, guard server-side y RLS.
 - Un deployment sin Supabase puede servir la web pública, pero debe bloquear las rutas OPS y llevarlas a `/login?reason=configuration`.
 - `robots.txt` y `X-Robots-Tag` complementan la seguridad; no sustituyen autenticación.
+- `/api/health` expone provenance mínima para comprobar que el preview corresponde al branch/SHA esperado.
 
 ## Variables de entorno
 ### Preview público sin OPS remoto
 No activar un bypass local. En Vercel, el gate de v0.11 bloquea OPS si no existe configuración Supabase completa.
 
 ### Preview con OPS remoto
-Configurar únicamente:
+Configurar:
 - `NEXT_PUBLIC_DATA_MODE=supabase`
 - `NEXT_PUBLIC_SUPABASE_URL=<project-url>`
 - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<publishable-key>`
+- `SUPABASE_SECRET_KEY=<server-only-secret>` cuando se prueben administración, invitaciones o health completo.
+
+Para redirects de autenticación:
+- `APP_BASE_URL` es la autoridad explícita cuando está definido.
+- En Vercel Preview, si falta, el servidor puede usar la variable de sistema `VERCEL_BRANCH_URL` sobre HTTPS.
+- En Production, `APP_BASE_URL` es obligatorio; no existe fallback de branch URL.
 
 Nunca configurar `GREENATICS_OPS_LOCAL_BYPASS` en Vercel.
-Nunca exponer `service_role` mediante variables `NEXT_PUBLIC_*`.
+Nunca exponer `SUPABASE_SECRET_KEY` ni ninguna credencial administrativa mediante variables `NEXT_PUBLIC_*`.
 
 ## Gate funcional del preview
-1. `/` responde y muestra HOME pública.
-2. `/wondergreen`, `/soluciones`, `/proyectos`, `/impacto`, `/biblioteca`, `/nosotros` y `/contacto` responden sin inicializar stores OPS.
-3. `/sitemap.xml` contiene exclusivamente rutas públicas gobernadas.
-4. `/robots.txt` bloquea rutas internas y `/api/`.
-5. Respuestas públicas incluyen `nosniff`, `DENY` para framing, política de referrer y permisos restringidos.
-6. `/app` y demás familias OPS incluyen `private, no-store` y `X-Robots-Tag: noindex, nofollow, noarchive`.
-7. Preview sin Supabase: `/app` redirige a `/login?reason=configuration` y no muestra datos OPS.
-8. Preview con Supabase: usuario sin sesión va a login; usuario válido necesita perfil activo y membresía activa de planta.
-9. Un usuario autorizado entra a `/app`; RLS conserva aislamiento por planta/rol.
-10. Salir de OPS hacia la web pública y entrar desde la web pública a OPS cruza una frontera documental, no depende de preservar el árbol de providers del cliente.
+1. `/api/health` identifica `deployment.platform=vercel`, `deployment.environment=preview` y branch/SHA correspondientes al commit GitHub que se está auditando.
+2. `/` responde y muestra HOME pública.
+3. `/wondergreen`, `/soluciones`, `/proyectos`, `/impacto`, `/biblioteca`, `/nosotros` y `/contacto` responden sin inicializar stores OPS.
+4. `/sitemap.xml` contiene exclusivamente rutas públicas gobernadas.
+5. `/robots.txt` bloquea rutas internas y `/api/`.
+6. Respuestas públicas incluyen `nosniff`, `DENY` para framing, política de referrer y permisos restringidos.
+7. `/app` y demás familias OPS incluyen `private, no-store` y `X-Robots-Tag: noindex, nofollow, noarchive`.
+8. Preview sin Supabase: `/app` redirige a `/login?reason=configuration` y no muestra datos OPS; `/api/health` reporta `opsAccess=configuration-block`.
+9. Preview con Supabase: usuario sin sesión va a login; usuario válido necesita perfil activo y membresía activa de planta; `/api/health` reporta `opsAccess=supabase-auth`.
+10. Un usuario autorizado entra a `/app`; RLS conserva aislamiento por planta/rol.
+11. Salir de OPS hacia la web pública y entrar desde la web pública a OPS cruza una frontera documental, no depende de preservar el árbol de providers del cliente.
 
 ## Gate de observabilidad
 - Revisar build logs sin errores.
 - Revisar runtime errors del preview.
 - Probar desktop y móvil.
-- No asociar el dominio si existen 5xx, bucles de redirect, datos OPS visibles sin sesión o headers internos ausentes.
+- No asociar el dominio si existen 5xx inesperados, bucles de redirect, datos OPS visibles sin sesión, provenance incorrecta o headers internos ausentes.
 
 ## Dominio
 `greenatics.com.co` se asocia únicamente después de aprobar el preview. El cambio de DNS/dominio no debe utilizarse como mecanismo de prueba.

--- a/docs/deployment/VERCEL-GIT-INTEGRATION.md
+++ b/docs/deployment/VERCEL-GIT-INTEGRATION.md
@@ -1,0 +1,87 @@
+# GREENATICS · Vercel Git Integration
+
+## Objetivo
+Vincular `arendon7/GTCS-WEB` a Vercel mediante Git Integration para obtener previews reproducibles del mismo commit que revisa GitHub, sin crear un bundle manual alternativo y sin tocar el dominio productivo durante la validación.
+
+## Estado de release
+A 2026-08-12 `main` y `develop` están divergidas. `develop` contiene la plataforma pública + GREENATICS OPS vigente, mientras `main` conserva commits propios no reconciliados.
+
+**Regla:** no definir todavía una rama productiva ni asociar `greenatics.com.co`. La primera integración se usa exclusivamente para Preview Deployments de branches/PRs hasta que exista una decisión explícita de release y convergencia.
+
+## Configuración única en Vercel
+1. Importar el repositorio GitHub `arendon7/GTCS-WEB` en el team autorizado.
+2. Mantener Framework Preset `Next.js` y Root Directory en la raíz del repositorio.
+3. No sobrescribir Build Command, Output Directory ni Install Command salvo que un gate posterior demuestre que es necesario.
+4. Mantener Git Integration activa para que cada branch/PR genere su Preview Deployment.
+5. No asociar dominio productivo durante esta fase.
+6. No configurar `GREENATICS_OPS_LOCAL_BYPASS` en Vercel.
+
+No se requiere `vercel.json` para este contrato inicial.
+
+## Preview público sin OPS remoto
+Puede desplegarse sin credenciales Supabase para validar la superficie pública.
+
+Estado esperado en `/api/health`:
+- `deployment.platform = "vercel"`
+- `deployment.environment = "preview"`
+- `deployment.branch` = branch desplegada
+- `deployment.commit` = SHA abreviado del commit desplegado
+- `mode = "local"`
+- `opsAccess = "configuration-block"`
+
+Esto significa: la web pública puede validarse, pero las rutas OPS permanecen cerradas por el gate de producción. `mode=local` no implica bypass en Vercel.
+
+## Preview con OPS remoto
+Configurar en el entorno Preview únicamente lo necesario:
+
+```text
+NEXT_PUBLIC_DATA_MODE=supabase
+NEXT_PUBLIC_SUPABASE_URL=<project-url>
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<publishable-key>
+SUPABASE_SECRET_KEY=<server-only-secret>
+```
+
+`SUPABASE_SECRET_KEY` nunca debe usar prefijo `NEXT_PUBLIC_`.
+
+### Origen de autenticación
+- Si `APP_BASE_URL` está definido, sigue siendo la autoridad explícita.
+- Si `APP_BASE_URL` no está definido y `VERCEL_ENV=preview`, el servidor puede usar la variable de sistema `VERCEL_BRANCH_URL` como origen HTTPS estable de la rama.
+- En producción **no existe ese fallback**: `APP_BASE_URL` debe configurarse explícitamente con el origen canónico aprobado.
+- El origen de preview utilizado por Auth debe estar permitido también en la configuración de redirects del proyecto Supabase antes de probar invitaciones/confirmaciones.
+
+Estado esperado en `/api/health` con backend completo:
+- `status = "ready"`
+- `opsAccess = "supabase-auth"`
+- `checks.backend = "ok"`
+- `checks.admin = "ok"`
+- `checks.appOrigin = "ok"`
+
+## Provenance segura
+`/api/health` publica únicamente:
+- plataforma (`vercel` o `generic`),
+- entorno,
+- nombre de branch validado,
+- primeros 12 caracteres del SHA Git.
+
+No publica `VERCEL_URL`, IDs de proyecto/team, mensajes de commit, secretos ni valores de configuración.
+
+## Preview Gate
+Antes de aprobar un preview:
+1. Confirmar que branch y SHA de `/api/health` coinciden con el commit GitHub esperado.
+2. Validar `/`, `/wondergreen`, `/soluciones`, `/proyectos`, `/impacto`, `/biblioteca`, `/nosotros` y `/contacto`.
+3. Verificar `sitemap.xml` y `robots.txt`.
+4. Verificar headers públicos e internos.
+5. Confirmar que `/app` está bloqueado sin Supabase o exige sesión válida con Supabase.
+6. Ejecutar login, perfil y membresía si el preview usa OPS remoto.
+7. Revisar logs de build/runtime y ausencia de 5xx/bucles de redirect.
+8. Probar desktop y móvil.
+
+El gate completo continúa definido en `docs/deployment/PREVIEW-GATE.md`.
+
+## Paso posterior
+Solo después de un preview aprobado se decide:
+- estrategia de convergencia `main` / `develop`,
+- rama de producción Vercel,
+- variables Production,
+- dominio `greenatics.com.co`,
+- canonical/sitemap/robots sobre el hostname definitivo.

--- a/e2e/deployment-readiness.spec.ts
+++ b/e2e/deployment-readiness.spec.ts
@@ -36,6 +36,25 @@ test("login is private and excluded from indexing in the development E2E server"
   expectDevelopmentNonCacheable(headers["cache-control"]);
 });
 
+test("health exposes only safe deployment provenance", async ({ request }) => {
+  const response = await request.get("/api/health");
+  expect(response.ok()).toBe(true);
+  const body = await response.json() as {
+    status: string;
+    mode: string;
+    opsAccess: string;
+    deployment: { platform: string; environment: string; branch: string | null; commit: string | null };
+  };
+
+  expect(body.status).toBe("ready");
+  expect(body.mode).toBe("local");
+  expect(body.opsAccess).toBe("local-bypass");
+  expect(body.deployment.platform).toBe("generic");
+  expect(Object.keys(body.deployment).sort()).toEqual(["branch", "commit", "environment", "platform"]);
+  expect(body.deployment.branch).toBeNull();
+  expect(body.deployment.commit).toBeNull();
+});
+
 test("HOME content CTA crosses the public-to-OPS document boundary", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("link", { name: "Entrar a GREENATICS OPS" }).click();

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getDataMode, isSupabaseConfigured } from "@/lib/data-mode";
 import { getDeploymentProvenance } from "@/lib/deployment-provenance";
+import { getOpsAccessMode } from "@/lib/ops-access-policy";
 import { createAdminClient, getAppBaseUrl, isSupabaseAdminConfigured } from "@/lib/supabase/admin";
 
 export const dynamic = "force-dynamic";
@@ -33,6 +34,7 @@ export async function GET() {
     {
       status: ready ? "ready" : "degraded",
       mode,
+      opsAccess: getOpsAccessMode(),
       checks,
       deployment: getDeploymentProvenance(),
     },

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDataMode, isSupabaseConfigured } from "@/lib/data-mode";
+import { getDeploymentProvenance } from "@/lib/deployment-provenance";
 import { createAdminClient, getAppBaseUrl, isSupabaseAdminConfigured } from "@/lib/supabase/admin";
 
 export const dynamic = "force-dynamic";
@@ -29,7 +30,12 @@ export async function GET() {
 
   const ready = mode === "local" || (checks.backend === "ok" && checks.admin === "ok" && checks.appOrigin === "ok");
   const response = NextResponse.json(
-    { status: ready ? "ready" : "degraded", mode, checks, runtime: process.env.VERCEL_ENV || process.env.NODE_ENV || "unknown" },
+    {
+      status: ready ? "ready" : "degraded",
+      mode,
+      checks,
+      deployment: getDeploymentProvenance(),
+    },
     { status: ready ? 200 : 503 },
   );
   response.headers.set("Cache-Control", "no-store");

--- a/src/lib/deployment-origin.test.ts
+++ b/src/lib/deployment-origin.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { resolveTrustedAppBaseUrl } from "./deployment-origin";
+
+describe("trusted deployment origin", () => {
+  it("prefers an explicit APP_BASE_URL and reduces it to origin", () => {
+    expect(resolveTrustedAppBaseUrl({
+      APP_BASE_URL: "https://greenatics.com.co/account/setup?ignored=1",
+      VERCEL_ENV: "preview",
+      VERCEL_BRANCH_URL: "preview.example.vercel.app",
+    })).toBe("https://greenatics.com.co");
+  });
+
+  it("uses the Vercel branch URL only for preview deployments", () => {
+    expect(resolveTrustedAppBaseUrl({
+      VERCEL_ENV: "preview",
+      VERCEL_BRANCH_URL: "gtcs-web-git-feature-team.vercel.app",
+    })).toBe("https://gtcs-web-git-feature-team.vercel.app");
+  });
+
+  it("does not use a Vercel branch URL as the production canonical origin", () => {
+    expect(resolveTrustedAppBaseUrl({
+      VERCEL_ENV: "production",
+      VERCEL_BRANCH_URL: "gtcs-web-git-main-team.vercel.app",
+    })).toBeNull();
+  });
+
+  it("rejects malformed branch URLs with path or credentials", () => {
+    expect(resolveTrustedAppBaseUrl({ VERCEL_ENV: "preview", VERCEL_BRANCH_URL: "example.vercel.app/path" })).toBeNull();
+    expect(resolveTrustedAppBaseUrl({ VERCEL_ENV: "preview", VERCEL_BRANCH_URL: "user:pass@example.vercel.app" })).toBeNull();
+  });
+});

--- a/src/lib/deployment-origin.ts
+++ b/src/lib/deployment-origin.ts
@@ -1,0 +1,33 @@
+type OriginEnv = Record<string, string | undefined>;
+
+function explicitOrigin(raw: string | undefined) {
+  const value = raw?.trim();
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function vercelPreviewOrigin(env: OriginEnv) {
+  if (env.VERCEL_ENV !== "preview") return null;
+  const branchUrl = env.VERCEL_BRANCH_URL?.trim();
+  if (!branchUrl) return null;
+
+  try {
+    const url = new URL(`https://${branchUrl}`);
+    if (url.protocol !== "https:" || url.username || url.password) return null;
+    if (url.pathname !== "/" || url.search || url.hash) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveTrustedAppBaseUrl(env: OriginEnv = process.env) {
+  return explicitOrigin(env.APP_BASE_URL) ?? vercelPreviewOrigin(env);
+}

--- a/src/lib/deployment-provenance.test.ts
+++ b/src/lib/deployment-provenance.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { getDeploymentProvenance } from "./deployment-provenance";
+
+describe("deployment provenance", () => {
+  it("reports a Vercel preview with only safe branch and short commit metadata", () => {
+    expect(getDeploymentProvenance({
+      VERCEL: "1",
+      VERCEL_ENV: "preview",
+      VERCEL_GIT_COMMIT_REF: "feat/vercel-preview-contract-v0.13.1",
+      VERCEL_GIT_COMMIT_SHA: "ABCDEF1234567890abcdef1234567890abcdef12",
+      VERCEL_URL: "private-preview.example.vercel.app",
+    })).toEqual({
+      platform: "vercel",
+      environment: "preview",
+      branch: "feat/vercel-preview-contract-v0.13.1",
+      commit: "abcdef123456",
+    });
+  });
+
+  it("does not invent Git provenance outside Vercel", () => {
+    expect(getDeploymentProvenance({ NODE_ENV: "test" })).toEqual({
+      platform: "generic",
+      environment: "test",
+      branch: null,
+      commit: null,
+    });
+  });
+
+  it("drops malformed branch and commit values instead of reflecting arbitrary input", () => {
+    expect(getDeploymentProvenance({
+      VERCEL_ENV: "preview",
+      VERCEL_GIT_COMMIT_REF: "bad branch <script>",
+      VERCEL_GIT_COMMIT_SHA: "not-a-sha",
+    })).toEqual({
+      platform: "vercel",
+      environment: "preview",
+      branch: null,
+      commit: null,
+    });
+  });
+
+  it("normalizes an invalid environment label to unknown", () => {
+    expect(getDeploymentProvenance({ VERCEL_ENV: "preview<script>" }).environment).toBe("unknown");
+  });
+});

--- a/src/lib/deployment-provenance.ts
+++ b/src/lib/deployment-provenance.ts
@@ -1,0 +1,34 @@
+export type DeploymentProvenance = {
+  platform: "vercel" | "generic";
+  environment: string;
+  branch: string | null;
+  commit: string | null;
+};
+
+type DeploymentEnv = Record<string, string | undefined>;
+
+function safeBranch(value: string | undefined) {
+  if (!value || value.length > 120) return null;
+  return /^[A-Za-z0-9._/-]+$/.test(value) ? value : null;
+}
+
+function shortCommit(value: string | undefined) {
+  if (!value || !/^[0-9a-f]{7,64}$/i.test(value)) return null;
+  return value.slice(0, 12).toLowerCase();
+}
+
+function safeEnvironment(value: string | undefined) {
+  if (!value || value.length > 40) return "unknown";
+  return /^[A-Za-z0-9._-]+$/.test(value) ? value : "unknown";
+}
+
+export function getDeploymentProvenance(env: DeploymentEnv = process.env): DeploymentProvenance {
+  const vercel = env.VERCEL === "1" || Boolean(env.VERCEL_ENV);
+
+  return {
+    platform: vercel ? "vercel" : "generic",
+    environment: safeEnvironment(env.VERCEL_ENV || env.NODE_ENV),
+    branch: vercel ? safeBranch(env.VERCEL_GIT_COMMIT_REF) : null,
+    commit: vercel ? shortCommit(env.VERCEL_GIT_COMMIT_SHA) : null,
+  };
+}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,21 +1,14 @@
 import "server-only";
 
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { resolveTrustedAppBaseUrl } from "@/lib/deployment-origin";
 
 export function isSupabaseAdminConfigured() {
   return Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.SUPABASE_SECRET_KEY);
 }
 
 export function getAppBaseUrl() {
-  const raw = process.env.APP_BASE_URL?.trim();
-  if (!raw) return null;
-  try {
-    const url = new URL(raw);
-    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
-    return url.origin;
-  } catch {
-    return null;
-  }
+  return resolveTrustedAppBaseUrl();
 }
 
 export function createAdminClient() {


### PR DESCRIPTION
## Objetivo
Preparar GTCS-WEB para previews Vercel vinculados por Git sin crear un bundle alternativo ni tocar dominio productivo.

## Cambios
- Provenance segura de deployment: plataforma, entorno, branch validado y SHA abreviado.
- `/api/health` reporta provenance y `opsAccess` efectivo sin exponer URL/IDs/secrets.
- `APP_BASE_URL` sigue siendo autoridad; solo Vercel Preview puede usar `VERCEL_BRANCH_URL` como fallback HTTPS confiable.
- Tests unitarios de provenance/origen y E2E del health contract.
- Runbook `VERCEL-GIT-INTEGRATION.md` y Preview Gate actualizado.
- `.env.example` reconciliado con SharePoint y reglas Vercel.

## Guardrails
- Producción sigue requiriendo `APP_BASE_URL` explícito.
- No se configura `GREENATICS_OPS_LOCAL_BYPASS` en Vercel.
- No se publica `VERCEL_URL`, IDs, mensajes de commit ni secretos.
- No se define todavía rama productiva: `main` y `develop` requieren decisión de convergencia.
- No se toca DNS ni `greenatics.com.co`.

## Preservación
- Incluye la base SharePoint ya fusionada en develop; no modifica su contrato.
- No cambia RLS, esquema, datos ni rutas públicas/OPS.
