### PR TITLE
CORE-004D · Bootstrap atómico del primer director

### DIFF
--- a/scripts/bootstrap-director.mjs
+++ b/scripts/bootstrap-director.mjs
@@ -31,17 +31,6 @@ if (!plantCodes.length) fail("Selecciona al menos una planta con --plants.");
 
 const admin = createClient(url, secret, { auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false } });
 
-const { data: directorRows, error: directorError } = await admin.from("plant_memberships").select("user_id").eq("role", "director").eq("active", true).limit(1);
-if (directorError) fail(`No fue posible verificar directores existentes: ${directorError.message}`);
-if (directorRows?.length) fail("Ya existe un director activo. Usa la pantalla Usuarios y accesos; el bootstrap queda cerrado.");
-
-const { data: plants, error: plantError } = await admin.from("plants").select("id,code,name,active").in("code", plantCodes).eq("active", true);
-if (plantError) fail(`No fue posible cargar plantas: ${plantError.message}`);
-if (!plants || plants.length !== new Set(plantCodes).size) {
-  const found = new Set((plants || []).map((plant) => plant.code));
-  fail(`No se encontraron todas las plantas solicitadas. Faltan: ${plantCodes.filter((code) => !found.has(code)).join(", ")}`);
-}
-
 const { data: userPage, error: listError } = await admin.auth.admin.listUsers({ page: 1, perPage: 1000 });
 if (listError) fail(`No fue posible buscar usuarios Auth: ${listError.message}`);
 let user = userPage.users.find((candidate) => (candidate.email || "").toLowerCase() === email);
@@ -55,16 +44,21 @@ if (!user) {
 }
 if (!user) fail("Supabase no devolvió el usuario objetivo.");
 
