### PR TITLE
CORE-004E · Backend preflight hospedado + códigos canónicos

### DIFF
--- a/docs/deployment/HOSTED_PILOT_RUNBOOK.md
+++ b/docs/deployment/HOSTED_PILOT_RUNBOOK.md
@@ -10,6 +10,8 @@ Publicar un piloto multiusuario de la plataforma dual GREENATICS sin exponer sec
 4. Verificar las plantas canónicas que se usarán en el piloto.
 5. No crear tablas, políticas ni RPC manualmente por fuera de migraciones.
 
+Para el piloto actual, los códigos canónicos son `TAM` (Támesis) y `YAR` (Yarumal). Los scripts aceptan los alias humanos `Támesis`/`Tamesis` y `Yarumal`, pero el runbook y la base deben usar los códigos canónicos.
+
 ## 2. Frontera pública / interna
 La misma base de producto contiene dos superficies:
 - públicas: `/`, `/wondergreen`, `/soluciones`, `/proyectos`, `/impacto`, `/biblioteca`, `/nosotros`, `/contacto` y sus descendientes;
@@ -47,17 +49,27 @@ APP_BASE_URL=https://<origen-canonico>
 
 `APP_BASE_URL` debe ser un origen HTTP/HTTPS confiable. La API de invitaciones no usa el header `Host` como sustituto.
 
-## 5. Primer director · bootstrap único
-Con variables cargadas en un entorno administrativo:
+## 5. Backend preflight + primer director
+Antes de enviar una invitación real, validar que Supabase, Auth Admin, las plantas canónicas y el estado de bootstrap sean coherentes:
+
+```bash
+npm run pilot:backend-preflight -- \
+  --plants TAM,YAR \
+  --require-no-director
+```
+
+Este gate es de solo lectura: no crea usuarios, no cambia membresías y no imprime secretos. Debe pasar antes del primer bootstrap.
+
+Con variables cargadas en un entorno administrativo y `APP_BASE_URL` ya fijado al deployment real:
 
 ```bash
 npm run bootstrap:director -- \
   --email director@greenatics.com.co \
   --name "Director GREENATICS" \
-  --plants tamesis,yarumal
+  --plants TAM,YAR
 ```
 
-El script se niega a operar si ya existe cualquier membresía activa con rol `director`. Después de ese punto, las invitaciones y cambios de rol se hacen desde `/admin/users`.
+El bootstrap usa una RPC atómica y se niega a operar si ya existe cualquier membresía activa con rol `director`. Después de ese punto, las invitaciones y cambios de rol se hacen desde `/admin/users`.
 
 ## 6. Activación del usuario invitado
 1. Dirección invita desde `/admin/users`.
@@ -112,6 +124,7 @@ Con dos perfiles de navegador distintos:
 ## 9. Gate de promoción
 Antes de promover el piloto:
 - CI de PR verde (`quality` + `database`);
+- `npm run pilot:backend-preflight -- --plants TAM,YAR` en PASS;
 - `npm run pilot:preflight` en PASS contra el SHA exacto desplegado;
 - smoke multiusuario aprobado;
 - redirects Auth configurados;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "bootstrap:director": "node scripts/bootstrap-director.mjs",
