### PR TITLE
CORE-004C · Hosted Supabase advisor hardening

### DIFF
--- a/supabase/migrations/0022_hosted_advisor_hardening.sql
+++ b/supabase/migrations/0022_hosted_advisor_hardening.sql
@@ -1,0 +1,39 @@
+-- CORE-004C · Hosted Supabase advisor hardening.
+-- Preserve inventory authorization semantics while avoiding duplicate permissive INSERT policies.
+
+create index if not exists activities_plant_idx on public.activities(plant_id);
+create index if not exists activities_import_run_idx on public.activities(import_run_id) where import_run_id is not null;
+create index if not exists employees_plant_idx on public.employees(plant_id);
+create index if not exists incidents_plant_idx on public.incidents(plant_id);
+create index if not exists incidents_equipment_idx on public.incidents(equipment_id) where equipment_id is not null;
+create index if not exists maintenance_tickets_plant_idx on public.maintenance_tickets(plant_id);
+create index if not exists material_receipts_import_run_idx on public.material_receipts(import_run_id) where import_run_id is not null;
+create index if not exists production_records_product_idx on public.production_records(product_id);
+create index if not exists production_records_source_pile_idx on public.production_records(source_pile_id) where source_pile_id is not null;
+create index if not exists sales_product_idx on public.sales(product_id);
+create index if not exists scheduled_activities_plant_idx on public.scheduled_activities(plant_id);
+create index if not exists supply_receipts_plant_supply_idx on public.supply_receipts(plant_id,supply_id);
+create index if not exists supply_movements_supply_idx on public.supply_movements(supply_id);
+
+drop policy if exists "inventory_dispatch_insert" on public.inventory_movements;
+drop policy if exists "inventory_adjustment_insert" on public.inventory_movements;
+drop policy if exists "inventory_movements_insert" on public.inventory_movements;
+
+create policy "inventory_movements_insert"
+on public.inventory_movements
+for insert
+to authenticated
+with check (
+  (
+    kind = 'dispatch'
+    and (select private.has_plant_role(plant_id,array['operator','supervisor','technical','admin','director']))
+  )
+  or
+  (
+    kind in ('adjustment_in','adjustment_out')
+    and (select private.has_plant_role(plant_id,array['supervisor','technical','admin','director']))
+  )
+);
+
+-- No unused indexes are removed here: a fresh hosted database has no representative workload yet.
+-- SECURITY DEFINER RPCs remain unchanged; their role checks are an intentional transactional boundary.

--- a/supabase/tests/database/hosted_advisor_hardening.test.sql
+++ b/supabase/tests/database/hosted_advisor_hardening.test.sql
@@ -1,0 +1,37 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+select plan(17);
+
+select is(
+  (select count(*) from pg_policies where schemaname='public' and tablename='inventory_movements' and cmd='INSERT'),
+  1::bigint,
+  'inventory movements has one permissive INSERT policy'
+);
+select policies_are('public','inventory_movements',array['inventory_movements_insert','inventory_movements_member_select']::text[],'inventory policies are canonical after hardening');
+
+select has_index('public','activities','activities_plant_idx','activities plant FK is indexed');
+select has_index('public','activities','activities_import_run_idx','activities import provenance FK is indexed');
+select has_index('public','employees','employees_plant_idx','employees plant FK is indexed');
+select has_index('public','incidents','incidents_plant_idx','incidents plant FK is indexed');
+select has_index('public','incidents','incidents_equipment_idx','incidents equipment FK is indexed');
+select has_index('public','maintenance_tickets','maintenance_tickets_plant_idx','maintenance plant FK is indexed');
+select has_index('public','material_receipts','material_receipts_import_run_idx','receipt provenance FK is indexed');
+select has_index('public','production_records','production_records_product_idx','production product FK is indexed');
+select has_index('public','production_records','production_records_source_pile_idx','production source pile FK is indexed');
+select has_index('public','sales','sales_product_idx','sales product FK is indexed');
+select has_index('public','scheduled_activities','scheduled_activities_plant_idx','scheduled activity plant FK is indexed');
+select has_index('public','supply_receipts','supply_receipts_plant_supply_idx','supply receipt plant+supply FKs are indexed');
+select has_index('public','supply_movements','supply_movements_supply_idx','supply movement supply FK is indexed');
+
+select ok(
+  position('kind = ''dispatch''' in (select with_check from pg_policies where schemaname='public' and tablename='inventory_movements' and policyname='inventory_movements_insert')) > 0,
+  'combined policy preserves dispatch branch'
+);
+select ok(
+  position('adjustment_in' in (select with_check from pg_policies where schemaname='public' and tablename='inventory_movements' and policyname='inventory_movements_insert')) > 0,
+  'combined policy preserves adjustment branch'
+);
+
+select finish();
+rollback;


### PR DESCRIPTION
Closes #71.

- Adds canonical migration `0022_hosted_advisor_hardening.sql`.
- Consolidates the two authenticated INSERT policies on `inventory_movements` into one logically equivalent policy.
- Adds selected covering indexes for operational/provenance foreign keys reported by the hosted Supabase advisor.
- Does not remove fresh-database `unused_index` candidates.
- Does not alter the intentional role-gated SECURITY DEFINER transactional RPC boundary.
- Adds pgTAP contract coverage for policy shape and selected indexes.

After merge and green CI, the exact canonical migration will be applied to the hosted `greenatics-ops` project and advisors rerun.