### PR TITLE
CORE-005B · Adapter Graph SharePoint read-only server-side

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,9 @@ SHAREPOINT_SITE_HOSTNAME=
 SHAREPOINT_SITE_PATH=
 SHAREPOINT_DRIVE_ID=
 SHAREPOINT_DOCUMENT_ROOT=
+
+# Microsoft Entra app-only credentials for the SharePoint Graph read adapter.
+# Server-only. Prefer Sites.Selected + an explicit read grant for the configured site.
+SHAREPOINT_TENANT_ID=
+SHAREPOINT_CLIENT_ID=
+SHAREPOINT_CLIENT_SECRET=

--- a/docs/integrations/SHAREPOINT_GRAPH_READONLY.md
+++ b/docs/integrations/SHAREPOINT_GRAPH_READONLY.md
@@ -1,0 +1,77 @@
+# GREENATICS OPS · Microsoft Graph read-only adapter
+
+## Propósito
+CORE-005B añade el adapter server-side que convierte archivos de una biblioteca SharePoint en referencias documentales seguras de GREENATICS OPS. No cambia la fuente de verdad operacional: las transacciones continúan en Supabase/RLS y SharePoint permanece como repositorio documental e histórico.
+
+## Modelo de autenticación
+El runtime usa OAuth 2.0 **client credentials** contra Microsoft Entra. La aplicación solicita `https://graph.microsoft.com/.default` y utiliza únicamente permisos de aplicación previamente consentidos por un administrador.
+
+Variables server-only:
+
+```text
+SHAREPOINT_TENANT_ID=
+SHAREPOINT_CLIENT_ID=
+SHAREPOINT_CLIENT_SECRET=
+```
+
+Nunca usar prefijo `NEXT_PUBLIC_`, serializar estas variables al cliente, imprimir el access token ni incorporar secretos a errores o logs.
+
+## Permiso recomendado
+Para el piloto, la política preferida es **`Sites.Selected`** con una asignación explícita de `read` únicamente al sitio SharePoint autorizado. Consentir `Sites.Selected` por sí solo no concede acceso al contenido: también se requiere la asignación del recurso seleccionado.
+
+No sustituirlo por `Sites.Read.All` o permisos de escritura por conveniencia. Un alcance mayor requiere una decisión explícita y documentada.
+
+## Lectura implementada
+El adapter consulta Microsoft Graph v1.0 sobre el `driveId` configurado y una ruta siempre confinada bajo `SHAREPOINT_DOCUMENT_ROOT`.
+
+Características:
+- listado no recursivo de archivos de una carpeta;
+- path encoding por segmento antes de construir la URL Graph;
+- bloqueo de `.` / `..`, rutas absolutas y separadores Windows;
+- `$select` limitado a `id`, `name`, `webUrl`, `lastModifiedDateTime`, `file` y `folder`;
+- carpetas se ignoran como documentos; pueden consultarse de forma explícita pasando una subruta permitida;
+- cada archivo se valida mediante el contrato CORE-005A antes de devolverse;
+- la identidad estable sigue siendo `sharepoint:<driveId>:<itemId>`;
+- no se lee ni devuelve `@microsoft.graph.downloadUrl`;
+- no se descargan binarios.
+
+## Paginación y límites
+El adapter sigue `@odata.nextLink` únicamente cuando:
+- usa HTTPS;
+- el host es exactamente `graph.microsoft.com`;
+- permanece en Microsoft Graph v1.0;
+- permanece bajo el mismo `driveId` configurado.
+
+Límites de defensa:
+- máximo 5 páginas Graph por listado;
+- máximo 200 documentos por listado;
+- cualquier referencia documental malformada hace fallar la operación en lugar de exponer datos parciales no validados.
+
+## Caché
+Hay dos cachés de proceso, ambas efímeras:
+1. **Access token:** se reutiliza hasta antes de su expiración, con margen de seguridad. Nunca se persiste.
+2. **Metadatos documentales:** TTL de 60 segundos por carpeta. `forceRefresh` permite invalidar la lectura cuando una operación server-side lo necesite.
+
+La caché desaparece con el proceso/serverless instance y no es fuente de verdad.
+
+## Provisioning externo pendiente
+Para activar la lectura contra el tenant real se debe:
+1. crear o seleccionar una App Registration dedicada;
+2. agregar `Sites.Selected` como application permission para Microsoft Graph;
+3. otorgar admin consent;
+4. conceder a esa aplicación `read` sobre el sitio SharePoint autorizado;
+5. guardar tenant ID, client ID y client secret únicamente en el proveedor de secretos/runtime;
+6. cargar la configuración CORE-005A (`hostname`, `sitePath`, `driveId`, `documentRoot`) fuera de Git;
+7. ejecutar una lectura smoke server-side y confirmar que la aplicación no puede leer otro sitio no asignado.
+
+Hasta completar ese provisioning, el adapter queda certificado por contrato y fixtures sanitizados, pero no debe afirmarse que el tenant real está conectado.
+
+## Fuera de alcance
+CORE-005B no implementa:
+- subida, edición, renombre, movimiento o borrado;
+- sincronización automática;
+- permisos de escritura;
+- navegación Graph desde el browser;
+- endpoints públicos de documentos;
+- autorización operacional basada en SharePoint;
+- persistencia de tokens o URLs temporales de descarga.

