### PR TITLE
CORE-004F · Seed canónico reproducible de plantas del piloto

### DIFF
--- a/supabase/migrations/0024_canonical_pilot_plants.sql
+++ b/supabase/migrations/0024_canonical_pilot_plants.sql
@@ -1,0 +1,9 @@
+-- CORE-004F · Canonical pilot plants.
+-- Fresh environments must contain the two operational plants without requiring manual seed steps.
+-- Existing rows are preserved exactly as administered.
+
+insert into public.plants(code, name, active)
+values
+  ('TAM', 'Támesis', true),
+  ('YAR', 'Yarumal', true)
+on conflict (code) do nothing;

--- a/supabase/tests/database/canonical_pilot_plants.test.sql
+++ b/supabase/tests/database/canonical_pilot_plants.test.sql
@@ -1,0 +1,35 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+select plan(5);
+
+select is(
+  (select count(*) from public.plants where code in ('TAM','YAR')),
+  2::bigint,
+  'fresh migrations create both canonical pilot plants'
+);
+
+select is(
+  (select name from public.plants where code='TAM'),
+  'Támesis'::text,
+  'TAM resolves to Támesis'
+);
+
+select is(
+  (select name from public.plants where code='YAR'),
+  'Yarumal'::text,
+  'YAR resolves to Yarumal'
+);
+
+select ok(
+  coalesce((select active from public.plants where code='TAM'), false),
+  'Támesis starts active in a fresh environment'
+);
+
+select ok(
+  coalesce((select active from public.plants where code='YAR'), false),
+  'Yarumal starts active in a fresh environment'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #79

## Qué cambia
- añade migración `0024_canonical_pilot_plants.sql`;
- crea `TAM` = `Támesis` y `YAR` = `Yarumal` en entornos frescos;
- usa `ON CONFLICT (code) DO NOTHING`, por lo que no reescribe filas existentes administradas;
- añade pgTAP para existencia, nombre y estado activo de ambas plantas.

## Por qué
El Supabase hospedado actual ya contiene las plantas, pero no había una semilla canónica versionada detectable en las migraciones. Un backend nuevo podía quedar migrado pero sin plantas operativas.

## Límite
No crea usuarios, membresías, datos operativos ni modifica plantas ya existentes.