### PR TITLE
CORE-004B · Hosted pilot preflight ejecutable

### DIFF
--- a/docs/deployment/HOSTED_PILOT_RUNBOOK.md
+++ b/docs/deployment/HOSTED_PILOT_RUNBOOK.md
@@ -68,14 +68,33 @@ El script se niega a operar si ya existe cualquier membresía activa con rol `di
 6. Al completar la activación se entra a `/app`.
 7. RLS limita lectura y escritura a plantas/membresías autorizadas.
 
-## 7. Readiness
+## 7. Readiness ejecutable
 `GET /api/health` es público y no devuelve credenciales.
 
 Estados:
 - `200 ready`: modo local, o backend + Auth Admin + origen canónico operativos.
 - `503 degraded`: falta configuración o falla el backend remoto.
 
-Antes de habilitar el acceso real a OPS, exigir `200 ready` en el dominio final.
+Antes de habilitar el acceso real a OPS, exigir `200 ready` en el dominio final y ejecutar el gate anónimo del deployment:
+
+```bash
+npm run pilot:preflight -- \
+  --base-url https://<deployment> \
+  --expected-branch develop \
+  --expected-commit <sha-desplegado>
+```
+
+El preflight falla si:
+- `/api/health` no reporta `ready`, `supabase`, `supabase-auth` y checks remotos `ok`;
+- el runtime no reporta Vercel `preview` o `production`;
+- rama o commit no coinciden con lo esperado;
+- faltan headers de seguridad o privacidad;
+- `/app` anónimo no redirige al login canónico conservando `next=/app`;
+- el deployment sigue en `configuration-block`;
+- el sitemap expone rutas internas;
+- `robots.txt` deja de bloquear `/app`, `/login` o `/api/`.
+
+Este gate no usa correos, contraseñas ni tokens de usuarios y no sustituye el smoke multiusuario.
 
 ## 8. Smoke multiusuario obligatorio
 Con dos perfiles de navegador distintos:
@@ -93,7 +112,7 @@ Con dos perfiles de navegador distintos:
 ## 9. Gate de promoción
 Antes de promover el piloto:
 - CI de PR verde (`quality` + `database`);
-- `/api/health` en `ready`;
+- `npm run pilot:preflight` en PASS contra el SHA exacto desplegado;
 - smoke multiusuario aprobado;
 - redirects Auth configurados;
 - ningún secreto presente en GitHub, bundle cliente o logs;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "bootstrap:director": "node scripts/bootstrap-director.mjs"
+    "bootstrap:director": "node scripts/bootstrap-director.mjs",
+    "pilot:preflight": "node scripts/hosted-pilot-preflight.mjs"
   },
   "dependencies": {
     "@supabase/ssr": "latest",

--- a/scripts/hosted-pilot-preflight-lib.mjs
+++ b/scripts/hosted-pilot-preflight-lib.mjs
@@ -1,0 +1,198 @@
+const BASELINE_HEADERS = {
+  "x-content-type-options": "nosniff",
+  "referrer-policy": "strict-origin-when-cross-origin",
+  "x-frame-options": "DENY",
+};
+
+const PRIVATE_HEADERS = {
+  pragma: "no-cache",
+  "x-robots-tag": "noindex, nofollow, noarchive",
+};
+
+export class PreflightError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PreflightError";
+  }
+}
+
+function fail(message) {
+  throw new PreflightError(message);
+}
+
+export function normalizeHostedBaseUrl(value) {
+  if (!value) fail("Falta --base-url o APP_BASE_URL.");
+
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    fail("El origen del piloto no es una URL válida.");
+  }
+
+  if (url.protocol !== "https:") fail("El piloto hospedado debe usar HTTPS.");
+  if (url.username || url.password) fail("El origen del piloto no puede incluir credenciales.");
+  if (url.pathname !== "/" || url.search || url.hash) fail("Usa únicamente el origen del deployment, sin ruta, query ni fragmento.");
+
+  return url.origin;
+}
+
+function requireStatus(response, expected, label) {
+  if (response.status !== expected) fail(`${label}: HTTP ${response.status}; se esperaba ${expected}.`);
+}
+
+function requireHeader(response, name, expected, label) {
+  const actual = response.headers.get(name);
+  if (actual !== expected) fail(`${label}: header ${name} inválido o ausente.`);
+}
+
+function requireHeaderIncludes(response, name, expected, label) {
+  const actual = response.headers.get(name) ?? "";
+  if (!actual.toLowerCase().includes(expected.toLowerCase())) fail(`${label}: header ${name} no contiene ${expected}.`);
+}
+
+function assertBaselineHeaders(response, label) {
+  for (const [name, value] of Object.entries(BASELINE_HEADERS)) requireHeader(response, name, value, label);
+  const permissions = response.headers.get("permissions-policy") ?? "";
+  for (const token of ["camera=()", "microphone=()", "geolocation=()"] ) {
+    if (!permissions.includes(token)) fail(`${label}: Permissions-Policy no contiene ${token}.`);
+  }
+}
+
+function assertPrivateHeaders(response, label) {
+  requireHeaderIncludes(response, "cache-control", "no-store", label);
+  for (const [name, value] of Object.entries(PRIVATE_HEADERS)) requireHeader(response, name, value, label);
+}
+
+function normalizeCommit(value) {
+  if (!value || !/^[0-9a-f]{7,64}$/i.test(value)) return null;
+  return value.toLowerCase();
+}
+
+export function assertHostedHealth(payload, { expectedBranch, expectedCommit } = {}) {
+  if (!payload || typeof payload !== "object") fail("health: respuesta JSON inválida.");
+  if (payload.status !== "ready") fail(`health: status=${String(payload.status)}; se esperaba ready.`);
+  if (payload.mode !== "supabase") fail(`health: mode=${String(payload.mode)}; se esperaba supabase.`);
+  if (payload.opsAccess !== "supabase-auth") fail(`health: opsAccess=${String(payload.opsAccess)}; se esperaba supabase-auth.`);
+
+  const checks = payload.checks ?? {};
+  for (const key of ["backend", "admin", "appOrigin"]) {
+    if (checks[key] !== "ok") fail(`health: check ${key}=${String(checks[key])}; se esperaba ok.`);
+  }
+
+  const deployment = payload.deployment ?? {};
+  if (deployment.platform !== "vercel") fail(`health: platform=${String(deployment.platform)}; se esperaba vercel.`);
+  if (!new Set(["preview", "production"]).has(deployment.environment)) {
+    fail(`health: environment=${String(deployment.environment)}; se esperaba preview o production.`);
+  }
+
+  if (expectedBranch && deployment.branch !== expectedBranch) {
+    fail(`health: branch=${String(deployment.branch)}; se esperaba ${expectedBranch}.`);
+  }
+
+  if (expectedCommit) {
+    const expected = normalizeCommit(expectedCommit);
+    const actual = normalizeCommit(deployment.commit);
+    if (!expected) fail("--expected-commit no parece un SHA de Git válido.");
+    if (!actual || expected.slice(0, 12) !== actual.slice(0, 12)) {
+      fail(`health: commit=${String(deployment.commit)}; no coincide con el commit esperado.`);
+    }
+  }
+
+  return deployment;
+}
+
+function sitemapLocations(xml) {
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/gi)].map((match) => match[1].trim());
+}
+
+function assertPublicSitemap(xml, origin) {
+  const locations = sitemapLocations(xml);
+  if (locations.length === 0) fail("sitemap: no contiene URLs públicas.");
+
+  const forbiddenPrefixes = ["/app", "/login", "/admin", "/api", "/account", "/dashboard", "/imports"];
+  for (const location of locations) {
+    let url;
+    try {
+      url = new URL(location);
+    } catch {
+      fail(`sitemap: URL inválida: ${location}`);
+    }
+    if (url.origin !== origin) fail(`sitemap: URL fuera del origen del piloto: ${location}`);
+    if (forbiddenPrefixes.some((prefix) => url.pathname === prefix || url.pathname.startsWith(`${prefix}/`))) {
+      fail(`sitemap: expone una ruta interna: ${url.pathname}`);
+    }
+  }
+}
+
+function assertRobots(text) {
+  for (const rule of ["Disallow: /app", "Disallow: /login", "Disallow: /api/"]) {
+    if (!text.includes(rule)) fail(`robots: falta ${rule}.`);
+  }
+}
+
+async function get(fetchImpl, url) {
+  return fetchImpl(url, {
+    redirect: "manual",
+    headers: { "user-agent": "GREENATICS-HOSTED-PILOT-PREFLIGHT/1.0" },
+  });
+}
+
+export async function runHostedPilotPreflight({
+  baseUrl,
+  expectedBranch,
+  expectedCommit,
+  fetchImpl = globalThis.fetch,
+}) {
+  if (typeof fetchImpl !== "function") fail("No existe una implementación fetch disponible.");
+  const origin = normalizeHostedBaseUrl(baseUrl);
+
+  const healthResponse = await get(fetchImpl, `${origin}/api/health`);
+  requireStatus(healthResponse, 200, "health");
+  assertBaselineHeaders(healthResponse, "health");
+  assertPrivateHeaders(healthResponse, "health");
+  let health;
+  try {
+    health = await healthResponse.json();
+  } catch {
+    fail("health: el endpoint no devolvió JSON válido.");
+  }
+  const deployment = assertHostedHealth(health, { expectedBranch, expectedCommit });
+
+  const publicResponse = await get(fetchImpl, `${origin}/`);
+  requireStatus(publicResponse, 200, "home pública");
+  assertBaselineHeaders(publicResponse, "home pública");
+  if (publicResponse.headers.has("x-robots-tag")) fail("home pública: no debe llevar X-Robots-Tag interno.");
+
+  const loginResponse = await get(fetchImpl, `${origin}/login`);
+  requireStatus(loginResponse, 200, "login");
+  assertBaselineHeaders(loginResponse, "login");
+  assertPrivateHeaders(loginResponse, "login");
+
+  const appResponse = await get(fetchImpl, `${origin}/app`);
+  if (![301, 302, 303, 307, 308].includes(appResponse.status)) {
+    fail(`OPS anónimo: HTTP ${appResponse.status}; se esperaba redirect a login.`);
+  }
+  assertBaselineHeaders(appResponse, "OPS anónimo");
+  assertPrivateHeaders(appResponse, "OPS anónimo");
+  const location = appResponse.headers.get("location");
+  if (!location) fail("OPS anónimo: falta header Location.");
+  const loginTarget = new URL(location, origin);
+  if (loginTarget.origin !== origin || loginTarget.pathname !== "/login") fail("OPS anónimo: redirect fuera del login canónico.");
+  if (loginTarget.searchParams.get("next") !== "/app") fail("OPS anónimo: redirect no conserva next=/app.");
+  if (loginTarget.searchParams.has("reason")) fail("OPS anónimo: el deployment sigue en bloqueo de configuración.");
+
+  const sitemapResponse = await get(fetchImpl, `${origin}/sitemap.xml`);
+  requireStatus(sitemapResponse, 200, "sitemap");
+  assertPublicSitemap(await sitemapResponse.text(), origin);
+
+  const robotsResponse = await get(fetchImpl, `${origin}/robots.txt`);
+  requireStatus(robotsResponse, 200, "robots");
+  assertRobots(await robotsResponse.text());
+
+  return {
+    origin,
+    deployment,
+    checks: ["health", "public-boundary", "login-private", "ops-anonymous", "sitemap", "robots"],
+  };
+}

--- a/scripts/hosted-pilot-preflight.mjs
+++ b/scripts/hosted-pilot-preflight.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { runHostedPilotPreflight } from "./hosted-pilot-preflight-lib.mjs";
+
+function readArg(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`Falta valor para ${name}.`);
+  return value;
+}
+
+function printHelp() {
+  console.log(`GREENATICS hosted pilot preflight
+
+Uso:
+  npm run pilot:preflight -- --base-url https://preview.example.com [opciones]
+
+Opciones:
+  --base-url <origin>        Origen HTTPS del deployment. APP_BASE_URL es fallback.
+  --expected-branch <name>   Exige que /api/health reporte esta rama.
+  --expected-commit <sha>    Exige que /api/health reporte este commit (12 primeros caracteres).
+  --help                     Muestra esta ayuda.
+`);
+}
+
+async function main() {
+  if (process.argv.includes("--help")) {
+    printHelp();
+    return;
+  }
+
+  const result = await runHostedPilotPreflight({
+    baseUrl: readArg("--base-url") ?? process.env.APP_BASE_URL,
+    expectedBranch: readArg("--expected-branch"),
+    expectedCommit: readArg("--expected-commit"),
+  });
+
+  console.log("GREENATICS hosted pilot preflight: PASS");
+  console.log(`origin: ${result.origin}`);
+  console.log(`deployment: ${result.deployment.platform}/${result.deployment.environment}`);
+  console.log(`branch: ${result.deployment.branch ?? "n/a"}`);
+  console.log(`commit: ${result.deployment.commit ?? "n/a"}`);
+  console.log(`checks: ${result.checks.join(", ")}`);
+}
+
+main().catch((error) => {
+  console.error(`GREENATICS hosted pilot preflight: FAIL · ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/hosted-pilot-preflight.test.mjs
+++ b/scripts/hosted-pilot-preflight.test.mjs
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  PreflightError,
+  assertHostedHealth,
+  normalizeHostedBaseUrl,
+  runHostedPilotPreflight,
+} from "./hosted-pilot-preflight-lib.mjs";
+
+const baselineHeaders = {
+  "x-content-type-options": "nosniff",
+  "referrer-policy": "strict-origin-when-cross-origin",
+  "x-frame-options": "DENY",
+  "permissions-policy": "camera=(), microphone=(), geolocation=()",
+};
+
+const privateHeaders = {
+  ...baselineHeaders,
+  "cache-control": "private, no-store, max-age=0",
+  pragma: "no-cache",
+  "x-robots-tag": "noindex, nofollow, noarchive",
+};
+
+const healthPayload = {
+  status: "ready",
+  mode: "supabase",
+  opsAccess: "supabase-auth",
+  checks: { backend: "ok", admin: "ok", appOrigin: "ok" },
+  deployment: {
+    platform: "vercel",
+    environment: "preview",
+    branch: "develop",
+    commit: "850ffcea0800",
+  },
+};
+
+function jsonResponse(payload, init = {}) {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    ...init,
+    headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+  });
+}
+
+function hostedFixture(overrides = {}) {
+  const origin = "https://greenatics-pilot.vercel.app";
+  const responses = {
+    [`${origin}/api/health`]: jsonResponse(healthPayload, { headers: privateHeaders }),
+    [`${origin}/`]: new Response("home", { status: 200, headers: baselineHeaders }),
+    [`${origin}/login`]: new Response("login", { status: 200, headers: privateHeaders }),
+    [`${origin}/app`]: new Response(null, {
+      status: 307,
+      headers: { ...privateHeaders, location: `${origin}/login?next=%2Fapp` },
+    }),
+    [`${origin}/sitemap.xml`]: new Response(
+      `<?xml version="1.0"?><urlset><url><loc>${origin}/</loc></url><url><loc>${origin}/wondergreen</loc></url></urlset>`,
+      { status: 200 },
+    ),
+    [`${origin}/robots.txt`]: new Response("User-agent: *\nDisallow: /app\nDisallow: /login\nDisallow: /api/\n", { status: 200 }),
+    ...overrides,
+  };
+
+  return {
+    origin,
+    fetchImpl: async (url) => {
+      const response = responses[String(url)];
+      if (!response) throw new Error(`Unexpected URL ${String(url)}`);
+      return response.clone();
+    },
+  };
+}
+
+describe("hosted pilot preflight", () => {
+  it("normalizes only HTTPS origins without embedded paths or credentials", () => {
+    expect(normalizeHostedBaseUrl("https://pilot.example.com")).toBe("https://pilot.example.com");
+    expect(() => normalizeHostedBaseUrl("http://pilot.example.com")).toThrow(PreflightError);
+    expect(() => normalizeHostedBaseUrl("https://user:pass@pilot.example.com")).toThrow(PreflightError);
+    expect(() => normalizeHostedBaseUrl("https://pilot.example.com/app")).toThrow(PreflightError);
+  });
+
+  it("accepts a ready Supabase deployment with matching branch and commit", async () => {
+    const fixture = hostedFixture();
+    const result = await runHostedPilotPreflight({
+      baseUrl: fixture.origin,
+      expectedBranch: "develop",
+      expectedCommit: "850ffcea08008f40f7d6747a39a122259b5ccbf9",
+      fetchImpl: fixture.fetchImpl,
+    });
+
+    expect(result.origin).toBe(fixture.origin);
+    expect(result.deployment.environment).toBe("preview");
+    expect(result.checks).toContain("ops-anonymous");
+  });
+
+  it("rejects a deployment that still reports configuration-block", () => {
+    expect(() => assertHostedHealth({ ...healthPayload, opsAccess: "configuration-block" })).toThrow(/supabase-auth/);
+  });
+
+  it("rejects anonymous OPS redirects that leave the canonical origin", async () => {
+    const fixture = hostedFixture({
+      "https://greenatics-pilot.vercel.app/app": new Response(null, {
+        status: 307,
+        headers: { ...privateHeaders, location: "https://evil.example/login?next=%2Fapp" },
+      }),
+    });
+
+    await expect(runHostedPilotPreflight({ baseUrl: fixture.origin, fetchImpl: fixture.fetchImpl })).rejects.toThrow(/login canónico/);
+  });
+
+  it("rejects internal routes leaked into the public sitemap", async () => {
+    const fixture = hostedFixture({
+      "https://greenatics-pilot.vercel.app/sitemap.xml": new Response(
+        `<?xml version="1.0"?><urlset><url><loc>https://greenatics-pilot.vercel.app/app</loc></url></urlset>`,
+        { status: 200 },
+      ),
+    });
+
+    await expect(runHostedPilotPreflight({ baseUrl: fixture.origin, fetchImpl: fixture.fetchImpl })).rejects.toThrow(/ruta interna/);
+  });
+});


### PR DESCRIPTION
## Objetivo
Convertir la parte anónima/runtime del piloto hospedado de CORE-004 en un gate ejecutable y reproducible, sin manejar credenciales de usuarios ni sustituir el smoke multiusuario.

## Cambios
- `npm run pilot:preflight` contra un origen HTTPS hospedado.
- valida `/api/health = ready`, modo Supabase y `supabase-auth`;
- exige checks backend/admin/appOrigin en `ok`;
- exige procedencia Vercel preview/production y permite fijar rama/SHA esperado;
- valida headers públicos e internos;
- valida `/app` anónimo -> login canónico con `next=/app` y sin `configuration-block`;
- valida que sitemap no exponga rutas OPS y que robots siga bloqueando `/app`, `/login` y `/api/`;
- pruebas unitarias sin red ni secretos;
- runbook actualizado con gate de promoción ejecutable.

## Límites deliberados
- No crea Vercel ni Supabase.
- No versiona ni consume secretos.
- No automatiza el smoke autenticado director/operario; ese gate sigue requiriendo el entorno real.

Ref: #47