### PR TITLE
Public v0.15 · Editorial polish + governed project evidence

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -22,6 +22,15 @@ Operacional, clara, sobria, moderna y confiable. Debe sentirse más cerca de sof
 - La tecnología de sólidos organominerales puede visualizar matriz orgánica → formulación/oclusión → peletizado → suelo → disponibilidad gradual cuando la afirmación esté soportada.
 - Los estados regulatorios/comerciales de bioinsumos deben ser visibles cuando condicionen compra, cotización o uso.
 
+### Lenguaje editorial público V0.15
+- La referencia de tono es **editorial premium / heritage contemporáneo**, nunca la copia literal de otra marca o de sus activos.
+- Combinar serif editorial de gran escala para titulares con sans neutral y muy legible para navegación, cuerpo y datos.
+- Preferir composiciones asimétricas, bandas de color plano, reglas finas, numeración editorial y espacios amplios sobre grids de tarjetas repetitivas.
+- Los elementos gráficos de color plano —logos, isotipos, tipografía, bandas, iconos y fondos definidos como planos— permanecen uniformes: sin grano, dithering, textura, claroscuro, degradado o sombreado interno.
+- La fotografía documental debe incluir contexto/procedencia cuando sea necesario. Una imagen histórica acredita experiencia documentada, no capacidad, producción o estado actual.
+- El HOME prioriza la narrativa **Greenatics → Wondergreen → rutas de solución → evidencia real → tecnología → conocimiento → impacto**, evitando que el acceso a OPS domine la experiencia pública.
+- El color amarillo/lima funciona como acento estructural; el verde bosque, crema y blanco construyen la mayor parte de la superficie. El color no sustituye jerarquía ni significado.
+
 ## Dirección visual GREENATICS OPS
 - Operación móvil: velocidad, botones grandes, lectura inmediata.
 - Dirección desktop/tablet: densidad media-alta, jerarquía clara, comparación rápida.

--- a/e2e/ops-access-isolation.spec.ts
+++ b/e2e/ops-access-isolation.spec.ts
@@ -4,7 +4,7 @@ const OPS_STORAGE_KEY = "greenatics-ops-mvp-001";
 
 test("public routes do not mount or persist the local OPS store", async ({ page }) => {
   await page.goto("/");
-  await expect(page.getByRole("heading", { name: /Convertimos residuos orgánicos/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Transformar residuos en vida/i })).toBeVisible();
   await page.waitForTimeout(100);
   await expect.poll(() => page.evaluate((key) => window.localStorage.getItem(key), OPS_STORAGE_KEY)).toBeNull();
 });

--- a/e2e/public-editorial-home.spec.ts
+++ b/e2e/public-editorial-home.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test("public HOME presents the editorial hierarchy and governed Yarumal evidence", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: /Transformar residuos en vida/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Más que NPK." })).toBeVisible();
+  await expect(page.getByRole("img", { name: "Vista aérea documentada de la planta de Yarumal" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Ver caso Yarumal →" })).toHaveAttribute("href", "/proyectos/yarumal");
+  await expect(page.getByText(/Product Truth vigente/i)).toBeVisible();
+});
+
+test("public HOME keeps its primary routes explicit and separate from OPS", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("link", { name: "Descubrir Wondergreen" })).toHaveAttribute("href", "/wondergreen");
+  await expect(page.getByRole("link", { name: "Explorar soluciones", exact: true }).first()).toHaveAttribute("href", "/soluciones");
+  await expect(page.getByRole("link", { name: "Contactar a Greenatics" })).toHaveAttribute("href", "/contacto");
+  await expect(page.getByRole("link", { name: "Acceder a la app interna" })).toHaveAttribute("href", "/app");
+});

--- a/e2e/public-web.spec.ts
+++ b/e2e/public-web.spec.ts
@@ -3,10 +3,10 @@ import { test, expect } from "@playwright/test";
 test("public home presents Greenatics and links to OPS", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: /Convertimos residuos orgánicos/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Transformar residuos en vida/i })).toBeVisible();
   await expect(page.getByRole("img", { name: "Greenatics" }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: "Acceder a Greenatics" })).toHaveAttribute("href", "/app");
