### PR TITLE
CORE-005C · Centro documental OPS protegido

### DIFF
--- a/e2e/documents.spec.ts
+++ b/e2e/documents.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+
+test("document center is reachable in local OPS without fabricating SharePoint data", async ({ page }) => {
+  await page.goto("/documents");
+
+  await expect(page.getByRole("heading", { name: "Centro documental", level: 1 })).toBeVisible();
+  await expect(page.getByText("Integración pendiente de activación.")).toBeVisible();
+  await expect(page.getByText(/No se muestran documentos ficticios/)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Documentos" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Abrir en SharePoint" })).toHaveCount(0);
+});
+
+test("public robots policy keeps the document center out of indexing", async ({ request }) => {
+  const response = await request.get("/robots.txt");
+  expect(response.ok()).toBeTruthy();
+  const body = await response.text();
+  expect(body).toContain("Disallow: /documents");
+});

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -95,11 +95,17 @@ function DocumentList({ documents }: { documents: readonly SharePointDocumentRef
 
 export default async function DocumentsPage() {
   const access = await getOpsServerAccess();
-  if (!access.ok && (access.reason === "configuration" || access.reason === "session")) {
-    redirect("/login?next=%2Fdocuments");
+  if (!access.ok) {
+    switch (access.reason) {
+      case "configuration":
+      case "session":
+        redirect("/login?next=%2Fdocuments");
+      case "membership":
+        return <AppShell><AccessProblem reason="membership" /></AppShell>;
+      case "backend":
+        return <AppShell><AccessProblem reason="backend" /></AppShell>;
+    }
   }
-
-  if (!access.ok) return <AppShell><AccessProblem reason={access.reason} /></AppShell>;
 
   const config = parseSharePointGraphRuntimeConfig(process.env);
   if (!config.ok) return <AppShell><PendingIntegration /></AppShell>;

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -1,0 +1,115 @@
+import { redirect } from "next/navigation";
+import { AppShell } from "@/components/app-shell";
+import { getOpsServerAccess } from "@/lib/ops-server-access";
+import { parseSharePointGraphRuntimeConfig } from "@/lib/sharepoint/graph-readonly";
+import { getSharePointGraphRuntimeClient } from "@/lib/sharepoint/runtime-client";
+import type { SharePointDocumentReference } from "@/lib/document-source-contract";
+
+export const dynamic = "force-dynamic";
+
+function formattedDate(value?: string) {
+  if (!value) return "Sin fecha de modificación";
+  try {
+    return new Intl.DateTimeFormat("es-CO", { dateStyle: "medium" }).format(new Date(value));
+  } catch {
+    return "Fecha no disponible";
+  }
+}
+
+function PendingIntegration() {
+  return (
+    <section className="panel mx-auto max-w-5xl">
+      <p className="eyebrow">Documentos · SharePoint</p>
+      <h1 className="text-3xl">Centro documental</h1>
+      <p className="lede mt-3">La superficie documental está lista, pero este entorno todavía no tiene la conexión Microsoft Graph completa.</p>
+      <div className="mt-6 rounded-2xl bg-[var(--amber-soft)] p-5 text-sm text-[var(--amber)]" role="status">
+        <strong>Integración pendiente de activación.</strong>
+        <span className="mt-2 block">No se muestran documentos ficticios como si fueran información real. La operación diaria de GREENATICS OPS continúa en su fuente transaccional independiente.</span>
+      </div>
+      <div className="mt-6 grid gap-3 md:grid-cols-3">
+        <article className="rounded-2xl border border-[var(--line)] p-4"><strong className="block">1 · Entra</strong><span className="mt-1 block text-sm text-[var(--muted)]">App Registration y permiso de lectura seleccionado.</span></article>
+        <article className="rounded-2xl border border-[var(--line)] p-4"><strong className="block">2 · Runtime</strong><span className="mt-1 block text-sm text-[var(--muted)]">Credenciales e identificadores solo del lado servidor.</span></article>
+        <article className="rounded-2xl border border-[var(--line)] p-4"><strong className="block">3 · Smoke</strong><span className="mt-1 block text-sm text-[var(--muted)]">Confirmar sitio permitido y rechazo de sitios no asignados.</span></article>
+      </div>
+    </section>
+  );
+}
+
+function AccessProblem({ reason }: { reason: "membership" | "backend" }) {
+  const membership = reason === "membership";
+  return (
+    <section className="panel mx-auto max-w-3xl" role="alert">
+      <p className="eyebrow">Centro documental</p>
+      <h1 className="text-3xl">{membership ? "Acceso documental no habilitado" : "No fue posible validar el acceso"}</h1>
+      <p className="lede mt-3">
+        {membership
+          ? "Tu sesión existe, pero no tiene una membresía activa sobre una planta activa. SharePoint no se consulta en este estado."
+          : "No se pudo comprobar tu membresía operacional. Por seguridad, SharePoint no se consulta mientras esa validación esté incompleta."}
+      </p>
+    </section>
+  );
+}
+
+function RemoteProblem() {
+  return (
+    <section className="panel mx-auto max-w-4xl" role="alert">
+      <p className="eyebrow">Documentos · SharePoint</p>
+      <h1 className="text-3xl">Repositorio documental temporalmente no disponible</h1>
+      <p className="lede mt-3">La consulta documental falló de forma cerrada. No se muestran resultados parciales y la operación transaccional de GREENATICS OPS no se reemplaza por este repositorio.</p>
+      <p className="mt-5 rounded-2xl bg-[var(--red-soft)] p-4 text-sm font-semibold text-[var(--red)]">Reintenta más tarde o revisa la configuración server-side de Microsoft Graph.</p>
+    </section>
+  );
+}
+
+function DocumentList({ documents }: { documents: readonly SharePointDocumentReference[] }) {
+  return (
+    <section className="mx-auto grid max-w-5xl gap-5">
+      <header className="panel">
+        <p className="eyebrow">Documentos · SharePoint</p>
+        <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
+          <div><h1 className="text-3xl">Centro documental</h1><p className="lede mt-2">Referencias de solo lectura al repositorio documental autorizado.</p></div>
+          <span className="rounded-full bg-[var(--green-soft)] px-4 py-2 text-sm font-bold text-[var(--green-dark)]">{documents.length} documento{documents.length === 1 ? "" : "s"}</span>
+        </div>
+      </header>
+
+      {documents.length === 0 ? (
+        <section className="panel"><h2 className="text-xl">No hay archivos en esta carpeta</h2><p className="mt-2 text-sm text-[var(--muted)]">La conexión respondió correctamente, pero la raíz documental configurada no contiene archivos directos.</p></section>
+      ) : (
+        <div className="grid gap-3">
+          {documents.map((document) => (
+            <article className="panel flex flex-col gap-4 md:flex-row md:items-center md:justify-between" key={`${document.driveId}:${document.itemId}`}>
+              <div className="min-w-0">
+                <h2 className="break-words text-lg font-bold">{document.title}</h2>
+                <p className="mt-1 text-sm text-[var(--muted)]">{document.mimeType || "Tipo de archivo no informado"} · {formattedDate(document.modifiedAt)}</p>
+              </div>
+              <a className="button secondary shrink-0" href={document.webUrl} target="_blank" rel="noopener noreferrer">Abrir en SharePoint</a>
+            </article>
+          ))}
+        </div>
+      )}
+
+      <p className="text-xs text-[var(--muted)]">GREENATICS OPS conserva únicamente referencias documentales. Los archivos permanecen en SharePoint y esta vista no descarga ni modifica binarios.</p>
+    </section>
+  );
+}
+
+export default async function DocumentsPage() {
+  const access = await getOpsServerAccess();
+  if (!access.ok && (access.reason === "configuration" || access.reason === "session")) {
+    redirect("/login?next=%2Fdocuments");
+  }
+
+  if (!access.ok) return <AppShell><AccessProblem reason={access.reason} /></AppShell>;
+
+  const config = parseSharePointGraphRuntimeConfig(process.env);
+  if (!config.ok) return <AppShell><PendingIntegration /></AppShell>;
+
+  let documents: readonly SharePointDocumentReference[];
+  try {
+    documents = await getSharePointGraphRuntimeClient().listDocuments();
+  } catch {
+    return <AppShell><RemoteProblem /></AppShell>;
+  }
+
+  return <AppShell><DocumentList documents={documents} /></AppShell>;
+}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -13,7 +13,7 @@ import { useSupplyStore } from "@/components/supply-store";
 import { usePurchaseRequestStore } from "@/components/purchase-request-store";
 import { useSettlementStore } from "@/components/settlement-store";
 
-const nav = [["Hoy", "/app"], ["Calendario", "/calendar"], ["Recepciones", "/receptions"], ["Compostaje", "/compost"], ["Producción", "/production"], ["Inventario", "/inventory"], ["Insumos", "/supplies"], ["Ventas", "/sales"], ["Solicitudes", "/purchases"], ["Compras/Gastos", "/expenses"], ["Caja", "/cash"], ["Finanzas", "/finance"], ["Equipos", "/equipment"], ["Dashboard", "/dashboard"], ["Importaciones", "/imports"], ["Registrar actividad", "/activities/new"], ["Alertas", "/app#alertas"]] as const;
+const nav = [["Hoy", "/app"], ["Calendario", "/calendar"], ["Recepciones", "/receptions"], ["Compostaje", "/compost"], ["Producción", "/production"], ["Inventario", "/inventory"], ["Insumos", "/supplies"], ["Ventas", "/sales"], ["Solicitudes", "/purchases"], ["Compras/Gastos", "/expenses"], ["Caja", "/cash"], ["Finanzas", "/finance"], ["Equipos", "/equipment"], ["Dashboard", "/dashboard"], ["Importaciones", "/imports"], ["Documentos", "/documents"], ["Registrar actividad", "/activities/new"], ["Alertas", "/app#alertas"]] as const;
 
 export function AppShell({ children }: { children: ReactNode }) {
   const router = useRouter();

--- a/src/data/public-site.ts
+++ b/src/data/public-site.ts
@@ -69,6 +69,7 @@ export const internalRoutePrefixes = [
   "/cash",
   "/compost",
   "/dashboard",
+  "/documents",
   "/equipment",
   "/expenses",
   "/finance",

--- a/src/lib/ops-access-policy.test.ts
+++ b/src/lib/ops-access-policy.test.ts
@@ -12,7 +12,7 @@ const base = {
 
 describe("OPS access policy", () => {
   it("recognizes every protected route family without swallowing public routes", () => {
-    for (const path of ["/account/setup", "/admin/users", "/app", "/activities/new", "/compost/abc", "/dashboard", "/receptions/new", "/sales", "/supplies/consume"]) {
+    for (const path of ["/account/setup", "/admin/users", "/app", "/activities/new", "/compost/abc", "/dashboard", "/documents", "/receptions/new", "/sales", "/supplies/consume"]) {
       expect(isProtectedOpsPath(path)).toBe(true);
     }
     for (const path of ["/", "/wondergreen", "/soluciones", "/proyectos/yarumal", "/contacto", "/login", "/auth/confirm"]) {

--- a/src/lib/ops-access-policy.ts
+++ b/src/lib/ops-access-policy.ts
@@ -7,6 +7,7 @@ export const protectedOpsRoutePrefixes = [
   "/cash",
   "/compost",
   "/dashboard",
+  "/documents",
   "/equipment",
   "/expenses",
   "/finance",

--- a/src/lib/ops-server-access.test.ts
+++ b/src/lib/ops-server-access.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { hasActivePlantMembership } from "./ops-server-access";
+
+describe("OPS server access membership semantics", () => {
+  it("requires at least one active joined plant", () => {
+    expect(hasActivePlantMembership([])).toBe(false);
+    expect(hasActivePlantMembership([{ plant_id: "plant-1", plants: { active: false } }])).toBe(false);
+    expect(hasActivePlantMembership([{ plant_id: "plant-1", plants: null }])).toBe(false);
+    expect(hasActivePlantMembership([{ plant_id: "plant-1", plants: { active: true } }])).toBe(true);
+  });
+
+  it("supports Supabase joins represented as arrays without accepting missing plant ids", () => {
+    expect(hasActivePlantMembership([{ plant_id: "plant-1", plants: [{ active: true }] }])).toBe(true);
+    expect(hasActivePlantMembership([{ plants: [{ active: true }] }])).toBe(false);
+  });
+});

--- a/src/lib/ops-server-access.ts
+++ b/src/lib/ops-server-access.ts
@@ -1,0 +1,45 @@
+import { getOpsAccessMode } from "@/lib/ops-access-policy";
+import { createClient } from "@/lib/supabase/server";
+
+export type OpsServerAccess =
+  | { ok: true; mode: "local-bypass"; userId: null }
+  | { ok: true; mode: "supabase-auth"; userId: string }
+  | { ok: false; reason: "configuration" | "session" | "membership" | "backend" };
+
+type JoinedPlant = { active?: boolean };
+type MembershipRow = { plant_id?: string; plants?: JoinedPlant | JoinedPlant[] | null };
+
+function onePlant(value: MembershipRow["plants"]) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function hasActivePlantMembership(rows: readonly MembershipRow[]) {
+  return rows.some((row) => Boolean(row.plant_id) && onePlant(row.plants)?.active === true);
+}
+
+export async function getOpsServerAccess(): Promise<OpsServerAccess> {
+  const mode = getOpsAccessMode();
+  if (mode === "local-bypass") return { ok: true, mode, userId: null };
+  if (mode === "configuration-block") return { ok: false, reason: "configuration" };
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) return { ok: false, reason: "session" };
+
+  const { data, error } = await supabase
+    .from("plant_memberships")
+    .select("plant_id,plants!inner(active)")
+    .eq("user_id", user.id)
+    .eq("active", true);
+
+  if (error) return { ok: false, reason: "backend" };
+  if (!hasActivePlantMembership((data ?? []) as unknown as MembershipRow[])) {
+    return { ok: false, reason: "membership" };
+  }
+
+  return { ok: true, mode, userId: user.id };
+}

--- a/src/lib/sharepoint/runtime-client.ts
+++ b/src/lib/sharepoint/runtime-client.ts
@@ -1,0 +1,8 @@
+import { createSharePointGraphReadonlyClient, type SharePointGraphReadonlyClient } from "./graph-readonly";
+
+let runtimeClient: SharePointGraphReadonlyClient | null = null;
+
+export function getSharePointGraphRuntimeClient() {
+  if (!runtimeClient) runtimeClient = createSharePointGraphReadonlyClient(process.env);
+  return runtimeClient;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -36,6 +36,7 @@ export const config = {
     "/cash/:path*",
     "/compost/:path*",
     "/dashboard/:path*",
+    "/documents/:path*",
     "/equipment/:path*",
     "/expenses/:path*",
     "/finance/:path*",


### PR DESCRIPTION
## Objetivo
Habilitar la primera superficie documental de GREENATICS OPS sobre CORE-005B sin exponer OAuth al browser ni consultar SharePoint antes de validar autorización operacional server-side.

## Cambios
- nueva ruta interna `/documents` dentro de `AppShell`;
- entrada `Documentos` en navegación OPS;
- `/documents` agregado a proxy, rutas protegidas y política robots/noindex;
- guard server-side adicional que exige sesión Supabase + al menos una membresía activa sobre planta activa antes de ejecutar Graph;
- local/configuración Graph incompleta: estado explícito de activación pendiente, sin datos ficticios;
- Graph configurado: listado de referencias documentales de solo lectura;
- error remoto fail-closed y sin detalles sensibles;
- links humanos a SharePoint, sin download URLs/binarios;
- cliente Graph process-local para reutilizar token/cache efímera;
- unit tests de membresía y ruta protegida;
- E2E del estado local + robots.

## Fuera de alcance
Sin búsqueda, árbol recursivo, uploads, previews binarios, asignación por planta/proyecto ni provisioning real de Entra.

Closes #69