### PR TITLE
CORE-005D · Navegación documental read-only por subcarpetas

### DIFF
--- a/e2e/documents.spec.ts
+++ b/e2e/documents.spec.ts
@@ -10,6 +10,15 @@ test("document center is reachable in local OPS without fabricating SharePoint d
   await expect(page.getByRole("link", { name: "Abrir en SharePoint" })).toHaveCount(0);
 });
 
+test("invalid relative document routes fail closed before Graph is consulted", async ({ page }) => {
+  await page.goto("/documents?folder=..%2FFinance");
+
+  await expect(page.getByRole("heading", { name: "Ruta documental no válida", level: 1 })).toBeVisible();
+  await expect(page.getByText(/SharePoint no fue consultado/)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Volver a la raíz documental" })).toHaveAttribute("href", "/documents");
+  await expect(page.getByRole("link", { name: "Abrir en SharePoint" })).toHaveCount(0);
+});
+
 test("public robots policy keeps the document center out of indexing", async ({ request }) => {
   const response = await request.get("/robots.txt");
   expect(response.ok()).toBeTruthy();

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -1,11 +1,17 @@
 import { redirect } from "next/navigation";
 import { AppShell } from "@/components/app-shell";
 import { getOpsServerAccess } from "@/lib/ops-server-access";
-import { parseSharePointGraphRuntimeConfig } from "@/lib/sharepoint/graph-readonly";
+import {
+  normalizeSharePointRelativeFolder,
+  parseSharePointGraphRuntimeConfig,
+  type SharePointDirectoryListing,
+} from "@/lib/sharepoint/graph-readonly";
 import { getSharePointGraphRuntimeClient } from "@/lib/sharepoint/runtime-client";
 import type { SharePointDocumentReference } from "@/lib/document-source-contract";
 
 export const dynamic = "force-dynamic";
+
+type DocumentsSearchParams = Promise<{ folder?: string | string[] }>;
 
 function formattedDate(value?: string) {
   if (!value) return "Sin fecha de modificación";
@@ -13,6 +19,19 @@ function formattedDate(value?: string) {
     return new Intl.DateTimeFormat("es-CO", { dateStyle: "medium" }).format(new Date(value));
   } catch {
     return "Fecha no disponible";
+  }
+}
+
+function folderHref(relativePath: string) {
+  return relativePath ? `/documents?folder=${encodeURIComponent(relativePath)}` : "/documents";
+}
+
+function parseRequestedFolder(value: string | string[] | undefined) {
+  if (Array.isArray(value)) return { ok: false as const };
+  try {
+    return { ok: true as const, value: normalizeSharePointRelativeFolder(value || "") };
+  } catch {
+    return { ok: false as const };
   }
 }
 
@@ -50,6 +69,17 @@ function AccessProblem({ reason }: { reason: "membership" | "backend" }) {
   );
 }
 
+function InvalidFolder() {
+  return (
+    <section className="panel mx-auto max-w-4xl" role="alert">
+      <p className="eyebrow">Documentos · SharePoint</p>
+      <h1 className="text-3xl">Ruta documental no válida</h1>
+      <p className="lede mt-3">La carpeta solicitada no pertenece a una ruta relativa navegable dentro de la raíz documental autorizada. SharePoint no fue consultado.</p>
+      <a className="button secondary mt-5 inline-flex" href="/documents">Volver a la raíz documental</a>
+    </section>
+  );
+}
+
 function RemoteProblem() {
   return (
     <section className="panel mx-auto max-w-4xl" role="alert">
@@ -61,39 +91,84 @@ function RemoteProblem() {
   );
 }
 
-function DocumentList({ documents }: { documents: readonly SharePointDocumentReference[] }) {
+function Breadcrumbs({ relativeFolder }: { relativeFolder: string }) {
+  const segments = relativeFolder ? relativeFolder.split("/") : [];
+  let currentPath = "";
+  return (
+    <nav aria-label="Ruta documental" className="mt-5 flex flex-wrap items-center gap-2 text-sm">
+      <a className="font-semibold text-[var(--green-dark)] underline-offset-4 hover:underline" href="/documents">Raíz</a>
+      {segments.map((segment, index) => {
+        currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+        const isCurrent = index === segments.length - 1;
+        return (
+          <span className="flex items-center gap-2" key={currentPath}>
+            <span aria-hidden="true" className="text-[var(--muted)]">/</span>
+            {isCurrent ? <span aria-current="page" className="font-semibold">{segment}</span> : <a className="text-[var(--green-dark)] underline-offset-4 hover:underline" href={folderHref(currentPath)}>{segment}</a>}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
+
+function DocumentCards({ documents }: { documents: readonly SharePointDocumentReference[] }) {
+  if (!documents.length) return null;
+  return (
+    <section className="grid gap-3" aria-labelledby="document-files-heading">
+      <h2 className="text-xl font-bold" id="document-files-heading">Archivos</h2>
+      {documents.map((document) => (
+        <article className="panel flex flex-col gap-4 md:flex-row md:items-center md:justify-between" key={`${document.driveId}:${document.itemId}`}>
+          <div className="min-w-0">
+            <h3 className="break-words text-lg font-bold">{document.title}</h3>
+            <p className="mt-1 text-sm text-[var(--muted)]">{document.mimeType || "Tipo de archivo no informado"} · {formattedDate(document.modifiedAt)}</p>
+          </div>
+          <a className="button secondary shrink-0" href={document.webUrl} target="_blank" rel="noopener noreferrer">Abrir en SharePoint</a>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+function DirectoryView({ listing }: { listing: SharePointDirectoryListing }) {
+  const total = listing.folders.length + listing.documents.length;
   return (
     <section className="mx-auto grid max-w-5xl gap-5">
       <header className="panel">
         <p className="eyebrow">Documentos · SharePoint</p>
         <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
-          <div><h1 className="text-3xl">Centro documental</h1><p className="lede mt-2">Referencias de solo lectura al repositorio documental autorizado.</p></div>
-          <span className="rounded-full bg-[var(--green-soft)] px-4 py-2 text-sm font-bold text-[var(--green-dark)]">{documents.length} documento{documents.length === 1 ? "" : "s"}</span>
+          <div><h1 className="text-3xl">Centro documental</h1><p className="lede mt-2">Navegación de solo lectura dentro de la raíz documental autorizada.</p></div>
+          <span className="rounded-full bg-[var(--green-soft)] px-4 py-2 text-sm font-bold text-[var(--green-dark)]">{listing.folders.length} carpeta{listing.folders.length === 1 ? "" : "s"} · {listing.documents.length} archivo{listing.documents.length === 1 ? "" : "s"}</span>
         </div>
+        <Breadcrumbs relativeFolder={listing.relativeFolder} />
       </header>
 
-      {documents.length === 0 ? (
-        <section className="panel"><h2 className="text-xl">No hay archivos en esta carpeta</h2><p className="mt-2 text-sm text-[var(--muted)]">La conexión respondió correctamente, pero la raíz documental configurada no contiene archivos directos.</p></section>
-      ) : (
-        <div className="grid gap-3">
-          {documents.map((document) => (
-            <article className="panel flex flex-col gap-4 md:flex-row md:items-center md:justify-between" key={`${document.driveId}:${document.itemId}`}>
-              <div className="min-w-0">
-                <h2 className="break-words text-lg font-bold">{document.title}</h2>
-                <p className="mt-1 text-sm text-[var(--muted)]">{document.mimeType || "Tipo de archivo no informado"} · {formattedDate(document.modifiedAt)}</p>
-              </div>
-              <a className="button secondary shrink-0" href={document.webUrl} target="_blank" rel="noopener noreferrer">Abrir en SharePoint</a>
-            </article>
-          ))}
-        </div>
-      )}
+      {listing.folders.length > 0 ? (
+        <section className="grid gap-3" aria-labelledby="document-folders-heading">
+          <h2 className="text-xl font-bold" id="document-folders-heading">Carpetas</h2>
+          <div className="grid gap-3 md:grid-cols-2">
+            {listing.folders.map((folder) => (
+              <a className="panel block transition-transform hover:-translate-y-0.5" href={folderHref(folder.relativePath)} key={folder.relativePath}>
+                <span className="eyebrow">Carpeta</span>
+                <h3 className="mt-1 break-words text-lg font-bold">{folder.title}</h3>
+                <p className="mt-2 text-sm text-[var(--muted)]">{folder.childCount === undefined ? "Contenido no informado por SharePoint" : `${folder.childCount} elemento${folder.childCount === 1 ? "" : "s"}`}</p>
+              </a>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
-      <p className="text-xs text-[var(--muted)]">GREENATICS OPS conserva únicamente referencias documentales. Los archivos permanecen en SharePoint y esta vista no descarga ni modifica binarios.</p>
+      <DocumentCards documents={listing.documents} />
+
+      {total === 0 ? (
+        <section className="panel"><h2 className="text-xl">Carpeta vacía</h2><p className="mt-2 text-sm text-[var(--muted)]">La conexión respondió correctamente y esta carpeta no contiene archivos ni subcarpetas directas.</p></section>
+      ) : null}
+
+      <p className="text-xs text-[var(--muted)]">GREENATICS OPS conserva únicamente referencias y metadata documental. Los archivos permanecen en SharePoint; esta vista no descarga, modifica, mueve ni elimina binarios.</p>
     </section>
   );
 }
 
-export default async function DocumentsPage() {
+export default async function DocumentsPage({ searchParams }: { searchParams: DocumentsSearchParams }) {
   const access = await getOpsServerAccess();
   if (!access.ok) {
     switch (access.reason) {
@@ -107,15 +182,19 @@ export default async function DocumentsPage() {
     }
   }
 
+  const params = await searchParams;
+  const requestedFolder = parseRequestedFolder(params.folder);
+  if (!requestedFolder.ok) return <AppShell><InvalidFolder /></AppShell>;
+
   const config = parseSharePointGraphRuntimeConfig(process.env);
   if (!config.ok) return <AppShell><PendingIntegration /></AppShell>;
 
-  let documents: readonly SharePointDocumentReference[];
+  let listing: SharePointDirectoryListing;
   try {
-    documents = await getSharePointGraphRuntimeClient().listDocuments();
+    listing = await getSharePointGraphRuntimeClient().listDirectory(requestedFolder.value);
   } catch {
     return <AppShell><RemoteProblem /></AppShell>;
   }
 
-  return <AppShell><DocumentList documents={documents} /></AppShell>;
+  return <AppShell><DirectoryView listing={listing} /></AppShell>;
 }

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -93,12 +93,11 @@ function RemoteProblem() {
 
 function Breadcrumbs({ relativeFolder }: { relativeFolder: string }) {
   const segments = relativeFolder ? relativeFolder.split("/") : [];
-  let currentPath = "";
   return (
     <nav aria-label="Ruta documental" className="mt-5 flex flex-wrap items-center gap-2 text-sm">
       <a className="font-semibold text-[var(--green-dark)] underline-offset-4 hover:underline" href="/documents">Raíz</a>
       {segments.map((segment, index) => {
-        currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+        const currentPath = segments.slice(0, index + 1).join("/");
         const isCurrent = index === segments.length - 1;
         return (
           <span className="flex items-center gap-2" key={currentPath}>

--- a/src/lib/sharepoint/graph-directory.test.ts
+++ b/src/lib/sharepoint/graph-directory.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SharePointGraphReadonlyClient,
+  normalizeSharePointRelativeFolder,
+  parseSharePointGraphRuntimeConfig,
+} from "./graph-readonly";
+
+const env = {
+  SHAREPOINT_SITE_HOSTNAME: "contoso.sharepoint.com",
+  SHAREPOINT_SITE_PATH: "/sites/Sanitized",
+  SHAREPOINT_DRIVE_ID: "b!sanitizedDrive_123",
+  SHAREPOINT_DOCUMENT_ROOT: "Shared Documents/Operations",
+  SHAREPOINT_TENANT_ID: "11111111-1111-4111-8111-111111111111",
+  SHAREPOINT_CLIENT_ID: "22222222-2222-4222-8222-222222222222",
+  SHAREPOINT_CLIENT_SECRET: "sanitized-test-secret",
+};
+
+function runtimeConfig() {
+  const parsed = parseSharePointGraphRuntimeConfig(env);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.value;
+}
+
+function tokenResponse() {
+  return new Response(JSON.stringify({ access_token: "directory-token", expires_in: 3600 }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function graphResponse(value: unknown[]) {
+  return new Response(JSON.stringify({ value }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("SharePoint directory navigation", () => {
+  it("normalizes only confined relative folders", () => {
+    expect(normalizeSharePointRelativeFolder("Calidad/Lote #1")).toBe("Calidad/Lote #1");
+    expect(normalizeSharePointRelativeFolder("")).toBe("");
+    expect(() => normalizeSharePointRelativeFolder("../Finanzas")).toThrow(/navegación relativa/);
+    expect(() => normalizeSharePointRelativeFolder("/Finanzas")).toThrow(/no es válida/);
+    expect(() => normalizeSharePointRelativeFolder("Finanzas\\2026")).toThrow(/no es válida/);
+  });
+
+  it("returns direct folders and documents without recursive reads", async () => {
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.includes("login.microsoftonline.com")) return tokenResponse();
+      return graphResponse([
+        {
+          id: "01SANITIZEDFOLDER123",
+          name: "Lote #1",
+          folder: { childCount: 4 },
+        },
+        {
+          id: "01SANITIZEDFILE123",
+          name: "Control.xlsx",
+          webUrl: "https://contoso.sharepoint.com/sites/Sanitized/Shared%20Documents/Operations/Calidad/Control.xlsx",
+          lastModifiedDateTime: "2026-08-01T14:30:00Z",
+          file: { mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+        },
+      ]);
+    }) as unknown as typeof fetch;
+
+    const client = new SharePointGraphReadonlyClient(runtimeConfig(), fetchImpl);
+    const listing = await client.listDirectory("Calidad");
+
+    expect(listing.relativeFolder).toBe("Calidad");
+    expect(listing.folders).toEqual([{ title: "Lote #1", relativePath: "Calidad/Lote #1", childCount: 4 }]);
+    expect(listing.documents).toHaveLength(1);
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toContain("/root:/Shared%20Documents/Operations/Calidad:/children");
+    expect(calls.some((url) => url.includes("Lote%20%231:/children"))).toBe(false);
+  });
+
+  it("fails closed when Graph returns a non-navigable folder name", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("login.microsoftonline.com")) return tokenResponse();
+      return graphResponse([{ id: "01SANITIZEDFOLDER123", name: "../Finance", folder: { childCount: 1 } }]);
+    }) as unknown as typeof fetch;
+
+    const client = new SharePointGraphReadonlyClient(runtimeConfig(), fetchImpl);
+    await expect(client.listDirectory()).rejects.toThrow(/nombre no navegable/);
+  });
+});

--- a/src/lib/sharepoint/graph-readonly.ts
+++ b/src/lib/sharepoint/graph-readonly.ts
@@ -16,6 +16,18 @@ export type SharePointGraphRuntimeConfig = Readonly<{
   auth: SharePointGraphAuthConfig;
 }>;
 
+export type SharePointFolderReference = Readonly<{
+  title: string;
+  relativePath: string;
+  childCount?: number;
+}>;
+
+export type SharePointDirectoryListing = Readonly<{
+  relativeFolder: string;
+  folders: readonly SharePointFolderReference[];
+  documents: readonly SharePointDocumentReference[];
+}>;
+
 type FetchLike = typeof fetch;
 type Clock = () => number;
 
@@ -24,9 +36,9 @@ type TokenCache = {
   refreshAfter: number;
 };
 
-type DocumentCacheEntry = {
+type DirectoryCacheEntry = {
   expiresAt: number;
-  documents: readonly SharePointDocumentReference[];
+  listing: SharePointDirectoryListing;
 };
 
 type GraphDriveItem = {
@@ -43,6 +55,11 @@ type GraphChildrenPage = {
   "@odata.nextLink"?: unknown;
 };
 
+type MappedDriveItem =
+  | { kind: "document"; value: SharePointDocumentReference }
+  | { kind: "folder"; value: SharePointFolderReference }
+  | null;
+
 export type SharePointListOptions = Readonly<{
   forceRefresh?: boolean;
 }>;
@@ -54,7 +71,10 @@ const TOKEN_SCOPE = "https://graph.microsoft.com/.default";
 const TOKEN_REFRESH_SAFETY_MS = 60_000;
 const DEFAULT_DOCUMENT_CACHE_TTL_MS = 60_000;
 const MAX_GRAPH_PAGES = 5;
-const MAX_DOCUMENTS = 200;
+const MAX_DIRECTORY_ITEMS = 200;
+const MAX_RELATIVE_PATH_LENGTH = 2048;
+const MAX_RELATIVE_SEGMENTS = 32;
+const MAX_FOLDER_NAME_LENGTH = 255;
 const GRAPH_PAGE_SIZE = 100;
 
 function clean(value: unknown) {
@@ -94,15 +114,22 @@ export function parseSharePointGraphRuntimeConfig(
 
 function relativeSegments(value: string) {
   if (!value) return [];
-  if (value.startsWith("/") || value.endsWith("/") || value.includes("\\")) {
+  if (value.length > MAX_RELATIVE_PATH_LENGTH || value.startsWith("/") || value.endsWith("/") || value.includes("\\")) {
     throw new Error("La ruta documental relativa no es válida.");
   }
 
   const segments = value.split("/").map((segment) => segment.trim());
-  if (segments.some((segment) => !segment || segment === "." || segment === "..")) {
+  if (
+    segments.length > MAX_RELATIVE_SEGMENTS ||
+    segments.some((segment) => !segment || segment === "." || segment === ".." || segment.length > MAX_FOLDER_NAME_LENGTH)
+  ) {
     throw new Error("La ruta documental relativa no puede contener segmentos vacíos ni navegación relativa.");
   }
   return segments;
+}
+
+export function normalizeSharePointRelativeFolder(value = "") {
+  return relativeSegments(value).join("/");
 }
 
 function sourceRootSegments(documentRoot: string) {
@@ -119,11 +146,29 @@ export function encodeSharePointGraphPath(documentRoot: string, relativeFolder =
 }
 
 function cacheKey(relativeFolder: string) {
-  return relativeSegments(relativeFolder).join("/");
+  return normalizeSharePointRelativeFolder(relativeFolder);
 }
 
 function asObject(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function safeFolderName(value: unknown) {
+  if (typeof value !== "string") throw new Error("Microsoft Graph devolvió una carpeta sin nombre válido.");
+  const name = value;
+  if (
+    !name ||
+    name !== name.trim() ||
+    name === "." ||
+    name === ".." ||
+    name.length > MAX_FOLDER_NAME_LENGTH ||
+    name.includes("/") ||
+    name.includes("\\") ||
+    /[\u0000-\u001f]/.test(name)
+  ) {
+    throw new Error("Microsoft Graph devolvió una carpeta con nombre no navegable.");
+  }
+  return name;
 }
 
 function safeGraphNextLink(value: unknown, driveId: string) {
@@ -151,10 +196,27 @@ function safeGraphNextLink(value: unknown, driveId: string) {
   return url.toString();
 }
 
-function mapDriveItem(item: unknown, driveId: string): SharePointDocumentReference | null {
+function mapDriveItem(item: unknown, driveId: string, relativeFolder: string): MappedDriveItem {
   const row = asObject(item) as GraphDriveItem | null;
   if (!row) throw new Error("Microsoft Graph devolvió un driveItem inválido.");
-  if (row.folder) return null;
+
+  if (row.folder !== undefined && row.folder !== null) {
+    const folderMetadata = asObject(row.folder);
+    if (!folderMetadata) throw new Error("Microsoft Graph devolvió metadata de carpeta inválida.");
+    const title = safeFolderName(row.name);
+    const relativePath = normalizeSharePointRelativeFolder(relativeFolder ? `${relativeFolder}/${title}` : title);
+    const rawChildCount = folderMetadata.childCount;
+    let childCount: number | undefined;
+    if (rawChildCount !== undefined) {
+      const parsed = Number(rawChildCount);
+      if (!Number.isSafeInteger(parsed) || parsed < 0) {
+        throw new Error("Microsoft Graph devolvió un childCount de carpeta inválido.");
+      }
+      childCount = parsed;
+    }
+    return { kind: "folder", value: Object.freeze({ title, relativePath, ...(childCount === undefined ? {} : { childCount }) }) };
+  }
+
   if (!row.file || typeof row.file !== "object") return null;
 
   const reference = validateSharePointDocumentReference({
@@ -168,7 +230,7 @@ function mapDriveItem(item: unknown, driveId: string): SharePointDocumentReferen
   });
 
   if (!reference.ok) throw new Error(`Microsoft Graph devolvió una referencia documental inválida: ${reference.error}`);
-  return reference.value;
+  return { kind: "document", value: reference.value };
 }
 
 function graphChildrenUrl(source: SharePointSourceConfig, relativeFolder: string) {
@@ -181,7 +243,7 @@ function graphChildrenUrl(source: SharePointSourceConfig, relativeFolder: string
 
 export class SharePointGraphReadonlyClient {
   private tokenCache: TokenCache | null = null;
-  private readonly documentCache = new Map<string, DocumentCacheEntry>();
+  private readonly directoryCache = new Map<string, DirectoryCacheEntry>();
 
   constructor(
     private readonly config: SharePointGraphRuntimeConfig,
@@ -257,15 +319,16 @@ export class SharePointGraphReadonlyClient {
     return row as GraphChildrenPage;
   }
 
-  async listDocuments(relativeFolder = "", options: SharePointListOptions = {}) {
+  async listDirectory(relativeFolder = "", options: SharePointListOptions = {}): Promise<SharePointDirectoryListing> {
     const key = cacheKey(relativeFolder);
     const now = this.now();
-    const cached = this.documentCache.get(key);
-    if (!options.forceRefresh && cached && now < cached.expiresAt) return cached.documents;
+    const cached = this.directoryCache.get(key);
+    if (!options.forceRefresh && cached && now < cached.expiresAt) return cached.listing;
 
     const token = await this.accessToken();
     const documents: SharePointDocumentReference[] = [];
-    let pageUrl: string | null = graphChildrenUrl(this.config.source, relativeFolder);
+    const folders: SharePointFolderReference[] = [];
+    let pageUrl: string | null = graphChildrenUrl(this.config.source, key);
     let pageCount = 0;
 
     while (pageUrl) {
@@ -274,25 +337,34 @@ export class SharePointGraphReadonlyClient {
 
       const page = await this.graphPage(pageUrl, token);
       for (const item of page.value as unknown[]) {
-        const document = mapDriveItem(item, this.config.source.driveId);
-        if (!document) continue;
-        documents.push(document);
-        if (documents.length > MAX_DOCUMENTS) throw new Error("Microsoft Graph excedió el límite de documentos permitido.");
+        const mapped = mapDriveItem(item, this.config.source.driveId, key);
+        if (!mapped) continue;
+        if (mapped.kind === "folder") folders.push(mapped.value);
+        else documents.push(mapped.value);
+        if (folders.length + documents.length > MAX_DIRECTORY_ITEMS) {
+          throw new Error("Microsoft Graph excedió el límite de elementos documentales permitido.");
+        }
       }
 
       pageUrl = safeGraphNextLink(page["@odata.nextLink"], this.config.source.driveId);
     }
 
+    const immutableFolders = Object.freeze(folders.map((folder) => Object.freeze({ ...folder })));
     const immutableDocuments = Object.freeze(documents.map((document) => Object.freeze({ ...document })));
-    this.documentCache.set(key, {
-      documents: immutableDocuments,
+    const listing = Object.freeze({ relativeFolder: key, folders: immutableFolders, documents: immutableDocuments });
+    this.directoryCache.set(key, {
+      listing,
       expiresAt: now + Math.max(0, this.documentCacheTtlMs),
     });
-    return immutableDocuments;
+    return listing;
+  }
+
+  async listDocuments(relativeFolder = "", options: SharePointListOptions = {}) {
+    return (await this.listDirectory(relativeFolder, options)).documents;
   }
 
   clearDocumentCache() {
-    this.documentCache.clear();
+    this.directoryCache.clear();
   }
 }
 


### PR DESCRIPTION
Closes #75

## Qué cambia
- `SharePointGraphReadonlyClient.listDirectory()` devuelve carpetas + documentos directos sin recursión automática;
- rutas relativas normalizadas, con límites de longitud/segmentos y bloqueo de traversal/backslash;
- nombres de carpeta remotos no navegables fallan de forma cerrada;
- cache y paginación siguen confinados al mismo drive y a límites explícitos;
- `/documents?folder=...` añade breadcrumbs y navegación de carpetas;
- ruta inválida se rechaza después del gate OPS y antes de Microsoft Graph;
- mantiene la integración pendiente sin inventar documentos si no existen credenciales;
- unit tests y E2E del fail-closed.

## Fuera de alcance
Sin recursión implícita, búsqueda global, upload, move, delete, edición ni descarga de binarios.