+    "pilot:backend-preflight": "node scripts/hosted-backend-preflight.mjs",
     "pilot:preflight": "node scripts/hosted-pilot-preflight.mjs"
   },
   "dependencies": {

--- a/scripts/bootstrap-director.mjs
+++ b/scripts/bootstrap-director.mjs
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { DEFAULT_PILOT_PLANT_CODES, normalizePilotPlantCodes } from "./pilot-plant-codes.mjs";
 
 function arg(name) {
   const index = process.argv.indexOf(`--${name}`);
@@ -14,7 +15,12 @@ const secret = process.env.SUPABASE_SECRET_KEY;
 const rawBaseUrl = process.env.APP_BASE_URL?.trim();
 const email = (arg("email") || "").trim().toLowerCase();
 const displayName = (arg("name") || "").trim().replace(/\s+/g, " ");
-const plantCodes = (arg("plants") || "tamesis,yarumal").split(",").map((value) => value.trim()).filter(Boolean);
+let plantCodes;
+try {
+  plantCodes = normalizePilotPlantCodes(arg("plants") || DEFAULT_PILOT_PLANT_CODES);
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}
 
 if (!url || !secret) fail("Define NEXT_PUBLIC_SUPABASE_URL y SUPABASE_SECRET_KEY.");
 let baseUrl;
@@ -27,7 +33,6 @@ try {
 }
 if (!email || !email.includes("@")) fail("Usa --email usuario@dominio.");
 if (displayName.length < 2) fail("Usa --name 'Nombre Apellido'.");
-if (!plantCodes.length) fail("Selecciona al menos una planta con --plants.");
 
 const admin = createClient(url, secret, { auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false } });
 

--- a/scripts/hosted-backend-preflight-lib.mjs
+++ b/scripts/hosted-backend-preflight-lib.mjs
@@ -1,0 +1,106 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { DEFAULT_PILOT_PLANT_CODES, normalizePilotPlantCodes } from "./pilot-plant-codes.mjs";
+
+export class BackendPreflightError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "BackendPreflightError";
+  }
+}
+
+function clean(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function normalizeHostedSupabaseUrl(value) {
+  const raw = clean(value);
+  let url;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new BackendPreflightError("NEXT_PUBLIC_SUPABASE_URL no es una URL válida.");
+  }
+
+  if (url.protocol !== "https:" || url.username || url.password || (url.pathname !== "/" && url.pathname !== "")) {
+    throw new BackendPreflightError("NEXT_PUBLIC_SUPABASE_URL debe ser un origen HTTPS sin credenciales ni ruta.");
+  }
+  return url.origin;
+}
+
+export function parseHostedBackendConfig(env = process.env) {
+  const url = normalizeHostedSupabaseUrl(env.NEXT_PUBLIC_SUPABASE_URL);
+  const secret = clean(env.SUPABASE_SECRET_KEY);
+  if (!secret || secret.length > 4096) {
+    throw new BackendPreflightError("SUPABASE_SECRET_KEY falta o tiene una longitud inválida.");
+  }
+  return Object.freeze({ url, secret });
+}
+
+function requireRows(data, error, label) {
+  if (error) throw new BackendPreflightError(`${label}: ${error.message || "error remoto"}.`);
+  if (!Array.isArray(data)) throw new BackendPreflightError(`${label}: respuesta inválida.`);
+  return data;
+}
+
+export async function runHostedBackendPreflight({
+  env = process.env,
+  plants = DEFAULT_PILOT_PLANT_CODES,
+  requireNoDirector = false,
+  createClientImpl = createSupabaseClient,
+} = {}) {
+  const config = parseHostedBackendConfig(env);
+  const requestedCodes = normalizePilotPlantCodes(plants);
+  const admin = createClientImpl(config.url, config.secret, {
+    auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false },
+  });
+
+  const plantResponse = await admin
+    .from("plants")
+    .select("code,name,active")
+    .in("code", requestedCodes);
+  const plantRows = requireRows(plantResponse.data, plantResponse.error, "No fue posible validar las plantas");
+  const byCode = new Map(plantRows.map((row) => [String(row.code || "").toUpperCase(), row]));
+
+  const missing = requestedCodes.filter((code) => !byCode.has(code));
+  if (missing.length) {
+    throw new BackendPreflightError(`Faltan plantas solicitadas en Supabase: ${missing.join(", ")}.`);
+  }
+
+  const inactive = requestedCodes.filter((code) => !byCode.get(code)?.active);
+  if (inactive.length) {
+    throw new BackendPreflightError(`Hay plantas solicitadas inactivas: ${inactive.join(", ")}.`);
+  }
+
+  const { error: authError } = await admin.auth.admin.listUsers({ page: 1, perPage: 1 });
+  if (authError) {
+    throw new BackendPreflightError(`No fue posible validar Supabase Auth Admin: ${authError.message || "error remoto"}.`);
+  }
+
+  const directorResponse = await admin
+    .from("plant_memberships")
+    .select("user_id", { head: true, count: "exact" })
+    .eq("role", "director")
+    .eq("active", true);
+  if (directorResponse.error) {
+    throw new BackendPreflightError(`No fue posible validar el estado del director: ${directorResponse.error.message || "error remoto"}.`);
+  }
+  const activeDirectors = Number(directorResponse.count ?? 0);
+  if (!Number.isInteger(activeDirectors) || activeDirectors < 0) {
+    throw new BackendPreflightError("Supabase devolvió un conteo de directores inválido.");
+  }
+  if (requireNoDirector && activeDirectors > 0) {
+    throw new BackendPreflightError(`Ya existe ${activeDirectors} director activo; el bootstrap inicial debe permanecer bloqueado.`);
+  }
+
+  return Object.freeze({
+    projectOrigin: config.url,
+    plants: Object.freeze(requestedCodes.map((code) => Object.freeze({
+      code,
+      name: String(byCode.get(code)?.name || code),
+      active: true,
+    }))),
+    activeDirectors,
+    directorState: activeDirectors === 0 ? "empty" : "present",
+    checks: Object.freeze(["database", "auth-admin", "plants", "director-state"]),
+  });
+}