--- a/src/lib/sharepoint/graph-readonly.test.ts
+++ b/src/lib/sharepoint/graph-readonly.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SharePointGraphReadonlyClient,
+  encodeSharePointGraphPath,
+  parseSharePointGraphAuthConfig,
+  parseSharePointGraphRuntimeConfig,
+} from "./graph-readonly";
+
+const env = {
+  SHAREPOINT_SITE_HOSTNAME: "contoso.sharepoint.com",
+  SHAREPOINT_SITE_PATH: "/sites/Sanitized",
+  SHAREPOINT_DRIVE_ID: "b!sanitizedDrive_123",
+  SHAREPOINT_DOCUMENT_ROOT: "Shared Documents/Operations",
+  SHAREPOINT_TENANT_ID: "11111111-1111-4111-8111-111111111111",
+  SHAREPOINT_CLIENT_ID: "22222222-2222-4222-8222-222222222222",
+  SHAREPOINT_CLIENT_SECRET: "sanitized-test-secret",
+};
+
+function tokenResponse(token = "test-access-token", expiresIn = 3600) {
+  return new Response(JSON.stringify({ access_token: token, token_type: "Bearer", expires_in: expiresIn }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function graphResponse(value: unknown[], nextLink?: string) {
+  return new Response(JSON.stringify({ value, ...(nextLink ? { "@odata.nextLink": nextLink } : {}) }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function fileItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "01SANITIZEDFILE123",
+    name: "Control de calidad.xlsx",
+    webUrl: "https://contoso.sharepoint.com/sites/Sanitized/Shared%20Documents/Operations/Control%20de%20calidad.xlsx",
+    lastModifiedDateTime: "2026-08-01T14:30:00Z",
+    file: { mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+    ...overrides,
+  };
+}
+
+function runtimeConfig() {
+  const parsed = parseSharePointGraphRuntimeConfig(env);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.value;
+}
+
+describe("SharePoint Graph read-only adapter", () => {
+  it("requires sanitized server-only auth identifiers and a secret", () => {
+    const parsed = parseSharePointGraphAuthConfig(env);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.tenantId).toBe(env.SHAREPOINT_TENANT_ID);
+    expect(parsed.value.clientId).toBe(env.SHAREPOINT_CLIENT_ID);
+    expect(parsed.value.clientSecret).toBe(env.SHAREPOINT_CLIENT_SECRET);
+
+    expect(parseSharePointGraphAuthConfig({ ...env, SHAREPOINT_TENANT_ID: "organizations" }).ok).toBe(false);
+    expect(parseSharePointGraphAuthConfig({ ...env, SHAREPOINT_CLIENT_SECRET: "" }).ok).toBe(false);
+  });
+
+  it("encodes every Graph path segment and blocks traversal", () => {
+    expect(encodeSharePointGraphPath("Shared Documents/Operación", "Calidad/Lote #1"))
+      .toBe("Shared%20Documents/Operaci%C3%B3n/Calidad/Lote%20%231");
+    expect(() => encodeSharePointGraphPath("Shared Documents/Operations", "../Finance"))
+      .toThrow(/navegación relativa/);
+    expect(() => encodeSharePointGraphPath("Shared Documents/Operations", "/Finance"))
+      .toThrow(/no es válida/);
+  });
+
+  it("uses client credentials with Graph .default and maps only file driveItems", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url.includes("login.microsoftonline.com")) return tokenResponse();
+      return graphResponse([
+        fileItem(),
+        {
+          id: "01SANITIZEDFOLDER123",
+          name: "Subcarpeta",
+          webUrl: "https://contoso.sharepoint.com/sites/Sanitized/Shared%20Documents/Operations/Subcarpeta",
+          folder: { childCount: 2 },
+        },
+      ]);
+    }) as unknown as typeof fetch;
+
+    const client = new SharePointGraphReadonlyClient(runtimeConfig(), fetchImpl);
+    const documents = await client.listDocuments("Calidad");
+
+    expect(documents).toHaveLength(1);
+    expect(documents[0]).toEqual({
+      provider: "sharepoint",
+      driveId: env.SHAREPOINT_DRIVE_ID,
+      itemId: "01SANITIZEDFILE123",
+      title: "Control de calidad.xlsx",
+      webUrl: "https://contoso.sharepoint.com/sites/Sanitized/Shared%20Documents/Operations/Control%20de%20calidad.xlsx",
+      mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      modifiedAt: "2026-08-01T14:30:00.000Z",
+    });
+
+    const tokenCall = calls[0];
+    expect(tokenCall.url).toContain(`/11111111-1111-4111-8111-111111111111/oauth2/v2.0/token`);
+    const body = tokenCall.init?.body as URLSearchParams;
+    expect(body.get("grant_type")).toBe("client_credentials");
+    expect(body.get("scope")).toBe("https://graph.microsoft.com/.default");
+    expect(body.get("client_id")).toBe(env.SHAREPOINT_CLIENT_ID);
+    expect(body.get("client_secret")).toBe(env.SHAREPOINT_CLIENT_SECRET);
+
+    const graphCall = calls[1];
+    expect(graphCall.url).toContain("/v1.0/drives/b!sanitizedDrive_123/root:/Shared%20Documents/Operations/Calidad:/children");
+    expect(graphCall.init?.headers).toEqual(expect.objectContaining({ authorization: "Bearer test-access-token" }));
+  });
+
+  it("reuses the access token and document cache before their expirations", async () => {
+    let now = 1_000_000;
+    let tokenRequests = 0;
+    let graphRequests = 0;
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("login.microsoftonline.com")) {
+        tokenRequests += 1;
+        return tokenResponse(`token-${tokenRequests}`, 120);
+      }
+      graphRequests += 1;
+      return graphResponse([fileItem({ id: `01SANITIZEDFILE${graphRequests}` })]);
+    }) as unknown as typeof fetch;
+
+    const client = new SharePointGraphReadonlyClient(runtimeConfig(), fetchImpl, () => now, 30_000);
+    await client.listDocuments("Calidad");
+    await client.listDocuments("Calidad");
+    await client.listDocuments("Procesos");
+
+    expect(tokenRequests).toBe(1);
+    expect(graphRequests).toBe(2);
+
+    now += 121_000;
+    await client.listDocuments("Calidad", { forceRefresh: true });
+    expect(tokenRequests).toBe(2);
+    expect(graphRequests).toBe(3);
+  });
+
+  it("follows only same-drive Graph pagination links and caps untrusted redirects", async () => {
+    const safeNext = "https://graph.microsoft.com/v1.0/drives/b!sanitizedDrive_123/root:/Shared%20Documents/Operations:/children?$skiptoken=safe";
+    let graphPage = 0;
+    const safeFetch = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("login.microsoftonline.com")) return tokenResponse();
+      graphPage += 1;
+      return graphPage === 1
+        ? graphResponse([fileItem({ id: "01SANITIZEDPAGE1" })], safeNext)
+        : graphResponse([fileItem({ id: "01SANITIZEDPAGE2", name: "Segundo.pdf", file: { mimeType: "application/pdf" } })]);
+    }) as unknown as typeof fetch;
+
+    const client = new SharePointGraphReadonlyClient(runtimeConfig(), safeFetch);
+    const documents = await client.listDocuments();
+    expect(documents.map((document) => document.itemId)).toEqual(["01SANITIZEDPAGE1", "01SANITIZEDPAGE2"]);
+
+    const evilFetch = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("login.microsoftonline.com")) return tokenResponse();
+      return graphResponse([fileItem()], "https://evil.example/v1.0/drives/b!sanitizedDrive_123/items?page=2");
+    }) as unknown as typeof fetch;
+
+    const evilClient = new SharePointGraphReadonlyClient(runtimeConfig(), evilFetch);
+    await expect(evilClient.listDocuments()).rejects.toThrow(/fuera del recurso autorizado/);
+  });
+
+  it("fails closed on malformed file references instead of exposing partial Graph data", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("login.microsoftonline.com")) return tokenResponse();
+      return graphResponse([fileItem({ webUrl: "https://evil.example/document.xlsx" })]);
+    }) as unknown as typeof fetch;
+
+    const client = new SharePointGraphReadonlyClient(runtimeConfig(), fetchImpl);
+    await expect(client.listDocuments()).rejects.toThrow(/referencia documental inválida/);
+  });
+});

