### PR TITLE
CORE-004G · Smoke RLS multiusuario hospedado de solo lectura

### DIFF
--- a/docs/deployment/HOSTED_PILOT_RUNBOOK.md
+++ b/docs/deployment/HOSTED_PILOT_RUNBOOK.md
@@ -108,7 +108,27 @@ El preflight falla si:
 
 Este gate no usa correos, contraseñas ni tokens de usuarios y no sustituye el smoke multiusuario.
 
-## 8. Smoke multiusuario obligatorio
+## 8. Smoke RLS multiusuario de solo lectura
+Una vez existan el director y un operario de prueba de Támesis, cargar sus credenciales como variables efímeras del shell o secretos de CI; nunca guardarlas en archivos versionados, historial de comandos ni argumentos CLI:
+
+```text
+PILOT_DIRECTOR_EMAIL=...
+PILOT_DIRECTOR_PASSWORD=...
+PILOT_OPERATOR_EMAIL=...
+PILOT_OPERATOR_PASSWORD=...
+```
+
+Con `NEXT_PUBLIC_SUPABASE_URL` y `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` disponibles:
+
+```bash
+npm run pilot:rls-smoke
+```
+
+El gate usa dos sesiones independientes y únicamente la clave publicable/anon. Falla si recibe una `sb_secret_` o un JWT `service_role`. Por defecto exige que Dirección vea exactamente `TAM,YAR`, que el operario vea exactamente `TAM`, y que una lectura explícita de `YAR` como operario devuelva cero filas por RLS. Puede ajustarse el alcance esperado con `PILOT_DIRECTOR_PLANTS` y `PILOT_OPERATOR_PLANTS`.
+
+Este smoke no crea usuarios ni escribe datos. Certifica autenticación + aislamiento de lectura, pero no sustituye las transacciones funcionales siguientes.
+
+## 9. Smoke funcional multiusuario obligatorio
 Con dos perfiles de navegador distintos:
 1. La web pública abre sin sesión.
 2. `/app` redirige a `/login` sin sesión.
@@ -121,15 +141,16 @@ Con dos perfiles de navegador distintos:
 9. Consumo superior al lote es rechazado.
 10. Cerrar sesión invalida la navegación protegida y redirige a `/login`.
 
-## 9. Gate de promoción
+## 10. Gate de promoción
 Antes de promover el piloto:
 - CI de PR verde (`quality` + `database`);
 - `npm run pilot:backend-preflight -- --plants TAM,YAR` en PASS;
 - `npm run pilot:preflight` en PASS contra el SHA exacto desplegado;
-- smoke multiusuario aprobado;
+- `npm run pilot:rls-smoke` en PASS con los dos usuarios de prueba;
+- smoke funcional multiusuario aprobado;
 - redirects Auth configurados;
 - ningún secreto presente en GitHub, bundle cliente o logs;
 - web pública validada sin autenticación.
 
-## 10. Siguiente integración
+## 11. Siguiente integración
 SharePoint permanece como fuente documental e histórica. GREENATICS OPS es el sistema transaccional. La integración documental debe añadir referencias/lectura sin devolver las transacciones diarias a SharePoint.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:e2e": "playwright test",
     "bootstrap:director": "node scripts/bootstrap-director.mjs",
     "pilot:backend-preflight": "node scripts/hosted-backend-preflight.mjs",