--- a/scripts/hosted-backend-preflight.mjs
+++ b/scripts/hosted-backend-preflight.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import { runHostedBackendPreflight } from "./hosted-backend-preflight-lib.mjs";
+import { DEFAULT_PILOT_PLANT_CODES } from "./pilot-plant-codes.mjs";
+
+function readArg(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`Falta valor para ${name}.`);
+  return value;
+}
+
+function printHelp() {
+  console.log(`GREENATICS hosted backend preflight
+
+Uso:
+  npm run pilot:backend-preflight -- [opciones]
+
+Opciones:
+  --plants <codes>          Códigos o alias separados por coma. Default: TAM,YAR.
+  --require-no-director     Falla si ya existe un director activo.
+  --help                    Muestra esta ayuda.
+
+Variables requeridas:
+  NEXT_PUBLIC_SUPABASE_URL
+  SUPABASE_SECRET_KEY
+`);
+}
+
+async function main() {
+  if (process.argv.includes("--help")) {
+    printHelp();
+    return;
+  }
+
+  const result = await runHostedBackendPreflight({
+    plants: readArg("--plants") ?? DEFAULT_PILOT_PLANT_CODES,
+    requireNoDirector: process.argv.includes("--require-no-director"),
+  });
+
+  console.log("GREENATICS hosted backend preflight: PASS");
+  console.log(`project: ${new URL(result.projectOrigin).hostname}`);
+  console.log(`plants: ${result.plants.map((plant) => `${plant.code}=${plant.name}`).join(", ")}`);
+  console.log(`director-state: ${result.directorState} (${result.activeDirectors})`);
+  console.log(`checks: ${result.checks.join(", ")}`);
+}
+
+main().catch((error) => {
+  console.error(`GREENATICS hosted backend preflight: FAIL · ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/hosted-backend-preflight.test.mjs
+++ b/scripts/hosted-backend-preflight.test.mjs
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BackendPreflightError,
+  normalizeHostedSupabaseUrl,
+  runHostedBackendPreflight,
+} from "./hosted-backend-preflight-lib.mjs";
+import { normalizePilotPlantCodes } from "./pilot-plant-codes.mjs";
+
+const env = {
+  NEXT_PUBLIC_SUPABASE_URL: "https://sanitized-project.supabase.co",
+  SUPABASE_SECRET_KEY: "sanitized-server-secret",
+};
+
+function fakeClient({
+  plants = [
+    { code: "TAM", name: "Támesis", active: true },
+    { code: "YAR", name: "Yarumal", active: true },
+  ],
+  activeDirectors = 0,
+  authError = null,
+} = {}) {
+  return {
+    auth: {
+      admin: {
+        listUsers: vi.fn(async () => ({ data: { users: [] }, error: authError })),
+      },
+    },
+    from(table) {
+      if (table === "plants") {
+        return {
+          select() {
+            return {
+              async in(_column, codes) {
+                return { data: plants.filter((plant) => codes.includes(plant.code)), error: null };
+              },
+            };
+          },
+        };
+      }
+      if (table === "plant_memberships") {
+        return {
+          select() {
+            const response = { data: null, count: activeDirectors, error: null };
+            const chain = {
+              eq() { return chain; },
+              then(resolve, reject) { return Promise.resolve(response).then(resolve, reject); },
+            };
+            return chain;
+          },
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+describe("hosted backend preflight", () => {
+  it("normalizes canonical plant codes and human aliases", () => {
+    expect(normalizePilotPlantCodes("Támesis,Yarumal")).toEqual(["TAM", "YAR"]);
+    expect(normalizePilotPlantCodes("tam,YAR")).toEqual(["TAM", "YAR"]);
+    expect(() => normalizePilotPlantCodes("TAM,Támesis")).toThrow(/dos veces/);
+  });
+
+  it("accepts only a clean HTTPS Supabase origin", () => {
+    expect(normalizeHostedSupabaseUrl(env.NEXT_PUBLIC_SUPABASE_URL)).toBe(env.NEXT_PUBLIC_SUPABASE_URL);
+    expect(() => normalizeHostedSupabaseUrl("http://sanitized-project.supabase.co")).toThrow(BackendPreflightError);
+    expect(() => normalizeHostedSupabaseUrl("https://sanitized-project.supabase.co/rest/v1")).toThrow(BackendPreflightError);
+  });
+
+  it("passes without mutating data when backend, auth and pilot plants are ready", async () => {
+    const createClientImpl = vi.fn(() => fakeClient());
+    const result = await runHostedBackendPreflight({
+      env,
+      plants: "tamesis,yar",
+      requireNoDirector: true,
+      createClientImpl,
+    });
+
+    expect(result.plants.map((plant) => plant.code)).toEqual(["TAM", "YAR"]);
+    expect(result.activeDirectors).toBe(0);
+    expect(result.directorState).toBe("empty");
+    expect(result).not.toHaveProperty("secret");
+    expect(createClientImpl).toHaveBeenCalledWith(
+      env.NEXT_PUBLIC_SUPABASE_URL,
+      env.SUPABASE_SECRET_KEY,
+      expect.any(Object),
+    );
+  });
+
+  it("fails closed when a requested plant is missing or inactive", async () => {
+    await expect(runHostedBackendPreflight({
+      env,
+      createClientImpl: () => fakeClient({ plants: [{ code: "TAM", name: "Támesis", active: true }] }),
+    })).rejects.toThrow(/YAR/);
+
+    await expect(runHostedBackendPreflight({
+      env,
+      createClientImpl: () => fakeClient({
+        plants: [
+          { code: "TAM", name: "Támesis", active: false },
+          { code: "YAR", name: "Yarumal", active: true },
+        ],
+      }),
+    })).rejects.toThrow(/inactivas/);
+  });
+
+  it("can require a pristine bootstrap state without creating or deleting users", async () => {
+    await expect(runHostedBackendPreflight({
+      env,
+      requireNoDirector: true,
+      createClientImpl: () => fakeClient({ activeDirectors: 1 }),
+    })).rejects.toThrow(/Ya existe 1 director activo/);
+  });
+});

--- a/scripts/pilot-plant-codes.mjs
+++ b/scripts/pilot-plant-codes.mjs
@@ -1,0 +1,40 @@
+export const DEFAULT_PILOT_PLANT_CODES = Object.freeze(["TAM", "YAR"]);
+
+const PILOT_PLANT_ALIASES = new Map([
+  ["tam", "TAM"],
+  ["tamesis", "TAM"],
+  ["yar", "YAR"],
+  ["yarumal", "YAR"],
+]);
+
+function fold(value) {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase();
+}
+
+export function normalizePilotPlantCodes(input = DEFAULT_PILOT_PLANT_CODES) {
+  const values = Array.isArray(input) ? input : String(input ?? "").split(",");
+  const normalized = [];
+
+  for (const rawValue of values) {
+    const value = String(rawValue ?? "").trim();
+    if (!value) continue;
+
+    const alias = PILOT_PLANT_ALIASES.get(fold(value));
+    const code = alias ?? value.toUpperCase();
+    if (!/^[A-Z0-9][A-Z0-9_-]{1,31}$/.test(code)) {
+      throw new Error(`Código de planta inválido: ${value}.`);
+    }
+    if (normalized.includes(code)) {
+      throw new Error(`La planta ${code} no puede aparecer dos veces.`);
+    }
+    normalized.push(code);
+  }
+
+  if (!normalized.length) throw new Error("Selecciona al menos una planta.");
+  if (normalized.length > 20) throw new Error("No se permiten más de 20 plantas.");
+  return Object.freeze(normalized);
+}


### PR DESCRIPTION
Closes #77

## Qué cambia
- corrige el bootstrap para usar `TAM,YAR` como códigos canónicos;
- acepta alias humanos (`Támesis`/`Tamesis`, `Yarumal`) y los normaliza antes de llamar Supabase;
- añade `npm run pilot:backend-preflight` de solo lectura;
- el preflight valida origen Supabase, clave server-side presente, Auth Admin, plantas solicitadas activas y estado del director;
- `--require-no-director` bloquea el gate si el bootstrap inicial ya no está vacío;
- actualiza el runbook y añade pruebas unitarias sin secretos reales.

## Validación externa ya observada
El Supabase hospedado `greenatics-ops` está saludable y contiene `TAM` (Támesis) y `YAR` (Yarumal) activas, con 0 directores activos.

## Límite
No crea usuarios, no cambia RLS, no modifica datos operativos y no resuelve el provisioning pendiente de Vercel.