--- a/src/lib/sharepoint/graph-readonly.ts
+++ b/src/lib/sharepoint/graph-readonly.ts
@@ -94,7 +94,7 @@ export function parseSharePointGraphRuntimeConfig(
 
 function relativeSegments(value: string) {
   if (!value) return [];
-  if (value.startsWith("/") || value.endsWith("/") || value.includes("\\") || value.includes("?") || value.includes("#")) {
+  if (value.startsWith("/") || value.endsWith("/") || value.includes("\\")) {
     throw new Error("La ruta documental relativa no es válida.");
   }
 

--- a/src/lib/sharepoint/graph-readonly.ts
+++ b/src/lib/sharepoint/graph-readonly.ts
@@ -1,0 +1,315 @@
+import {
+  parseSharePointSourceConfig,
+  validateSharePointDocumentReference,
+  type SharePointDocumentReference,
+  type SharePointSourceConfig,
+} from "@/lib/document-source-contract";
+
+export type SharePointGraphAuthConfig = Readonly<{
+  tenantId: string;
+  clientId: string;
+  clientSecret: string;
+}>;
+
+export type SharePointGraphRuntimeConfig = Readonly<{
+  source: SharePointSourceConfig;
+  auth: SharePointGraphAuthConfig;
+}>;
+
+type FetchLike = typeof fetch;
+type Clock = () => number;
+
+type TokenCache = {
+  accessToken: string;
+  refreshAfter: number;
+};
+
+type DocumentCacheEntry = {
+  expiresAt: number;
+  documents: readonly SharePointDocumentReference[];
+};
+
+type GraphDriveItem = {
+  id?: unknown;
+  name?: unknown;
+  webUrl?: unknown;
+  lastModifiedDateTime?: unknown;
+  file?: { mimeType?: unknown } | null;
+  folder?: unknown;
+};
+
+type GraphChildrenPage = {
+  value?: unknown;
+  "@odata.nextLink"?: unknown;
+};
+
+export type SharePointListOptions = Readonly<{
+  forceRefresh?: boolean;
+}>;
+
+const GUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const GRAPH_ORIGIN = "https://graph.microsoft.com";
+const GRAPH_API_PREFIX = "/v1.0";
+const TOKEN_SCOPE = "https://graph.microsoft.com/.default";
+const TOKEN_REFRESH_SAFETY_MS = 60_000;
+const DEFAULT_DOCUMENT_CACHE_TTL_MS = 60_000;
+const MAX_GRAPH_PAGES = 5;
+const MAX_DOCUMENTS = 200;
+const GRAPH_PAGE_SIZE = 100;
+
+function clean(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseGuid(value: unknown) {
+  const normalized = clean(value).toLowerCase();
+  return GUID.test(normalized) ? normalized : null;
+}
+
+export function parseSharePointGraphAuthConfig(
+  env: Record<string, string | undefined>,
+): { ok: true; value: SharePointGraphAuthConfig } | { ok: false; error: string } {
+  const tenantId = parseGuid(env.SHAREPOINT_TENANT_ID);
+  const clientId = parseGuid(env.SHAREPOINT_CLIENT_ID);
+  const clientSecret = clean(env.SHAREPOINT_CLIENT_SECRET);
+
+  if (!tenantId) return { ok: false, error: "SHAREPOINT_TENANT_ID falta o no es un UUID válido." };
+  if (!clientId) return { ok: false, error: "SHAREPOINT_CLIENT_ID falta o no es un UUID válido." };
+  if (!clientSecret || clientSecret.length > 4096) {
+    return { ok: false, error: "SHAREPOINT_CLIENT_SECRET falta o tiene una longitud inválida." };
+  }
+
+  return { ok: true, value: { tenantId, clientId, clientSecret } };
+}
+
+export function parseSharePointGraphRuntimeConfig(
+  env: Record<string, string | undefined>,
+): { ok: true; value: SharePointGraphRuntimeConfig } | { ok: false; error: string } {
+  const source = parseSharePointSourceConfig(env);
+  if (!source.ok) return source;
+  const auth = parseSharePointGraphAuthConfig(env);
+  if (!auth.ok) return auth;
+  return { ok: true, value: { source: source.value, auth: auth.value } };
+}
+
+function relativeSegments(value: string) {
+  if (!value) return [];
+  if (value.startsWith("/") || value.endsWith("/") || value.includes("\\") || value.includes("?") || value.includes("#")) {
+    throw new Error("La ruta documental relativa no es válida.");
+  }
+
+  const segments = value.split("/").map((segment) => segment.trim());
+  if (segments.some((segment) => !segment || segment === "." || segment === "..")) {
+    throw new Error("La ruta documental relativa no puede contener segmentos vacíos ni navegación relativa.");
+  }
+  return segments;
+}
+
+function sourceRootSegments(documentRoot: string) {
+  const segments = documentRoot.split("/");
+  if (segments.some((segment) => !segment || segment === "." || segment === "..")) {
+    throw new Error("SHAREPOINT_DOCUMENT_ROOT no es una raíz documental válida.");
+  }
+  return segments;
+}
+
+export function encodeSharePointGraphPath(documentRoot: string, relativeFolder = "") {
+  const segments = [...sourceRootSegments(documentRoot), ...relativeSegments(relativeFolder)];
+  return segments.map((segment) => encodeURIComponent(segment)).join("/");
+}
+
+function cacheKey(relativeFolder: string) {
+  return relativeSegments(relativeFolder).join("/");
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function safeGraphNextLink(value: unknown, driveId: string) {
+  if (value === undefined) return null;
+  if (typeof value !== "string") throw new Error("Microsoft Graph devolvió un nextLink inválido.");
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Microsoft Graph devolvió un nextLink inválido.");
+  }
+
+  const expectedPrefix = `${GRAPH_API_PREFIX}/drives/${encodeURIComponent(driveId)}/`;
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.origin !== GRAPH_ORIGIN ||
+    !url.pathname.startsWith(expectedPrefix)
+  ) {
+    throw new Error("Microsoft Graph devolvió un nextLink fuera del recurso autorizado.");
+  }
+
+  return url.toString();
+}
+
+function mapDriveItem(item: unknown, driveId: string): SharePointDocumentReference | null {
+  const row = asObject(item) as GraphDriveItem | null;
+  if (!row) throw new Error("Microsoft Graph devolvió un driveItem inválido.");
+  if (row.folder) return null;
+  if (!row.file || typeof row.file !== "object") return null;
+
+  const reference = validateSharePointDocumentReference({
+    provider: "sharepoint",
+    driveId,
+    itemId: clean(row.id),
+    title: clean(row.name),
+    webUrl: clean(row.webUrl),
+    mimeType: clean(row.file.mimeType),
+    modifiedAt: clean(row.lastModifiedDateTime),
+  });
+
+  if (!reference.ok) throw new Error(`Microsoft Graph devolvió una referencia documental inválida: ${reference.error}`);
+  return reference.value;
+}
+
+function graphChildrenUrl(source: SharePointSourceConfig, relativeFolder: string) {
+  const path = encodeSharePointGraphPath(source.documentRoot, relativeFolder);
+  const url = new URL(`${GRAPH_ORIGIN}${GRAPH_API_PREFIX}/drives/${encodeURIComponent(source.driveId)}/root:/${path}:/children`);
+  url.searchParams.set("$select", "id,name,webUrl,lastModifiedDateTime,file,folder");
+  url.searchParams.set("$top", String(GRAPH_PAGE_SIZE));
+  return url.toString();
+}
+
+export class SharePointGraphReadonlyClient {
+  private tokenCache: TokenCache | null = null;
+  private readonly documentCache = new Map<string, DocumentCacheEntry>();
+
+  constructor(
+    private readonly config: SharePointGraphRuntimeConfig,
+    private readonly fetchImpl: FetchLike = fetch,
+    private readonly now: Clock = Date.now,
+    private readonly documentCacheTtlMs = DEFAULT_DOCUMENT_CACHE_TTL_MS,
+  ) {}
+
+  private async accessToken() {
+    const now = this.now();
+    if (this.tokenCache && now < this.tokenCache.refreshAfter) return this.tokenCache.accessToken;
+
+    const tokenUrl = `https://login.microsoftonline.com/${this.config.auth.tenantId}/oauth2/v2.0/token`;
+    const body = new URLSearchParams({
+      client_id: this.config.auth.clientId,
+      client_secret: this.config.auth.clientSecret,
+      scope: TOKEN_SCOPE,
+      grant_type: "client_credentials",
+    });
+
+    const response = await this.fetchImpl(tokenUrl, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body,
+      cache: "no-store",
+    });
+
+    if (!response.ok) throw new Error(`Microsoft identity token request failed with HTTP ${response.status}.`);
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new Error("Microsoft identity token response was not valid JSON.");
+    }
+
+    const row = asObject(payload);
+    const accessToken = clean(row?.access_token);
+    const expiresIn = Number(row?.expires_in);
+    if (!accessToken || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+      throw new Error("Microsoft identity token response was incomplete.");
+    }
+
+    const lifetimeMs = expiresIn * 1000;
+    const safetyMs = Math.min(TOKEN_REFRESH_SAFETY_MS, Math.max(1_000, Math.floor(lifetimeMs / 10)));
+    this.tokenCache = {
+      accessToken,
+      refreshAfter: now + Math.max(0, lifetimeMs - safetyMs),
+    };
+    return accessToken;
+  }
+
+  private async graphPage(url: string, accessToken: string): Promise<GraphChildrenPage> {
+    const response = await this.fetchImpl(url, {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${accessToken}`,
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) throw new Error(`Microsoft Graph read failed with HTTP ${response.status}.`);
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new Error("Microsoft Graph response was not valid JSON.");
+    }
+
+    const row = asObject(payload);
+    if (!row || !Array.isArray(row.value)) throw new Error("Microsoft Graph response did not contain a valid value array.");
+    return row as GraphChildrenPage;
+  }
+
+  async listDocuments(relativeFolder = "", options: SharePointListOptions = {}) {
+    const key = cacheKey(relativeFolder);
+    const now = this.now();
+    const cached = this.documentCache.get(key);
+    if (!options.forceRefresh && cached && now < cached.expiresAt) return cached.documents;
+
+    const token = await this.accessToken();
+    const documents: SharePointDocumentReference[] = [];
+    let pageUrl: string | null = graphChildrenUrl(this.config.source, relativeFolder);
+    let pageCount = 0;
+
+    while (pageUrl) {
+      pageCount += 1;
+      if (pageCount > MAX_GRAPH_PAGES) throw new Error("Microsoft Graph excedió el límite de paginación permitido.");
+
+      const page = await this.graphPage(pageUrl, token);
+      for (const item of page.value as unknown[]) {
+        const document = mapDriveItem(item, this.config.source.driveId);
+        if (!document) continue;
+        documents.push(document);
+        if (documents.length > MAX_DOCUMENTS) throw new Error("Microsoft Graph excedió el límite de documentos permitido.");
+      }
+
+      pageUrl = safeGraphNextLink(page["@odata.nextLink"], this.config.source.driveId);
+    }
+
+    const immutableDocuments = Object.freeze(documents.map((document) => Object.freeze({ ...document })));
+    this.documentCache.set(key, {
+      documents: immutableDocuments,
+      expiresAt: now + Math.max(0, this.documentCacheTtlMs),
+    });
+    return immutableDocuments;
+  }
+
+  clearDocumentCache() {
+    this.documentCache.clear();
+  }
+}
+
+export function createSharePointGraphReadonlyClient(
+  env: Record<string, string | undefined> = process.env,
+  options: {
+    fetchImpl?: FetchLike;
+    now?: Clock;
+    documentCacheTtlMs?: number;
+  } = {},
+) {
+  const config = parseSharePointGraphRuntimeConfig(env);
+  if (!config.ok) throw new Error(config.error);
+  return new SharePointGraphReadonlyClient(
+    config.value,
+    options.fetchImpl,
+    options.now,
+    options.documentCacheTtlMs,
+  );
+}


### PR DESCRIPTION
## Objetivo
Implementar el adapter server-side de Microsoft Graph que materializa referencias documentales SharePoint sobre el contrato CORE-005A, sin convertir SharePoint en fuente transaccional ni exponer OAuth al browser.

## Implementación
- OAuth 2.0 app-only/client credentials con `https://graph.microsoft.com/.default`;
- tenant/client/secret exclusivamente server-side;
- lectura Graph v1.0 por `driveId` + path confinado bajo `SHAREPOINT_DOCUMENT_ROOT`;
- encoding de ruta por segmento y bloqueo de traversal/absolutas;
- `$select` mínimo para metadata documental;
- referencias validadas por el contrato CORE-005A;
- carpetas ignoradas como documentos, sin recursividad implícita;
- paginación restringida a `graph.microsoft.com`, v1.0 y el mismo drive;
- límites de 5 páginas / 200 documentos;
- token cacheado solo en memoria con margen de expiración;
- caché efímera de metadata por carpeta (60s) + `forceRefresh`;
- fixtures totalmente sanitizados, sin tenant/rutas/IDs reales;
- documentación de provisioning con `Sites.Selected` + grant `read` explícito.

## Fuera de alcance
No añade endpoints públicos/UI, descargas binarias, uploads, edición, movimientos, borrado, sincronización, permisos de escritura ni secretos al cliente.

Closes code scope of #67. La activación contra el tenant real sigue requiriendo App Registration/admin consent/grant externo y se documenta expresamente; no se afirma conexión real hasta completar ese gate.