-  await expect(page.getByRole("heading", { name: /Suelo, nutrición y biología trabajando como un sistema/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Más que NPK." })).toBeVisible();
   await expect(page.getByText("5", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("referencias líquidas", { exact: true })).toBeVisible();
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,8 +10,9 @@ export const metadata: Metadata = {
   alternates: { canonical: "/" },
 };
 
-const doors = [
+const entryPoints = [
   {
+    number: "01",
     kicker: "Producto agrícola",
     title: "Wondergreen",
     copy: "Fertilizantes organominerales sólidos y líquidos, compost, bioinsumos, guías por cultivo y acompañamiento técnico.",
@@ -19,6 +20,7 @@ const doors = [
     cta: "Conocer Wondergreen",
   },
   {
+    number: "02",
     kicker: "Territorios",
     title: "Municipios y ESP",
     copy: "Diagnóstico, rutas selectivas, plantas, rehabilitación, operación y trazabilidad para convertir planeación en capacidad real.",
@@ -26,6 +28,7 @@ const doors = [
     cta: "Explorar soluciones",
   },
   {
+    number: "03",
     kicker: "Generadores",
     title: "Empresas",
     copy: "Caracterización, separación, recolección, tratamiento, infraestructura y evidencia para corrientes orgánicas empresariales.",
@@ -33,12 +36,21 @@ const doors = [
     cta: "Explorar soluciones",
   },
   {
+    number: "04",
     kicker: "Ingeniería + biología",
     title: "Plantas y tecnología",
     copy: "Compostaje, digestión anaerobia, biogás, biol, fertilizantes y operación basada en parámetros, mantenimiento y datos.",
     href: "/#tecnologia",
     cta: "Entender la tecnología",
   },
+];
+
+const cycleMarks = [
+  ["01", "Residuo", "Caracterizar"],
+  ["02", "Bioproceso", "Transformar"],
+  ["03", "Recurso", "Valorizar"],
+  ["04", "Suelo", "Retornar"],
+  ["05", "Datos", "Medir"],
 ];
 
 const chain = [
@@ -77,62 +89,122 @@ export default function Home() {
     <PublicShell>
       <div className={styles.publicSite}>
         <section className={styles.hero}>
+          <div className={styles.heroAccent} aria-hidden="true" />
           <div className={`${styles.container} ${styles.heroGrid}`}>
-            <div>
-              <div className={styles.heroBrand}>
-                <img src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
-              </div>
-              <span className={styles.eyebrow}>Economía circular aplicada · Colombia</span>
+            <div className={styles.heroCopy}>
+              <span className={styles.eyebrow}>Greenatics · Economía circular aplicada · Colombia</span>
               <h1>
-                Convertimos residuos orgánicos en <em>sistemas que devuelven valor al territorio y al suelo.</em>
+                Transformar residuos <em>en vida.</em>
               </h1>
               <p className={styles.lead}>
-                Greenatics conecta planeación, aprovechamiento, plantas, biotecnología, operación, Wondergreen y datos. No trabajamos una etapa aislada: diseñamos cómo el residuo entra, se transforma, se controla y vuelve al ciclo productivo.
+                Diseñamos y operamos sistemas que conectan residuos orgánicos, tecnología, territorio, suelo, Wondergreen y datos. El objetivo no es mover el residuo de lugar: es devolverle una función dentro del ciclo productivo.
               </p>
               <div className={styles.buttonRow}>
                 <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/wondergreen">Descubrir Wondergreen</Link>
-                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/soluciones">Conocer nuestras soluciones</Link>
+                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/soluciones">Explorar soluciones</Link>
+              </div>
+              <div className={styles.heroMeta} aria-label="Capacidades Greenatics">
+                <span>Planeación</span>
+                <span>Infraestructura</span>
+                <span>Operación</span>
+                <span>Producto</span>
+                <span>Trazabilidad</span>
               </div>
             </div>
 
-            <div className={styles.cycleVisual} aria-label="Ciclo Greenatics: residuo, bioproceso, recurso, suelo y datos">
-              <div className={styles.cycleCenter}>
-                <img src="/brand/greenatics-symbol.svg" alt="" aria-hidden="true" />
+            <aside className={styles.cycleLedger} aria-label="Ciclo Greenatics: residuo, bioproceso, recurso, suelo y datos">
+              <div className={styles.cycleLedgerTop}>
+                <div className={styles.cycleSymbol}>
+                  <img src="/brand/greenatics-symbol.svg" alt="" aria-hidden="true" />
+                </div>
+                <div>
+                  <span>El ciclo Greenatics</span>
+                  <strong>Una cadena, no piezas sueltas.</strong>
+                </div>
               </div>
-              <div className={`${styles.cycleNode} ${styles.node1}`}><strong>01</strong><span>Residuo</span></div>
-              <div className={`${styles.cycleNode} ${styles.node2}`}><strong>02</strong><span>Bioproceso</span></div>
-              <div className={`${styles.cycleNode} ${styles.node3}`}><strong>03</strong><span>Recurso</span></div>
-              <div className={`${styles.cycleNode} ${styles.node4}`}><strong>04</strong><span>Suelo</span></div>
-              <div className={`${styles.cycleNode} ${styles.node5}`}><strong>05</strong><span>Datos</span></div>
-            </div>
+              <div className={styles.cycleLedgerBody}>
+                {cycleMarks.map(([number, title, action]) => (
+                  <div className={styles.cycleLedgerRow} key={number}>
+                    <span>{number}</span>
+                    <strong>{title}</strong>
+                    <small>{action}</small>
+                  </div>
+                ))}
+              </div>
+              <p className={styles.cycleLedgerFoot}>Residuo → recurso → suelo → evidencia.</p>
+            </aside>
           </div>
         </section>
 
         <section className={styles.definition}>
-          <div className={`${styles.container} ${styles.definitionGrid}`}>
+          <div className={`${styles.container} ${styles.editorialSplit}`}>
+            <div className={styles.sectionIndex}>01</div>
             <div>
               <span className={styles.eyebrow}>Qué es Greenatics</span>
-              <h2>Una plataforma de aprovechamiento orgánico con una cadena completa de servicios, tecnología y producto.</h2>
+              <h2>No tratamos una etapa. Diseñamos el ciclo completo.</h2>
             </div>
-            <div>
+            <div className={styles.editorialCopy}>
               <p>
-                No somos únicamente una empresa de fertilizantes y tampoco únicamente una empresa de residuos. Greenatics une ambas puntas: gestionar biomasa residual de manera técnicamente controlada y convertir parte de ese proceso en recursos que puedan retornar a sistemas productivos, con información suficiente para operar, medir y aprender.
+                Greenatics une dos puntas que suelen operar separadas: gestionar biomasa residual de manera técnicamente controlada y convertir parte de ese proceso en recursos que puedan retornar a sistemas productivos. Planeación, recolección, plantas, bioprocesos, operación, producto y datos se conectan en una misma lógica.
               </p>
-              <Link className={styles.inlineLink} href="/soluciones">Ver cómo cerramos el ciclo →</Link>
+              <Link className={styles.inlineLink} href="/soluciones">Ver la arquitectura de soluciones →</Link>
             </div>
           </div>
         </section>
 
-        <section className={styles.doors} id="soluciones">
+        <section className={styles.wondergreen} id="wondergreen">
+          <div className={styles.container}>
+            <div className={styles.wgHeader}>
+              <div>
+                <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Wondergreen · Producto agrícola</span>
+                <img className={styles.wgLogo} src="/brand/wondergreen-nutrients.webp" alt="Wondergreen Nutrients" width="420" height="221" />
+                <h2>Más que NPK.</h2>
+              </div>
+              <div className={styles.wgLead}>
+                <p>
+                  Wondergreen integra suelo, nutrición, biología, conocimiento y acompañamiento. El portafolio se entiende como un sistema alrededor del cultivo y de su etapa, no como una colección de fórmulas aisladas.
+                </p>
+                <div className={styles.buttonRow}>
+                  <Link className={`${styles.button} ${styles.buttonLight}`} href="/wondergreen">Explorar Wondergreen</Link>
+                  <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/wondergreen/cultivos">Ver cultivos</Link>
+                </div>
+              </div>
+            </div>
+
+            <div className={styles.wgSystem}>
+              {wgSystem.map(([kicker, title, copy], index) => (
+                <article key={title}>
+                  <span className={styles.wgNumber}>0{index + 1}</span>
+                  <small>{kicker}</small>
+                  <h3>{title}</h3>
+                  <p>{copy}</p>
+                </article>
+              ))}
+            </div>
+
+            <div className={styles.wgStats} aria-label="Arquitectura vigente del portafolio Wondergreen">
+              <div><strong>5</strong><span>referencias líquidas</span></div>
+              <div><strong>4</strong><span>referencias sólidas</span></div>
+              <div><strong>+ compost</strong><span>y familia de bioinsumos</span></div>
+              <p>Disponibilidad, composición, dosis y condición comercial se publican únicamente desde Product Truth vigente.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.paths} id="soluciones">
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Cuatro puertas de entrada</span>
-              <h2>Empieza por lo que necesitas resolver hoy.</h2>
+              <h2>Empieza por el problema que necesitas resolver.</h2>
+              <p>La ruta cambia según el residuo, el cultivo, el territorio y la infraestructura existente.</p>
             </div>
-            <div className={styles.doorGrid}>
-              {doors.map((item) => (
-                <article className={styles.doorCard} key={item.title}>
-                  <span className={styles.eyebrow}>{item.kicker}</span>
+            <div className={styles.pathGrid}>
+              {entryPoints.map((item) => (
+                <article className={styles.pathItem} key={item.title}>
+                  <div className={styles.pathTop}>
+                    <span>{item.number}</span>
+                    <small>{item.kicker}</small>
+                  </div>
                   <h3>{item.title}</h3>
                   <p>{item.copy}</p>
                   <Link href={item.href}>{item.cta} →</Link>
@@ -142,60 +214,53 @@ export default function Home() {
             <div className={styles.router}>
               <div>
                 <strong>¿Tienes un residuo, un cultivo o un proyecto por resolver?</strong>
-                <span>La web enruta cada caso antes de recomendar producto, planta o servicio.</span>
+                <span>Primero entendemos el caso; luego definimos producto, servicio o infraestructura.</span>
               </div>
               <Link className={`${styles.button} ${styles.buttonDark}`} href="/contacto">Hablar con Greenatics</Link>
             </div>
           </div>
         </section>
 
-        <section className={styles.chain}>
-          <div className={styles.container}>
-            <div className={styles.sectionHeading}>
-              <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Cómo cerramos el ciclo</span>
-              <h2>Del generador al dato y del dato a la mejora.</h2>
-              <p>La propuesta se vuelve concreta cuando cada eslabón tiene una función y una salida verificable.</p>
-            </div>
-            <div className={styles.chainGrid}>
-              {chain.map(([number, title, copy]) => (
-                <article className={styles.chainCard} key={number}>
-                  <span>{number}</span><strong>{title}</strong><p>{copy}</p>
-                </article>
-              ))}
+        <section className={styles.evidence}>
+          <div className={`${styles.container} ${styles.evidenceGrid}`}>
+            <figure className={styles.evidenceMedia}>
+              <img
+                src="/projects/yarumal/aerial-01.webp"
+                alt="Vista aérea documentada de la planta de Yarumal"
+                width="1200"
+                height="900"
+              />
+              <figcaption>Archivo de proyecto · Yarumal · experiencia documentada</figcaption>
+            </figure>
+            <div className={styles.evidenceCopy}>
+              <span className={styles.eyebrow}>Experiencia que deja evidencia</span>
+              <h2>Proyecto, operación y aprendizaje en territorio.</h2>
+              <p>
+                La web empieza a incorporar material real de los proyectos para explicar lo que Greenatics ha construido y aprendido. Las fotografías históricas documentan experiencia; no se usan para afirmar capacidad, producción o estado actual sin una fuente vigente y aprobada.
+              </p>
+              <div className={styles.evidenceFacts}>
+                <div><span>Caso</span><strong>Yarumal</strong></div>
+                <div><span>Estado de publicación</span><strong>Experiencia documentada</strong></div>
+              </div>
+              <Link className={styles.inlineLink} href="/proyectos/yarumal">Ver caso Yarumal →</Link>
             </div>
           </div>
         </section>
 
-        <section className={styles.wondergreen} id="wondergreen">
+        <section className={styles.chain}>
           <div className={styles.container}>
-            <div className={styles.wgIntro}>
-              <div>
-                <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Wondergreen · producto agrícola</span>
-                <img className={styles.wgLogo} src="/brand/wondergreen-nutrients.webp" alt="Wondergreen Nutrients" width="420" height="221" />
-                <h2>Suelo, nutrición y biología trabajando como un sistema.</h2>
-              </div>
-              <div>
-                <p>
-                  Wondergreen integra materia orgánica, fertilizantes organominerales sólidos y líquidos, compost y bioinsumos dentro de programas pensados alrededor del cultivo, su etapa, condición y objetivo.
-                </p>
-                <div className={styles.wgStats}>
-                  <div className={styles.wgStat}><strong>5</strong><span>referencias líquidas</span></div>
-                  <div className={styles.wgStat}><strong>4</strong><span>referencias sólidas</span></div>
-                  <div className={styles.wgStat}><strong>+ compost</strong><span>y familia de bioinsumos</span></div>
-                </div>
-              </div>
+            <div className={styles.chainHeading}>
+              <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Cómo cerramos el ciclo</span>
+              <h2>Del generador al dato. Del dato a la mejora.</h2>
+              <p>La propuesta se vuelve concreta cuando cada eslabón tiene una función y una salida verificable.</p>
             </div>
-
-            <div className={styles.wgSystem}>
-              {wgSystem.map(([kicker, title, copy]) => (
-                <article key={title}>
-                  <span>{kicker}</span><h3>{title}</h3><p>{copy}</p>
+            <div className={styles.chainGrid}>
+              {chain.map(([number, title, copy]) => (
+                <article className={styles.chainItem} key={number}>
+                  <span>{number}</span>
+                  <div><strong>{title}</strong><p>{copy}</p></div>
                 </article>
               ))}
-            </div>
-            <div className={styles.buttonRow}>
-              <Link className={`${styles.button} ${styles.buttonLight}`} href="/wondergreen">Explorar Wondergreen</Link>
-              <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/wondergreen/cultivos">Ver conocimiento por cultivo</Link>
             </div>
           </div>
         </section>
@@ -203,16 +268,18 @@ export default function Home() {
         <section className={styles.technology} id="tecnologia">
           <div className={`${styles.container} ${styles.techGrid}`}>
             <div className={styles.techCopy}>
-              <span className={styles.eyebrow}>Wondergreen · Más que NPK</span>
-              <h2>Una forma diferente de integrar nutrientes y materia orgánica en el suelo.</h2>
+              <span className={styles.eyebrow}>Wondergreen · Tecnología de sólidos</span>
+              <h2>La formulación importa tanto como el número de la etiqueta.</h2>
               <p>
-                En las referencias sólidas que correspondan, la tecnología Wondergreen se explica desde la matriz organomineral, la oclusión y el peletizado. La web diferenciará siempre entre una característica documentada del producto y un efecto agronómico que todavía requiera evidencia específica.
+                En las referencias sólidas que correspondan, Wondergreen se explica desde la matriz organomineral, la oclusión y el peletizado. La web diferencia siempre una característica documentada del producto de cualquier efecto agronómico que todavía requiera evidencia específica.
               </p>
+              <Link className={styles.inlineLink} href="/wondergreen">Ir al Product Master público →</Link>
             </div>
             <div className={styles.techFlow}>
               {techSteps.map(([number, title, copy]) => (
                 <div className={styles.techStep} key={number}>
-                  <span>{number}</span><div><strong>{title}</strong><small>{copy}</small></div>
+                  <span>{number}</span>
+                  <div><strong>{title}</strong><small>{copy}</small></div>
                 </div>
               ))}
             </div>
@@ -223,13 +290,16 @@ export default function Home() {
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Conocimiento que se usa</span>
-              <h2>Las guías dejan de vivir escondidas en un PDF.</h2>
-              <p>El conocimiento ya construido en Greenatics Marketing Studio se está convirtiendo en rutas web conectadas a cultivos, productos, síntomas y acompañamiento.</p>
+              <h2>De documentos aislados a rutas técnicas navegables.</h2>
+              <p>La biblioteca conecta cultivos, síntomas, criterios de diagnóstico y familias de producto sin convertir una lectura visual en una prescripción automática.</p>
             </div>
             <div className={styles.knowledgeGrid}>
-              {knowledge.map(([title, copy]) => (
-                <article className={styles.knowledgeCard} key={title}>
-                  <span className={styles.eyebrow}>Biblioteca Wondergreen</span><h3>{title}</h3><p>{copy}</p><Link href="/biblioteca">Explorar biblioteca →</Link>
+              {knowledge.map(([title, copy], index) => (
+                <article className={styles.knowledgeItem} key={title}>
+                  <span>0{index + 1}</span>
+                  <h3>{title}</h3>
+                  <p>{copy}</p>
+                  <Link href="/biblioteca">Explorar biblioteca →</Link>
                 </article>
               ))}
             </div>
@@ -240,7 +310,7 @@ export default function Home() {
           <div className={`${styles.container} ${styles.impactGrid}`}>
             <div>
               <span className={styles.eyebrow}>Impacto conectado a la operación</span>
-              <h2>Preferimos un dato pendiente a una cifra espectacular sin trazabilidad.</h2>
+              <h2>Un dato verificable vale más que una cifra espectacular.</h2>
               <p>
                 GREENATICS OPS conecta recepción, proceso, producción, inventario, comercial y otros dominios internos. La capa pública solo muestra indicadores conciliados, aprobados, fechados y con metodología cuando corresponda.
               </p>
@@ -260,7 +330,11 @@ export default function Home() {
 
         <section className={styles.closing} id="contacto">
           <div className={`${styles.container} ${styles.closingInner}`}>
-            <div><span className={styles.eyebrow}>Greenatics</span><h2>¿Tienes un residuo, un cultivo, una planta o un territorio por transformar?</h2></div>
+            <div>
+              <span className={styles.eyebrow}>Greenatics</span>
+              <h2>¿Qué quieres devolver al ciclo?</h2>
+              <p>Un residuo, un cultivo, una planta o un territorio pueden ser el punto de entrada.</p>
+            </div>
             <div className={styles.buttonRow}>
               <Link className={`${styles.button} ${styles.buttonDark}`} href="/contacto">Contactar a Greenatics</Link>
               <a className={`${styles.button} ${styles.buttonGhost}`} href="/app">Acceder a la app interna</a>

--- a/src/app/public-home.module.css
+++ b/src/app/public-home.module.css
@@ -1,226 +1,1118 @@
 .publicSite {
-  --green950: #14352c;
-  --green800: #006b45;
-  --green700: #008b4c;
-  --green500: #48a942;
-  --lime400: #98cf4f;
-  --yellow400: #f4d944;
-  --ink: #17201c;
-  --muted: #647068;
-  --paper: #f7f8f3;
+  --forest: #12372c;
+  --forest-deep: #0b241c;
+  --green: #0a7a4b;
+  --green-soft: #4c9b4a;
+  --lime: #b8d65f;
+  --sun: #ddc952;
+  --ink: #18241f;
+  --muted: #69736d;
+  --paper: #fbfaf5;
+  --cream: #f0ede3;
   --white: #ffffff;
-  --line: #dfe5dc;
-  --radiusSm: 14px;
-  --radiusMd: 24px;
-  --radiusLg: 38px;
-  --shadow: 0 24px 70px rgba(20, 53, 44, 0.12);
+  --line: rgba(24, 36, 31, 0.16);
+  --line-dark: rgba(255, 255, 255, 0.18);
+  --display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Baskerville, Georgia, serif;
+  --sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: var(--ink);
   background: var(--paper);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--sans);
   line-height: 1.55;
   min-height: 100vh;
 }
 
-.publicSite *, .publicSite *::before, .publicSite *::after { box-sizing: border-box; }
-.publicSite a { color: inherit; text-decoration: none; }
-.container { width: min(1180px, calc(100% - 40px)); margin: 0 auto; }
-
-.header {
-  position: sticky;
-  top: 0;
-  z-index: 40;
-  background: rgba(247, 248, 243, 0.94);
-  backdrop-filter: blur(16px);
-  border-bottom: 1px solid rgba(223, 229, 220, 0.85);
+.publicSite *,
+.publicSite *::before,
+.publicSite *::after {
+  box-sizing: border-box;
 }
-.headerInner { min-height: 76px; display: flex; align-items: center; gap: 26px; }
-.brandLink { margin-right: auto; display: inline-flex; align-items: center; }
-.brandLogo { width: 184px; height: auto; display: block; }
-.nav { display: flex; align-items: center; gap: 22px; font-size: 0.92rem; }
-.nav a { transition: color 160ms ease; }
-.nav a:hover { color: var(--green700); }
-.headerActions { display: flex; gap: 10px; align-items: center; }
 
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 46px;
-  padding: 0 20px;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  font-weight: 800;
-  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+.publicSite a {
+  color: inherit;
+  text-decoration: none;
 }
-.button:hover { transform: translateY(-1px); }
-.buttonPrimary { background: var(--green700); color: white !important; }
-.buttonDark { background: var(--green950); color: white !important; }
-.buttonLight { background: white; color: var(--green950) !important; }
-.buttonGhost { border-color: var(--line); background: transparent; }
-.buttonOutlineLight { border-color: rgba(255,255,255,.48); color: white !important; }
-.buttonRow { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 30px; }
+
+.publicSite a:focus-visible,
+.publicSite button:focus-visible {
+  outline: 3px solid var(--sun);
+  outline-offset: 4px;
+}
+
+.container {
+  width: min(1240px, calc(100% - 48px));
+  margin: 0 auto;
+}
+
+.publicSite h1,
+.publicSite h2,
+.publicSite h3 {
+  margin: 0;
+  font-family: var(--display);
+  font-weight: 600;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+}
+
+.publicSite h1 {
+  font-size: clamp(4.4rem, 8.2vw, 8.2rem);
+  max-width: 890px;
+}
+
+.publicSite h2 {
+  font-size: clamp(3rem, 5.2vw, 5.6rem);
+}
+
+.publicSite h3 {
+  font-size: clamp(1.8rem, 2.4vw, 2.6rem);
+}
 
 .eyebrow {
   display: inline-block;
-  color: var(--green700);
-  font-size: 0.74rem;
-  font-weight: 900;
-  letter-spacing: 0.12em;
+  margin-bottom: 16px;
+  color: var(--green);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
   text-transform: uppercase;
-  margin-bottom: 12px;
 }
-.eyebrowLight { color: #d8ffbe; }
-.publicSite h1, .publicSite h2, .publicSite h3 {
-  margin: 0;
-  font-family: "Arial Rounded MT", "Arial Rounded MT Bold", Arial, sans-serif;
-  line-height: 1.04;
-  letter-spacing: -0.035em;
+
+.eyebrowLight {
+  color: #d8ed9c;
 }
-.publicSite h1 { font-size: clamp(3rem, 6vw, 6rem); }
-.publicSite h2 { font-size: clamp(2.1rem, 4vw, 4rem); }
-.publicSite h3 { font-size: 1.42rem; }
-.lead { font-size: clamp(1.08rem, 2vw, 1.3rem); color: #526058; max-width: 720px; }
-.sectionHeading { max-width: 780px; margin-bottom: 38px; }
-.sectionHeading p { color: var(--muted); font-size: 1.05rem; }
+
+.buttonRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 30px;
+}
+
+.button {
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 20px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+  transition: transform 160ms ease, background-color 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+}
+
+.buttonPrimary {
+  background: var(--green);
+  color: var(--white) !important;
+}
+
+.buttonDark {
+  background: var(--forest-deep);
+  color: var(--white) !important;
+}
+
+.buttonGhost {
+  border-color: var(--line);
+  background: transparent;
+}
+
+.buttonLight {
+  background: var(--paper);
+  color: var(--forest-deep) !important;
+}
+
+.buttonOutlineLight {
+  border-color: rgba(255, 255, 255, 0.48);
+  color: var(--white) !important;
+}
+
+.inlineLink {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  color: var(--green) !important;
+  font-weight: 800;
+  border-bottom: 1px solid currentColor;
+}
 
 .hero {
-  min-height: 720px;
+  position: relative;
+  overflow: hidden;
+  background: var(--cream);
+  border-bottom: 1px solid var(--line);
+}
+
+.heroAccent {
+  height: 8px;
+  background: var(--lime);
+}
+
+.heroGrid {
+  min-height: 760px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(340px, 0.75fr);
+  gap: 82px;
+  align-items: center;
+  padding: 88px 0 96px;
+}
+
+.heroCopy {
+  min-width: 0;
+}
+
+.hero h1 em {
+  display: block;
+  color: var(--green);
+  font-style: italic;
+  font-weight: 500;
+}
+
+.lead {
+  max-width: 760px;
+  margin: 30px 0 0;
+  color: #4c5b53;
+  font-size: clamp(1.08rem, 1.7vw, 1.34rem);
+  line-height: 1.65;
+}
+
+.heroMeta {
+  margin-top: 46px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 22px;
+  color: #5a665f;
+  font-size: 0.78rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cycleLedger {
+  align-self: stretch;
+  max-height: 640px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: var(--forest);
+  color: var(--white);
+  padding: 34px;
+  border-left: 8px solid var(--sun);
+}
+
+.cycleLedgerTop {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  padding-bottom: 28px;
+  border-bottom: 1px solid var(--line-dark);
+}
+
+.cycleLedgerTop > div:last-child {
+  display: grid;
+  gap: 2px;
+}
+
+.cycleLedgerTop span {
+  color: #c8d6ce;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.cycleLedgerTop strong {
+  font-family: var(--display);
+  font-size: 1.55rem;
+  font-weight: 600;
+}
+
+.cycleSymbol {
+  width: 58px;
+  height: 58px;
+  flex: 0 0 58px;
+  display: grid;
+  place-items: center;
+  background: var(--lime);
+}
+
+.cycleSymbol img {
+  width: 34px;
+  height: 34px;
+  object-fit: contain;
+}
+
+.cycleLedgerBody {
+  display: grid;
+}
+
+.cycleLedgerRow {
+  min-height: 72px;
+  display: grid;
+  grid-template-columns: 42px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid var(--line-dark);
+}
+
+.cycleLedgerRow > span {
+  color: #d8ed9c;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.cycleLedgerRow strong {
+  font-family: var(--display);
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.cycleLedgerRow small {
+  color: #aebfb5;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cycleLedgerFoot {
+  margin: 26px 0 0;
+  color: #d8ed9c;
+  font-size: 0.84rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.definition {
+  padding: 120px 0;
+  background: var(--paper);
+}
+
+.editorialSplit {
+  display: grid;
+  grid-template-columns: 90px minmax(0, 1.2fr) minmax(300px, 0.8fr);
+  gap: 44px;
+  align-items: start;
+}
+
+.sectionIndex {
+  color: var(--green);
+  font-family: var(--display);
+  font-size: 2rem;
+  border-top: 1px solid var(--green);
+  padding-top: 10px;
+}
+
+.editorialCopy {
+  padding-top: 38px;
+}
+
+.editorialCopy p {
+  margin: 0 0 20px;
+  color: var(--muted);
+  font-size: 1.08rem;
+  line-height: 1.75;
+}
+
+.wondergreen {
+  padding: 118px 0 108px;
+  background: var(--forest);
+  color: var(--white);
+}
+
+.wgHeader {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 76px;
+  align-items: end;
+  padding-bottom: 52px;
+  border-bottom: 1px solid var(--line-dark);
+}
+
+.wgLogo {
+  width: min(430px, 78vw);
+  height: auto;
+  display: block;
+  margin: 2px 0 20px;
+}
+
+.wgHeader h2 {
+  color: #f6f1df;
+}
+
+.wgLead p {
+  margin: 0;
+  color: #c5d4cb;
+  font-size: 1.1rem;
+  line-height: 1.7;
+}
+
+.wgSystem {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-bottom: 1px solid var(--line-dark);
+}
+
+.wgSystem article {
+  min-height: 250px;
+  padding: 28px 22px 28px 0;
+  border-right: 1px solid var(--line-dark);
+}
+
+.wgSystem article:not(:first-child) {
+  padding-left: 22px;
+}
+
+.wgSystem article:last-child {
+  border-right: 0;
+}
+
+.wgNumber {
+  display: block;
+  color: #d8ed9c;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  margin-bottom: 44px;
+}
+
+.wgSystem small {
+  color: #aebfb5;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.wgSystem h3 {
+  margin: 6px 0 14px;
+  font-size: 2rem;
+}
+
+.wgSystem p {
+  margin: 0;
+  color: #c5d4cb;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.wgStats {
+  display: grid;
+  grid-template-columns: 0.7fr 0.7fr 1fr 1.6fr;
+  gap: 28px;
+  align-items: end;
+  padding-top: 34px;
+}
+
+.wgStats > div {
+  display: grid;
+  gap: 2px;
+}
+
+.wgStats strong {
+  font-family: var(--display);
+  color: #f6f1df;
+  font-size: 2.4rem;
+  font-weight: 600;
+}
+
+.wgStats span {
+  color: #aebfb5;
+  font-size: 0.78rem;
+}
+
+.wgStats > p {
+  margin: 0;
+  color: #aebfb5;
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+.paths {
+  padding: 120px 0;
+  background: var(--paper);
+}
+
+.sectionHeading {
+  max-width: 900px;
+  margin-bottom: 54px;
+}
+
+.sectionHeading p,
+.chainHeading p {
+  max-width: 720px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+
+.pathGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+}
+
+.pathItem {
+  min-height: 340px;
+  display: flex;
+  flex-direction: column;
+  padding: 34px 38px 34px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.pathItem:nth-child(odd) {
+  border-right: 1px solid var(--line);
+}
+
+.pathItem:nth-child(even) {
+  padding-left: 38px;
+}
+
+.pathTop {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 54px;
+}
+
+.pathTop span {
+  color: var(--green);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.pathTop small {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.pathItem p {
+  max-width: 520px;
+  color: var(--muted);
+}
+
+.pathItem a {
+  margin-top: auto;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  color: var(--green);
+  font-weight: 800;
+}
+
+.router {
+  margin-top: 34px;
+  padding: 24px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
   display: flex;
   align-items: center;
-  overflow: hidden;
-  background:
-    radial-gradient(circle at 75% 22%, rgba(152,207,79,.25), transparent 28%),
-    linear-gradient(135deg, #fbfcf8, #edf5e9);
-}
-.heroGrid { display: grid; grid-template-columns: 1.15fr .85fr; gap: 70px; align-items: center; padding: 82px 0 92px; }
-.heroBrand { margin-bottom: 22px; }
-.heroBrand img { width: min(360px, 72vw); height: auto; display: block; }
-.hero h1 em { font-style: normal; color: var(--green700); }
-.cycleVisual {
-  position: relative;
-  aspect-ratio: 1;
-  max-width: 520px;
-  margin-left: auto;
-  border-radius: 50%;
-  border: 1px solid rgba(0,139,76,.18);
-  background:
-    radial-gradient(circle, rgba(255,255,255,.94) 0 31%, transparent 32%),
-    repeating-radial-gradient(circle, transparent 0 22%, rgba(0,139,76,.08) 22.3% 22.6%);
-  box-shadow: var(--shadow);
-}
-.cycleCenter { position: absolute; inset: 37%; border-radius: 50%; display: grid; place-items: center; background: var(--green800); }
-.cycleCenter img { width: 56%; height: 56%; object-fit: contain; }
-.cycleNode { position: absolute; width: 120px; min-height: 78px; padding: 12px; border-radius: 18px; background: white; box-shadow: 0 10px 30px rgba(20,53,44,.12); display: flex; flex-direction: column; }
-.cycleNode strong { color: var(--green700); font-size: .7rem; }
-.cycleNode span { font-weight: 800; }
-.node1 { top: 4%; left: 38%; }
-.node2 { top: 28%; right: -5%; }
-.node3 { bottom: 10%; right: 8%; }
-.node4 { bottom: 8%; left: 4%; }
-.node5 { top: 28%; left: -5%; }
-
-.definition { padding: 100px 0; background: white; }
-.definitionGrid { display: grid; grid-template-columns: 1.05fr .95fr; gap: 70px; align-items: start; }
-.definitionGrid p { margin-top: 0; color: var(--muted); font-size: 1.08rem; }
-.inlineLink { color: var(--green700) !important; font-weight: 800; }
-
-.doors { padding: 110px 0; }
-.doorGrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
-.doorCard { min-height: 290px; padding: 26px; border: 1px solid var(--line); border-radius: var(--radiusMd); background: white; display: flex; flex-direction: column; }
-.doorCard p { color: var(--muted); }
-.doorCard a { margin-top: auto; color: var(--green700); font-weight: 800; }
-.router { margin-top: 20px; padding: 22px 24px; border-radius: var(--radiusMd); background: #eaf3e7; display: flex; align-items: center; justify-content: space-between; gap: 24px; }
-.router div { display: grid; gap: 4px; }
-.router span { color: var(--muted); }
-
-.chain { padding: 110px 0; background: var(--green950); color: white; }
-.chain .sectionHeading p { color: #c6d3cc; }
-.chainGrid { display: grid; grid-template-columns: repeat(6, 1fr); border-top: 1px solid rgba(255,255,255,.18); }
-.chainCard { padding: 24px 16px; border-right: 1px solid rgba(255,255,255,.14); }
-.chainCard:last-child { border-right: 0; }
-.chainCard > span { display: block; color: #aeea83; font-size: .72rem; margin-bottom: 10px; }
-.chainCard strong { display: block; font-size: 1.04rem; }
-.chainCard p { color: #bac8c0; font-size: .9rem; }
-
-.wondergreen { padding: 110px 0; background: #0f5f40; color: white; }
-.wgIntro { display: grid; grid-template-columns: 1.1fr .9fr; gap: 60px; align-items: end; margin-bottom: 42px; }
-.wgLogo { width: min(390px, 70vw); height: auto; display: block; margin: 8px 0 20px; }
-.wgIntro p { color: #cfe0d7; font-size: 1.08rem; }
-.wgStats { display: grid; grid-template-columns: repeat(3,1fr); gap: 14px; margin-top: 26px; }
-.wgStat { padding: 18px; border-radius: 18px; background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.14); }
-.wgStat strong { display: block; font-size: 1.7rem; }
-.wgStat span { color: #cfe0d7; font-size: .9rem; }
-.wgSystem { display: grid; grid-template-columns: repeat(5,1fr); gap: 12px; }
-.wgSystem article { min-height: 190px; padding: 20px; border-radius: 20px; background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.14); }
-.wgSystem span { color: #c9f0a9; font-size: .72rem; text-transform: uppercase; letter-spacing: .08em; font-weight: 900; }
-.wgSystem p { color: #cfe0d7; font-size: .9rem; }
-
-.technology { padding: 110px 0; background: white; }
-.techGrid { display: grid; grid-template-columns: .9fr 1.1fr; gap: 70px; align-items: center; }
-.techCopy p { color: var(--muted); font-size: 1.07rem; }
-.techFlow { display: grid; gap: 10px; }
-.techStep { display: grid; grid-template-columns: 46px 1fr; gap: 14px; align-items: center; padding: 16px 18px; border: 1px solid var(--line); border-radius: 18px; background: #fafbf7; }
-.techStep span { width: 36px; height: 36px; border-radius: 50%; display: grid; place-items: center; background: #e4f2dd; color: var(--green800); font-weight: 900; }
-.techStep strong { display: block; }
-.techStep small { color: var(--muted); }
-
-.knowledge { padding: 110px 0; }
-.knowledgeGrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
-.knowledgeCard { padding: 28px; border-radius: var(--radiusMd); background: white; border: 1px solid var(--line); min-height: 250px; display: flex; flex-direction: column; }
-.knowledgeCard p { color: var(--muted); }
-.knowledgeCard a { margin-top: auto; color: var(--green700); font-weight: 800; }
-
-.impact { padding: 120px 0; background: white; }
-.impactGrid { display: grid; grid-template-columns: .9fr 1.1fr; gap: 70px; align-items: center; }
-.impactGrid p { color: var(--muted); font-size: 1.08rem; }
-.console { background: #101713; color: white; border-radius: var(--radiusLg); padding: 28px; box-shadow: var(--shadow); }
-.consoleTop { display: flex; justify-content: space-between; padding-bottom: 18px; border-bottom: 1px solid #2d3832; font-size: .72rem; letter-spacing: .08em; }
-.live { color: #aeea83; }
-.metric { display: grid; grid-template-columns: 1fr auto; gap: 2px 20px; padding: 20px 0; border-bottom: 1px solid #2d3832; }
-.metric strong { font-size: 2rem; }
-.metric small { color: #8ea096; }
-
-.closing { padding: 84px 0; background: var(--lime400); }
-.closingInner { display: flex; justify-content: space-between; gap: 40px; align-items: end; }
-.closingInner h2 { max-width: 820px; }
-
-.footer { background: #0d241d; color: white; padding: 58px 0 28px; }
-.footerGrid { display: grid; grid-template-columns: 1.2fr .8fr .8fr; gap: 50px; }
-.footerLogo { width: 210px; height: auto; filter: brightness(0) invert(1); opacity: .96; }
-.footer p, .footer a { color: #b9c8c0; }
-.footerLinks { display: grid; gap: 8px; }
-.footerBottom { margin-top: 34px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,.12); color: #809087; font-size: .82rem; }
-
-@media (max-width: 980px) {
-  .nav { display: none; }
-  .heroGrid, .definitionGrid, .wgIntro, .techGrid, .impactGrid { grid-template-columns: 1fr; }
-  .cycleVisual { margin: 10px auto 0; width: min(520px, 86vw); }
-  .doorGrid { grid-template-columns: repeat(2, 1fr); }
-  .chainGrid { grid-template-columns: repeat(3, 1fr); }
-  .wgSystem { grid-template-columns: repeat(2, 1fr); }
-  .knowledgeGrid { grid-template-columns: 1fr; }
-  .footerGrid { grid-template-columns: 1fr 1fr; }
+  justify-content: space-between;
+  gap: 28px;
 }
 
-@media (max-width: 680px) {
-  .container { width: min(100% - 28px, 1180px); }
-  .headerInner { min-height: 68px; gap: 10px; }
-  .brandLogo { width: 146px; }
-  .headerActions .buttonGhost { display: none; }
-  .headerActions .button { min-height: 42px; padding: 0 14px; font-size: .82rem; }
-  .hero { min-height: auto; }
-  .heroGrid { padding: 58px 0 72px; gap: 42px; }
-  .publicSite h1 { font-size: clamp(2.65rem, 13vw, 4.2rem); }
-  .publicSite h2 { font-size: clamp(2rem, 10vw, 3rem); }
-  .cycleNode { width: 94px; min-height: 66px; font-size: .78rem; }
-  .doorGrid, .wgStats, .wgSystem { grid-template-columns: 1fr; }
-  .chainGrid { grid-template-columns: 1fr; }
-  .chainCard { border-right: 0; border-bottom: 1px solid rgba(255,255,255,.14); }
-  .router, .closingInner { align-items: flex-start; flex-direction: column; }
-  .footerGrid { grid-template-columns: 1fr; }
+.router > div {
+  display: grid;
+  gap: 3px;
+}
+
+.router span {
+  color: var(--muted);
+}
+
+.evidence {
+  padding: 112px 0;
+  background: var(--cream);
+}
+
+.evidenceGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.12fr) minmax(320px, 0.88fr);
+  gap: 72px;
+  align-items: center;
+}
+
+.evidenceMedia {
+  margin: 0;
+  border-left: 8px solid var(--sun);
+  background: var(--forest-deep);
+}
+
+.evidenceMedia img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  display: block;
+  object-fit: cover;
+}
+
+.evidenceMedia figcaption {
+  padding: 12px 16px;
+  color: rgba(255, 255, 255, 0.74);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.evidenceCopy p {
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.evidenceFacts {
+  margin: 30px 0 12px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.evidenceFacts > div {
+  min-height: 66px;
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  align-items: center;
+  gap: 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.evidenceFacts > div:last-child {
+  border-bottom: 0;
+}
+
+.evidenceFacts span {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.chain {
+  padding: 118px 0;
+  background: var(--forest-deep);
+  color: var(--white);
+}
+
+.chainHeading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.7fr);
+  gap: 60px;
+  align-items: end;
+  margin-bottom: 48px;
+}
+
+.chainHeading .eyebrow {
+  grid-column: 1 / -1;
+  margin-bottom: -34px;
+}
+
+.chainHeading p {
+  color: #9fb1a6;
+  margin: 0;
+}
+
+.chainGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--line-dark);
+}
+
+.chainItem {
+  min-height: 220px;
+  display: grid;
+  grid-template-columns: 42px 1fr;
+  gap: 18px;
+  padding: 28px 26px 28px 0;
+  border-right: 1px solid var(--line-dark);
+  border-bottom: 1px solid var(--line-dark);
+}
+
+.chainItem:nth-child(3n + 2),
+.chainItem:nth-child(3n + 3) {
+  padding-left: 26px;
+}
+
+.chainItem:nth-child(3n) {
+  border-right: 0;
+}
+
+.chainItem > span {
+  color: #d8ed9c;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.chainItem strong {
+  display: block;
+  font-family: var(--display);
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.chainItem p {
+  color: #9fb1a6;
+  font-size: 0.92rem;
+  line-height: 1.65;
+}
+
+.technology {
+  padding: 120px 0;
+  background: var(--paper);
+}
+
+.techGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: 86px;
+  align-items: start;
+}
+
+.techCopy p {
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.techFlow {
+  border-top: 1px solid var(--line);
+}
+
+.techStep {
+  min-height: 92px;
+  display: grid;
+  grid-template-columns: 62px 1fr;
+  align-items: center;
+  gap: 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.techStep > span {
+  color: var(--green);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.techStep strong {
+  display: block;
+  font-family: var(--display);
+  font-size: 1.45rem;
+  font-weight: 600;
+}
+
+.techStep small {
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.knowledge {
+  padding: 118px 0;
+  background: var(--cream);
+}
+
+.knowledgeGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+}
+
+.knowledgeItem {
+  min-height: 310px;
+  display: flex;
+  flex-direction: column;
+  padding: 28px 28px 28px 0;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.knowledgeItem:not(:first-child) {
+  padding-left: 28px;
+}
+
+.knowledgeItem:last-child {
+  border-right: 0;
+}
+
+.knowledgeItem > span {
+  color: var(--green);
+  font-size: 0.72rem;
+  font-weight: 800;
+  margin-bottom: 56px;
+}
+
+.knowledgeItem p {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.knowledgeItem a {
+  margin-top: auto;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  color: var(--green);
+  font-weight: 800;
+}
+
+.impact {
+  padding: 120px 0;
+  background: #e9eee4;
+}
+
+.impactGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: 86px;
+  align-items: center;
+}
+
+.impactGrid p {
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.console {
+  background: var(--forest-deep);
+  color: var(--white);
+  border-left: 8px solid var(--lime);
+  padding: 30px 32px;
+}
+
+.consoleTop {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--line-dark);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.live {
+  color: #d8ed9c;
+}
+
+.metric {
+  min-height: 96px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2px 20px;
+  align-items: center;
+  border-bottom: 1px solid var(--line-dark);
+}
+
+.metric:last-child {
+  border-bottom: 0;
+}
+
+.metric strong {
+  font-family: var(--display);
+  font-size: 2.4rem;
+  font-weight: 500;
+}
+
+.metric small {
+  color: #95a89d;
+}
+
+.closing {
+  padding: 86px 0;
+  background: var(--lime);
+}
+
+.closingInner {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 54px;
+}
+
+.closingInner h2 {
+  max-width: 800px;
+}
+
+.closingInner p {
+  max-width: 650px;
+  margin-bottom: 0;
+  color: #33463c;
+}
+
+@media (max-width: 1060px) {
+  .heroGrid,
+  .wgHeader,
+  .evidenceGrid,
+  .techGrid,
+  .impactGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .heroGrid {
+    min-height: auto;
+  }
+
+  .cycleLedger {
+    max-height: none;
+  }
+
+  .editorialSplit {
+    grid-template-columns: 70px 1fr;
+  }
+
+  .editorialCopy {
+    grid-column: 2;
+    padding-top: 0;
+  }
+
+  .wgSystem {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .wgSystem article:nth-child(3) {
+    border-right: 0;
+  }
+
+  .wgSystem article:nth-child(4),
+  .wgSystem article:nth-child(5) {
+    border-top: 1px solid var(--line-dark);
+  }
+
+  .wgSystem article:nth-child(4) {
+    padding-left: 0;
+  }
+
+  .wgStats {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .wgStats > p {
+    grid-column: 1 / -1;
+  }
+
+  .chainHeading {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .chainHeading .eyebrow {
+    margin-bottom: 0;
+  }
+
+  .chainGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .chainItem:nth-child(3n) {
+    border-right: 1px solid var(--line-dark);
+  }
+
+  .chainItem:nth-child(even) {
+    border-right: 0;
+    padding-left: 26px;
+  }
+
+  .chainItem:nth-child(odd) {
+    padding-left: 0;
+  }
+}
+
+@media (max-width: 760px) {
+  .container {
+    width: min(100% - 28px, 1240px);
+  }
+
+  .publicSite h1 {
+    font-size: clamp(3.75rem, 17vw, 5.4rem);
+  }
+
+  .publicSite h2 {
+    font-size: clamp(2.65rem, 12vw, 4rem);
+  }
+
+  .heroGrid {
+    gap: 52px;
+    padding: 64px 0 72px;
+  }
+
+  .heroMeta {
+    gap: 8px 14px;
+  }
+
+  .cycleLedger {
+    padding: 24px;
+    border-left-width: 5px;
+  }
+
+  .cycleLedgerRow {
+    grid-template-columns: 34px 1fr;
+  }
+
+  .cycleLedgerRow small {
+    grid-column: 2;
+    margin-top: -14px;
+  }
+
+  .definition,
+  .wondergreen,
+  .paths,
+  .evidence,
+  .chain,
+  .technology,
+  .knowledge,
+  .impact {
+    padding: 84px 0;
+  }
+
+  .editorialSplit {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .sectionIndex {
+    width: 56px;
+  }
+
+  .editorialCopy {
+    grid-column: auto;
+  }
+
+  .wgHeader {
+    gap: 36px;
+  }
+
+  .wgSystem {
+    grid-template-columns: 1fr;
+  }
+
+  .wgSystem article,
+  .wgSystem article:not(:first-child),
+  .wgSystem article:nth-child(4) {
+    min-height: 0;
+    padding: 26px 0;
+    border-right: 0;
+    border-top: 0;
+    border-bottom: 1px solid var(--line-dark);
+  }
+
+  .wgSystem article:last-child {
+    border-bottom: 0;
+  }
+
+  .wgNumber {
+    margin-bottom: 20px;
+  }
+
+  .wgStats {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .wgStats > div:nth-child(3),
+  .wgStats > p {
+    grid-column: 1 / -1;
+  }
+
+  .pathGrid,
+  .chainGrid,
+  .knowledgeGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .pathItem,
+  .pathItem:nth-child(even),
+  .knowledgeItem,
+  .knowledgeItem:not(:first-child),
+  .chainItem,
+  .chainItem:nth-child(even),
+  .chainItem:nth-child(odd) {
+    padding-left: 0;
+    padding-right: 0;
+    border-right: 0;
+  }
+
+  .pathItem {
+    min-height: 310px;
+  }
+
+  .chainItem {
+    min-height: 0;
+  }
+
+  .router,
+  .closingInner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .evidenceGrid {
+    gap: 40px;
+  }
+
+  .evidenceFacts > div {
+    grid-template-columns: 1fr;
+    gap: 4px;
+    padding: 12px 0;
+  }
+
+  .knowledgeItem {
+    min-height: 260px;
+  }
+
+  .console {
+    padding: 24px 20px;
+    border-left-width: 5px;
+  }
+
+  .consoleTop {
+    flex-direction: column;
+    gap: 4px;
+  }
+}
+
+@media (max-width: 480px) {
+  .buttonRow {
+    width: 100%;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  .wgStats {
+    grid-template-columns: 1fr;
+  }
+
+  .wgStats > div:nth-child(3),
+  .wgStats > p {
+    grid-column: auto;
+  }
+
+  .pathTop {
+    flex-direction: column;
+    margin-bottom: 36px;
+  }
+
+  .metric {
+    grid-template-columns: 1fr auto;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .button, .nav a { transition: none; }
-  .button:hover { transform: none; }
+  .button {
+    transition: none;
+  }
+
+  .button:hover {
+    transform: none;
+  }
 }

--- a/src/components/public-shell.module.css
+++ b/src/components/public-shell.module.css
@@ -1,7 +1,8 @@
 .site {
   min-height: 100vh;
-  background: #f7f7f3;
-  color: #173127;
+  background: #fbfaf5;
+  color: #18241f;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 .skipLink {
@@ -9,8 +10,8 @@
   left: 16px;
   top: -80px;
   z-index: 1000;
-  border-radius: 999px;
-  background: #173127;
+  border-radius: 4px;
+  background: #0b241c;
   color: #fff;
   padding: 10px 16px;
   text-decoration: none;
@@ -25,29 +26,31 @@
   position: sticky;
   top: 0;
   z-index: 80;
-  border-bottom: 1px solid rgba(23, 49, 39, 0.12);
-  background: rgba(247, 247, 243, 0.94);
-  backdrop-filter: blur(16px);
+  border-top: 4px solid #b8d65f;
+  border-bottom: 1px solid rgba(24, 36, 31, 0.15);
+  background: rgba(251, 250, 245, 0.96);
+  backdrop-filter: blur(14px);
 }
 
 .headerInner,
 .footerGrid,
 .footerBottom {
-  width: min(1180px, calc(100% - 40px));
+  width: min(1240px, calc(100% - 48px));
   margin: 0 auto;
 }
 
 .headerInner {
-  min-height: 76px;
+  min-height: 78px;
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 24px;
+  gap: 30px;
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
+  min-height: 44px;
 }
 
 .brand img,
@@ -62,7 +65,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 20px;
+  gap: 24px;
   min-width: 0;
 }
 
@@ -74,8 +77,13 @@
 }
 
 .nav a {
-  font-size: 0.9rem;
-  font-weight: 650;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.78rem;
+  font-weight: 750;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
   white-space: nowrap;
 }
 
@@ -84,11 +92,19 @@
 .footerLinks a:hover,
 .footerLinks a:focus-visible {
   text-decoration: underline;
-  text-underline-offset: 4px;
+  text-underline-offset: 5px;
+}
+
+.nav a:focus-visible,
+.actions a:focus-visible,
+.brand:focus-visible,
+.footer a:focus-visible {
+  outline: 3px solid #ddc952;
+  outline-offset: 4px;
 }
 
 .mobileContact {
-  display: none;
+  display: none !important;
 }
 
 .actions {
@@ -99,23 +115,25 @@
 
 .contact,
 .ops {
-  min-height: 40px;
+  min-height: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: 4px;
   padding: 0 15px;
-  font-size: 0.86rem;
-  font-weight: 750;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
   white-space: nowrap;
 }
 
 .contact {
-  border: 1px solid rgba(23, 49, 39, 0.18);
+  border: 1px solid rgba(24, 36, 31, 0.2);
 }
 
 .ops {
-  background: #173127;
+  background: #12372c;
   color: #fff !important;
 }
 
@@ -133,21 +151,23 @@
 
 .footer {
   margin-top: 0;
-  background: #10251d;
+  border-top: 8px solid #b8d65f;
+  background: #0b241c;
   color: rgba(255, 255, 255, 0.82);
 }
 
 .footerGrid {
   display: grid;
-  grid-template-columns: minmax(260px, 1.6fr) repeat(3, minmax(120px, 0.6fr));
-  gap: 42px;
-  padding: 64px 0 42px;
+  grid-template-columns: minmax(280px, 1.7fr) repeat(3, minmax(120px, 0.55fr));
+  gap: 48px;
+  padding: 68px 0 46px;
 }
 
 .footerBrand p {
-  max-width: 520px;
-  line-height: 1.65;
-  margin: 20px 0;
+  max-width: 560px;
+  line-height: 1.7;
+  margin: 22px 0;
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .footerBrand img {
@@ -156,37 +176,45 @@
 
 .footerBrand address {
   font-style: normal;
-  line-height: 1.6;
-  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.58);
 }
 
 .footerLinks {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 7px;
 }
 
 .footerLinks strong {
-  color: #fff;
-  margin-bottom: 4px;
+  margin-bottom: 8px;
+  color: #d8ed9c;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
 }
 
 .footerLinks a {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
   color: rgba(255, 255, 255, 0.72);
-  font-size: 0.9rem;
+  font-size: 0.88rem;
 }
 
 .footerBottom {
   display: flex;
   justify-content: space-between;
   gap: 24px;
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
-  padding: 18px 0 24px;
-  color: rgba(255, 255, 255, 0.56);
-  font-size: 0.8rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
+  padding: 20px 0 26px;
+  color: rgba(255, 255, 255, 0.54);
+  font-size: 0.76rem;
+  letter-spacing: 0.04em;
 }
 
-@media (max-width: 1040px) {
+@media (max-width: 1080px) {
   .headerInner {
     grid-template-columns: auto auto;
   }
@@ -196,7 +224,7 @@
     grid-row: 2;
     justify-content: flex-start;
     overflow-x: auto;
-    padding: 0 0 12px;
+    padding: 0 0 10px;
     scrollbar-width: none;
   }
 
@@ -209,11 +237,11 @@
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 760px) {
   .headerInner,
   .footerGrid,
   .footerBottom {
-    width: min(100% - 28px, 1180px);
+    width: min(100% - 28px, 1240px);
   }
 
   .headerInner {
@@ -230,27 +258,27 @@
   }
 
   .mobileContact {
-    display: inline;
+    display: inline-flex !important;
   }
 
   .ops {
-    min-height: 36px;
-    padding: 0 12px;
-    font-size: 0.78rem;
+    min-height: 40px;
+    padding: 0 11px;
+    font-size: 0.66rem;
   }
 
   .nav {
-    gap: 18px;
+    gap: 20px;
   }
 
   .nav a {
-    font-size: 0.82rem;
+    font-size: 0.72rem;
   }
 
   .footerGrid {
     grid-template-columns: 1fr 1fr;
-    gap: 32px 24px;
-    padding-top: 48px;
+    gap: 34px 24px;
+    padding-top: 50px;
   }
 
   .footerBrand {
@@ -270,5 +298,11 @@
 
   .footerBrand {
     grid-column: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skipLink {
+    transition: none;
   }
 }


### PR DESCRIPTION
## Objetivo
Evolucionar la HOME pública desde una composición técnica basada en cards hacia un lenguaje editorial premium, contemporáneo y propio de Greenatics, preservando por completo la frontera con GREENATICS OPS.

## Cambios
- Hero editorial con la narrativa `Transformar residuos en vida` y el ciclo Greenatics en una pieza gráfica plana y funcional.
- Wondergreen pasa a ocupar una posición comercial prioritaria y se explica como suelo + nutrición + biología + conocimiento.
- Menos cards repetitivas; más composición editorial, reglas, numeración, bandas planas y jerarquía tipográfica.
- Nueva sección de evidencia con la vista aérea real ya gobernada de Yarumal.
- Truth lock explícito: la imagen documenta experiencia y no certifica capacidad, producción o estado actual.
- Header/footer compartidos alineados con el nuevo lenguaje visual, manteniendo navegación y acceso a `/app`.
- `DESIGN.md` incorpora el lenguaje editorial público V0.15 y la regla de integridad de color plano.
- Playwright cubre jerarquía editorial, evidencia Yarumal, Product Truth y rutas principales.

## Guardrails
- Solo activos oficiales o ya gobernados en el repositorio.
- Sin logos, empaques ni fotografías generados o reinterpretados.
- Sin métricas públicas nuevas ni claims cuantitativos.
- Sin cambios en OPS, auth, RLS, Supabase, SharePoint, stores ni lógica operacional.

## Gate
Mantener en draft hasta que el workflow `quality` complete typecheck, lint, unit, build y Playwright desktop/móvil.