+    "pilot:rls-smoke": "node scripts/hosted-rls-smoke.mjs",
     "pilot:preflight": "node scripts/hosted-pilot-preflight.mjs"
   },
   "dependencies": {

--- a/scripts/hosted-rls-smoke-lib.mjs
+++ b/scripts/hosted-rls-smoke-lib.mjs
@@ -1,0 +1,184 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { normalizePilotPlantCodes } from "./pilot-plant-codes.mjs";
+
+export class RlsSmokeError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "RlsSmokeError";
+  }
+}
+
+function clean(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeSupabaseUrl(value) {
+  let url;
+  try {
+    url = new URL(clean(value));
+  } catch {
+    throw new RlsSmokeError("NEXT_PUBLIC_SUPABASE_URL no es una URL válida.");
+  }
+
+  if (url.protocol !== "https:" || url.username || url.password || (url.pathname !== "/" && url.pathname !== "")) {
+    throw new RlsSmokeError("NEXT_PUBLIC_SUPABASE_URL debe ser un origen HTTPS sin credenciales ni ruta.");
+  }
+  return url.origin;
+}
+
+function decodeJwtPayload(value) {
+  const parts = value.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("payload");
+    }
+    return payload;
+  } catch {
+    throw new RlsSmokeError("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY parece un JWT inválido.");
+  }
+}
+
+export function validatePublishableKey(value) {
+  const key = clean(value);
+  if (!key || key.length > 8192) {
+    throw new RlsSmokeError("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY falta o tiene una longitud inválida.");
+  }
+  if (key.startsWith("sb_secret_")) {
+    throw new RlsSmokeError("El smoke RLS no acepta una clave secreta de Supabase.");
+  }
+
+  const payload = decodeJwtPayload(key);
+  if (payload?.role === "service_role") {
+    throw new RlsSmokeError("El smoke RLS no acepta un JWT service_role; debe ejecutarse con la clave publicable/anon.");
+  }
+  return key;
+}
+
+function credential(env, emailName, passwordName) {
+  const email = clean(env[emailName]).toLowerCase();
+  const password = typeof env[passwordName] === "string" ? env[passwordName] : "";
+  if (!email || !email.includes("@") || email.length > 320) {
+    throw new RlsSmokeError(`${emailName} falta o no es un correo válido.`);
+  }
+  if (!password || password.length > 4096) {
+    throw new RlsSmokeError(`${passwordName} falta o tiene una longitud inválida.`);
+  }
+  return Object.freeze({ email, password });
+}
+
+export function parseRlsSmokeConfig(env = process.env) {
+  const url = normalizeSupabaseUrl(env.NEXT_PUBLIC_SUPABASE_URL);
+  const publishableKey = validatePublishableKey(env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY);
+  const director = credential(env, "PILOT_DIRECTOR_EMAIL", "PILOT_DIRECTOR_PASSWORD");
+  const operator = credential(env, "PILOT_OPERATOR_EMAIL", "PILOT_OPERATOR_PASSWORD");
+  if (director.email === operator.email) {
+    throw new RlsSmokeError("Director y operario deben ser usuarios distintos.");
+  }
+
+  const directorPlants = normalizePilotPlantCodes(env.PILOT_DIRECTOR_PLANTS || "TAM,YAR");
+  const operatorPlants = normalizePilotPlantCodes(env.PILOT_OPERATOR_PLANTS || "TAM");
+  const directorSet = new Set(directorPlants);
+  const outsideDirectorScope = operatorPlants.filter((code) => !directorSet.has(code));
+  if (outsideDirectorScope.length) {
+    throw new RlsSmokeError(`El alcance esperado del operario no puede exceder al del director: ${outsideDirectorScope.join(", ")}.`);
+  }
+
+  return Object.freeze({ url, publishableKey, director, operator, directorPlants, operatorPlants });
+}
+
+function createUserClient(config, createClientImpl) {
+  return createClientImpl(config.url, config.publishableKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  });
+}
+
+async function signIn(client, credentials, label) {
+  const { error } = await client.auth.signInWithPassword(credentials);
+  if (error) throw new RlsSmokeError(`No fue posible autenticar el usuario de prueba ${label}: ${error.message || "error remoto"}.`);
+}
+
+async function visiblePlants(client, label) {
+  const { data, error } = await client.from("plants").select("code,name,active").order("code");
+  if (error) throw new RlsSmokeError(`No fue posible consultar plantas como ${label}: ${error.message || "error remoto"}.`);
+  if (!Array.isArray(data)) throw new RlsSmokeError(`Supabase devolvió una respuesta de plantas inválida para ${label}.`);
+
+  return data.map((row) => ({
+    code: String(row?.code || "").toUpperCase(),
+    active: row?.active === true,
+  }));
+}
+
+function assertExactVisibility(label, rows, expectedCodes) {
+  const codes = rows.map((row) => row.code);
+  if (codes.some((code) => !code) || new Set(codes).size !== codes.length) {
+    throw new RlsSmokeError(`La visibilidad de ${label} contiene códigos vacíos o duplicados.`);
+  }
+
+  const visible = [...codes].sort();
+  const expected = [...expectedCodes].sort();
+  if (visible.length !== expected.length || visible.some((code, index) => code !== expected[index])) {
+    throw new RlsSmokeError(`Visibilidad RLS inesperada para ${label}: esperado ${expected.join(",")}; visible ${visible.join(",") || "ninguna"}.`);
+  }
+
+  const inactive = rows.filter((row) => !row.active).map((row) => row.code);
+  if (inactive.length) {
+    throw new RlsSmokeError(`El usuario ${label} ve plantas piloto inactivas: ${inactive.join(",")}.`);
+  }
+  return Object.freeze(visible);
+}
+
+async function assertDeniedPlant(client, code) {
+  const { data, error } = await client.from("plants").select("code").eq("code", code).maybeSingle();
+  if (error) throw new RlsSmokeError(`La comprobación RLS explícita de ${code} falló con error remoto: ${error.message || "desconocido"}.`);
+  if (data !== null) {
+    throw new RlsSmokeError(`Fallo de aislamiento RLS: el operario pudo leer la planta ${code}.`);
+  }
+}
+
+async function safeSignOut(client) {
+  try {
+    await client.auth.signOut();
+  } catch {
+    // Cleanup must not replace the primary smoke result.
+  }
+}
+
+export async function runHostedRlsSmoke({ env = process.env, createClientImpl = createSupabaseClient } = {}) {
+  const config = parseRlsSmokeConfig(env);
+  const directorClient = createUserClient(config, createClientImpl);
+  const operatorClient = createUserClient(config, createClientImpl);
+
+  let directorSignedIn = false;
+  let operatorSignedIn = false;
+  try {
+    await signIn(directorClient, config.director, "director");
+    directorSignedIn = true;
+    const directorRows = await visiblePlants(directorClient, "director");
+    const directorVisible = assertExactVisibility("director", directorRows, config.directorPlants);
+
+    await signIn(operatorClient, config.operator, "operario");
+    operatorSignedIn = true;
+    const operatorRows = await visiblePlants(operatorClient, "operario");
+    const operatorVisible = assertExactVisibility("operario", operatorRows, config.operatorPlants);
+
+    const operatorSet = new Set(config.operatorPlants);
+    const deniedChecks = config.directorPlants.filter((code) => !operatorSet.has(code));
+    for (const code of deniedChecks) await assertDeniedPlant(operatorClient, code);
+
+    return Object.freeze({
+      directorPlants: directorVisible,
+      operatorPlants: operatorVisible,
+      deniedChecks: Object.freeze([...deniedChecks]),
+      checks: Object.freeze(["director-auth", "director-visibility", "operator-auth", "operator-visibility", "explicit-denial"]),
+    });
+  } finally {
+    if (operatorSignedIn) await safeSignOut(operatorClient);
+    if (directorSignedIn) await safeSignOut(directorClient);
+  }
+}