-try {
-  const { error: profileError } = await admin.from("profiles").upsert({ id: user.id, display_name: displayName, active: true }, { onConflict: "id" });
-  if (profileError) throw profileError;
-  const memberships = plants.map((plant) => ({ user_id: user.id, plant_id: plant.id, role: "director", active: true }));
-  const { error: membershipError } = await admin.from("plant_memberships").upsert(memberships, { onConflict: "user_id,plant_id" });
-  if (membershipError) throw membershipError;
-} catch (error) {
+const { data: bootstrapPlants, error: bootstrapError } = await admin.rpc("admin_bootstrap_first_director", {
+  target_user: user.id,
+  target_display_name: displayName,
+  target_plant_codes: plantCodes,
+});
+
+if (bootstrapError) {
   if (invited) await admin.auth.admin.deleteUser(user.id);
-  fail(`No fue posible completar perfil/membresías; ${invited ? "la invitación fue revertida" : "el usuario existente no fue eliminado"}: ${error instanceof Error ? error.message : String(error)}`);
+  fail(`No fue posible completar el bootstrap atómico; ${invited ? "la invitación fue revertida" : "el usuario existente no fue eliminado"}: ${bootstrapError.message}`);
 }
 
-console.log(`BOOTSTRAP_OK: ${displayName} (${email}) quedó como director en ${plants.map((plant) => plant.name).join(" + ")}.`);
-console.log("El bootstrap se bloqueará en futuras ejecuciones mientras exista un director activo.");
+if (!bootstrapPlants?.length) {
+  if (invited) await admin.auth.admin.deleteUser(user.id);
+  fail(`El bootstrap no devolvió plantas; ${invited ? "la invitación fue revertida" : "el usuario existente no fue eliminado"}.`);
+}
+
+console.log(`BOOTSTRAP_OK: ${displayName} (${email}) quedó como director en ${bootstrapPlants.map((plant) => plant.plant_name).join(" + ")}.`);
+console.log("El bootstrap atómico se bloqueará en futuras ejecuciones mientras exista un director activo.");

--- a/supabase/migrations/0023_atomic_first_director_bootstrap.sql
+++ b/supabase/migrations/0023_atomic_first_director_bootstrap.sql
@@ -1,0 +1,105 @@
+-- CORE-004D · Atomic first-director bootstrap.
+-- The initial privileged assignment is serialized and callable only with the server-side service role.
+
+create or replace function public.admin_bootstrap_first_director(
+  target_user uuid,
+  target_display_name text,
+  target_plant_codes text[]
+)
+returns table(plant_id uuid, plant_code text, plant_name text)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  requested_count integer;
+  matched_count integer;
+begin
+  if target_user is null then
+    raise exception 'El usuario objetivo es obligatorio.';
+  end if;
+
+  if target_display_name is null or length(btrim(target_display_name)) < 2 then
+    raise exception 'El nombre visible debe tener al menos 2 caracteres.';
+  end if;
+
+  if target_plant_codes is null or cardinality(target_plant_codes) = 0 then
+    raise exception 'Selecciona al menos una planta.';
+  end if;
+
+  if cardinality(target_plant_codes) > 20 then
+    raise exception 'No se permiten más de 20 plantas en el bootstrap.';
+  end if;
+
+  if exists (
+    select 1
+    from unnest(target_plant_codes) as requested(code)
+    where requested.code is null
+       or btrim(requested.code) = ''
+       or requested.code <> btrim(requested.code)
+  ) then
+    raise exception 'Los códigos de planta no pueden estar vacíos ni contener espacios externos.';
+  end if;
+
+  select count(distinct requested.code)
+  into requested_count
+  from unnest(target_plant_codes) as requested(code);
+
+  if requested_count <> cardinality(target_plant_codes) then
+    raise exception 'Una planta no puede aparecer dos veces.';
+  end if;
+
+  if not exists (select 1 from auth.users u where u.id = target_user) then
+    raise exception 'El usuario Auth objetivo no existe.';
+  end if;
+
+  -- Global transaction lock for the one-time bootstrap. The second concurrent caller
+  -- resumes only after the winner commits and then observes the active director.
+  perform pg_catalog.pg_advisory_xact_lock(741004, 1);
+
+  if exists (
+    select 1
+    from public.plant_memberships pm
+    where pm.role = 'director' and pm.active
+  ) then
+    raise exception 'Ya existe un director activo.';
+  end if;
+
+  select count(*)
+  into matched_count
+  from public.plants p
+  where p.active
+    and p.code = any(target_plant_codes);
+
+  if matched_count <> requested_count then
+    raise exception 'No se encontraron todas las plantas activas solicitadas.';
+  end if;
+
+  insert into public.profiles(id, display_name, active)
+  values (target_user, btrim(target_display_name), true)
+  on conflict (id) do update
+    set display_name = excluded.display_name,
+        active = true;
+
+  insert into public.plant_memberships(user_id, plant_id, role, active)
+  select target_user, p.id, 'director', true
+  from public.plants p
+  where p.active
+    and p.code = any(target_plant_codes)
+  on conflict (user_id, plant_id) do update
+    set role = 'director',
+        active = true;
+
+  return query
+  select p.id, p.code, p.name
+  from public.plants p
+  where p.active
+    and p.code = any(target_plant_codes)
+  order by p.code;
+end;
+$$;
+
+revoke all on function public.admin_bootstrap_first_director(uuid,text,text[]) from public;
+revoke all on function public.admin_bootstrap_first_director(uuid,text,text[]) from anon;
+revoke all on function public.admin_bootstrap_first_director(uuid,text,text[]) from authenticated;
+grant execute on function public.admin_bootstrap_first_director(uuid,text,text[]) to service_role;

--- a/supabase/migrations/0023_atomic_first_director_bootstrap.sql
+++ b/supabase/migrations/0023_atomic_first_director_bootstrap.sql
@@ -86,7 +86,7 @@ begin
   from public.plants p
   where p.active
     and p.code = any(target_plant_codes)
-  on conflict (user_id, plant_id) do update
+  on conflict on constraint plant_memberships_pkey do update
     set role = 'director',
         active = true;
 

--- a/supabase/tests/database/first_director_bootstrap.test.sql
+++ b/supabase/tests/database/first_director_bootstrap.test.sql
@@ -1,0 +1,45 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+select plan(9);
+
+select ok(has_function_privilege('service_role', 'public.admin_bootstrap_first_director(uuid,text,text[])', 'EXECUTE'), 'service role can execute bootstrap');
+select ok(not has_function_privilege('authenticated', 'public.admin_bootstrap_first_director(uuid,text,text[])', 'EXECUTE'), 'authenticated cannot execute bootstrap');
+select ok(not has_function_privilege('anon', 'public.admin_bootstrap_first_director(uuid,text,text[])', 'EXECUTE'), 'anon cannot execute bootstrap');
+
+insert into auth.users(id,email,created_at,updated_at)
+values
+  ('cccccccc-0000-4000-8000-000000000001','first@example.invalid',now(),now()),
+  ('cccccccc-0000-4000-8000-000000000002','second@example.invalid',now(),now());
+
+insert into public.plants(id,code,name,active)
+values
+  ('dddddddd-0000-4000-8000-000000000001','BOOT-A','Bootstrap Plant A',true),
+  ('dddddddd-0000-4000-8000-000000000002','BOOT-B','Bootstrap Plant B',true);
+
+set local role service_role;
+
+select throws_ok(
+  $$select * from public.admin_bootstrap_first_director('cccccccc-0000-4000-8000-000000000001'::uuid,'Bootstrap Director',array['BOOT-A','BOOT-MISSING']::text[])$$,
+  'P0001',
+  'No se encontraron todas las plantas activas solicitadas.',
+  'missing plant is rejected'
+);
+select is((select count(*) from public.profiles where id='cccccccc-0000-4000-8000-000000000001'::uuid),0::bigint,'failed bootstrap leaves no profile');
+
+select lives_ok(
+  $$select * from public.admin_bootstrap_first_director('cccccccc-0000-4000-8000-000000000001'::uuid,'Bootstrap Director',array['BOOT-A','BOOT-B']::text[])$$,
+  'first bootstrap succeeds'
+);
+select is((select display_name from public.profiles where id='cccccccc-0000-4000-8000-000000000001'::uuid),'Bootstrap Director'::text,'profile is persisted');
+select is((select count(*) from public.plant_memberships where user_id='cccccccc-0000-4000-8000-000000000001'::uuid and role='director' and active),2::bigint,'all requested memberships are persisted');
+
+select throws_ok(
+  $$select * from public.admin_bootstrap_first_director('cccccccc-0000-4000-8000-000000000002'::uuid,'Second Director',array['BOOT-A']::text[])$$,
+  'P0001',
+  'Ya existe un director activo.',
+  'second bootstrap is rejected'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #73

## Qué cambia
- añade `0023_atomic_first_director_bootstrap.sql`;
- serializa el bootstrap único con advisory transaction lock;
- valida usuario Auth, nombre y plantas activas dentro de la transacción;
- permite ejecutar la RPC únicamente a `service_role`;
- el script conserva invitación/rollback pero delega perfil + membresías a la RPC atómica;
- añade pgTAP para ACL, rollback, happy path y rechazo del segundo bootstrap.

## Límite
No crea usuarios reales ni incorpora secretos. El bootstrap hospedado real se ejecutará únicamente cuando exista el correo del primer director y el origen del deployment esté definido.