--- a/scripts/hosted-rls-smoke.mjs
+++ b/scripts/hosted-rls-smoke.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import { runHostedRlsSmoke } from "./hosted-rls-smoke-lib.mjs";
+
+function printHelp() {
+  console.log(`GREENATICS hosted RLS smoke · solo lectura
+
+Uso:
+  npm run pilot:rls-smoke
+
+Variables requeridas:
+  NEXT_PUBLIC_SUPABASE_URL
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  PILOT_DIRECTOR_EMAIL
+  PILOT_DIRECTOR_PASSWORD
+  PILOT_OPERATOR_EMAIL
+  PILOT_OPERATOR_PASSWORD
+
+Opcionales:
+  PILOT_DIRECTOR_PLANTS   Default: TAM,YAR
+  PILOT_OPERATOR_PLANTS   Default: TAM
+
+Las credenciales se leen únicamente desde variables de entorno. No se aceptan por argumentos CLI y no se imprimen en la salida.
+`);
+}
+
+async function main() {
+  if (process.argv.includes("--help")) {
+    printHelp();
+    return;
+  }
+  if (process.argv.length > 2) {
+    throw new Error("pilot:rls-smoke no acepta argumentos CLI; usa variables de entorno para credenciales y alcance esperado.");
+  }
+
+  const result = await runHostedRlsSmoke();
+  console.log("GREENATICS hosted RLS smoke: PASS");
+  console.log(`director-plants: ${result.directorPlants.join(",")}`);
+  console.log(`operator-plants: ${result.operatorPlants.join(",")}`);
+  console.log(`denied-checks: ${result.deniedChecks.join(",") || "none"}`);
+  console.log(`checks: ${result.checks.join(", ")}`);
+}
+
+main().catch((error) => {
+  console.error(`GREENATICS hosted RLS smoke: FAIL · ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/hosted-rls-smoke.test.mjs
+++ b/scripts/hosted-rls-smoke.test.mjs
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  RlsSmokeError,
+  parseRlsSmokeConfig,
+  runHostedRlsSmoke,
+  validatePublishableKey,
+} from "./hosted-rls-smoke-lib.mjs";
+
+const baseEnv = {
+  NEXT_PUBLIC_SUPABASE_URL: "https://sanitized-project.supabase.co",
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_sanitized_test_key",
+  PILOT_DIRECTOR_EMAIL: "director@example.test",
+  PILOT_DIRECTOR_PASSWORD: "director-test-password",
+  PILOT_OPERATOR_EMAIL: "operator@example.test",
+  PILOT_OPERATOR_PASSWORD: "operator-test-password",
+};
+
+function fakeJwt(payload) {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.sanitized-signature`;
+}
+
+function plantQuery(visibleCodes, deniedReads) {
+  return {
+    select() {
+      return {
+        async order() {
+          return {
+            data: [...visibleCodes].sort().map((code) => ({ code, name: code, active: true })),
+            error: null,
+          };
+        },
+        eq(_column, code) {
+          return {
+            async maybeSingle() {
+              deniedReads.push(code);
+              return visibleCodes.includes(code)
+                ? { data: { code }, error: null }
+                : { data: null, error: null };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function fakeUserClient(visibleCodes) {
+  const deniedReads = [];
+  const signInWithPassword = vi.fn(async () => ({ data: { user: { id: "sanitized-user" } }, error: null }));
+  const signOut = vi.fn(async () => ({ error: null }));
+  return {
+    client: {
+      auth: { signInWithPassword, signOut },
+      from(table) {
+        if (table !== "plants") throw new Error(`Unexpected table ${table}`);
+        return plantQuery(visibleCodes, deniedReads);
+      },
+    },
+    deniedReads,
+    signInWithPassword,
+    signOut,
+  };
+}
+
+describe("hosted multiuser RLS smoke", () => {
+  it("rejects secret/service-role keys instead of accidentally bypassing RLS", () => {
+    expect(() => validatePublishableKey("sb_secret_sanitized")).toThrow(RlsSmokeError);
+    expect(() => validatePublishableKey(fakeJwt({ role: "service_role" }))).toThrow(/service_role/);
+    expect(validatePublishableKey(fakeJwt({ role: "anon" }))).toContain(".");
+  });
+
+  it("normalizes expected plant aliases while keeping credentials out of the returned config shape used by results", () => {
+    const config = parseRlsSmokeConfig({
+      ...baseEnv,
+      PILOT_DIRECTOR_PLANTS: "Támesis,Yarumal",
+      PILOT_OPERATOR_PLANTS: "tamesis",
+    });
+    expect(config.directorPlants).toEqual(["TAM", "YAR"]);
+    expect(config.operatorPlants).toEqual(["TAM"]);
+    expect(config.publishableKey).toBe(baseEnv.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY);
+  });
+
+  it("certifies director TAM/YAR visibility and explicit YAR denial for a TAM-only operator", async () => {
+    const director = fakeUserClient(["TAM", "YAR"]);
+    const operator = fakeUserClient(["TAM"]);
+    const clients = [director.client, operator.client];
+    const createClientImpl = vi.fn(() => clients.shift());
+
+    const result = await runHostedRlsSmoke({ env: baseEnv, createClientImpl });
+
+    expect(result).toEqual({
+      directorPlants: ["TAM", "YAR"],
+      operatorPlants: ["TAM"],
+      deniedChecks: ["YAR"],
+      checks: ["director-auth", "director-visibility", "operator-auth", "operator-visibility", "explicit-denial"],
+    });
+    expect(operator.deniedReads).toEqual(["YAR"]);
+    expect(director.signInWithPassword).toHaveBeenCalledWith({
+      email: baseEnv.PILOT_DIRECTOR_EMAIL,
+      password: baseEnv.PILOT_DIRECTOR_PASSWORD,
+    });
+    expect(operator.signInWithPassword).toHaveBeenCalledWith({
+      email: baseEnv.PILOT_OPERATOR_EMAIL,
+      password: baseEnv.PILOT_OPERATOR_PASSWORD,
+    });
+    expect(director.signOut).toHaveBeenCalledOnce();
+    expect(operator.signOut).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed if the operator can see YAR", async () => {
+    const director = fakeUserClient(["TAM", "YAR"]);
+    const operator = fakeUserClient(["TAM", "YAR"]);
+    const clients = [director.client, operator.client];
+
+    await expect(runHostedRlsSmoke({
+      env: baseEnv,
+      createClientImpl: () => clients.shift(),
+    })).rejects.toThrow(/Visibilidad RLS inesperada para operario/);
+
+    expect(director.signOut).toHaveBeenCalledOnce();
+    expect(operator.signOut).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed if the director cannot see all expected pilot plants", async () => {
+    const director = fakeUserClient(["TAM"]);
+    const operator = fakeUserClient(["TAM"]);
+    const clients = [director.client, operator.client];
+
+    await expect(runHostedRlsSmoke({
+      env: baseEnv,
+      createClientImpl: () => clients.shift(),
+    })).rejects.toThrow(/Visibilidad RLS inesperada para director/);
+
+    expect(director.signOut).toHaveBeenCalledOnce();
+    expect(operator.signOut).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #81

## Qué cambia
- añade `npm run pilot:rls-smoke`;
- usa dos clientes Supabase independientes con clave publicable/anon;
- credenciales únicamente por variables de entorno, nunca argumentos CLI;
- rechaza `sb_secret_` y JWT `service_role` para impedir falsos positivos por bypass de RLS;
- exige por defecto Director = `TAM,YAR`, Operario = `TAM`;
- hace una lectura explícita de `YAR` como operario y exige cero filas;
- cierra ambas sesiones en `finally`;
- añade unit tests con clientes simulados y actualiza el runbook.

## Límite
No crea usuarios ni escribe datos. El smoke queda listo pero no puede ejecutarse contra el backend real hasta que existan los dos usuarios de prueba; actualmente el Supabase hospedado tiene 0 usuarios Auth.