### PR TITLE
Public v0.17 · Solutions + Projects editorial unification

### DIFF
--- a/e2e/public-editorial-sections.spec.ts
+++ b/e2e/public-editorial-sections.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+for (const route of ["/soluciones", "/proyectos"]) {
+  test(`${route} uses one canonical public shell`, async ({ page }) => {
+    await page.goto(route);
+
+    await expect(page.getByRole("banner")).toHaveCount(1);
+    await expect(page.getByRole("contentinfo")).toHaveCount(1);
+    await expect(page.getByRole("navigation", { name: "Navegación pública" })).toHaveCount(1);
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", new RegExp(`${route.replace("/", "\\/")}$`));
+  });
+}
+
+test("solution and project details keep governed public routes", async ({ page }) => {
+  await page.goto("/soluciones/diagnostico-caracterizacion");
+  await expect(page.getByRole("link", { name: "Hablar con Greenatics" })).toHaveAttribute("href", "/contacto");
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", /\/soluciones\/diagnostico-caracterizacion$/);
+
+  await page.goto("/proyectos/yarumal");
+  await expect(page.getByText("Contexto de publicación", { exact: true })).toBeVisible();
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", /\/proyectos\/yarumal$/);
+});

--- a/src/app/proyectos/[slug]/page.tsx
+++ b/src/app/proyectos/[slug]/page.tsx
@@ -28,7 +28,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const project = getPublicProject(slug);
   if (!project) return {};
-  return { title: `${project.name} | Proyectos Greenatics`, description: project.summary };
+  return {
+    title: `${project.name} | Proyectos Greenatics`,
+    description: project.summary,
+    alternates: { canonical: `/proyectos/${project.slug}` },
+  };
 }
 
 export default async function ProjectCasePage({ params }: Props) {
@@ -42,23 +46,48 @@ export default async function ProjectCasePage({ params }: Props) {
   return (
     <div className={styles.page}>
       <BreadcrumbJsonLd items={[{ name: "Greenatics", path: "/" }, { name: "Proyectos", path: "/proyectos" }, { name: project.name, path: `/proyectos/${project.slug}` as `/${string}` }]} />
-      <header className={styles.header}><div className={`${styles.container} ${styles.headerInner}`}><Link href="/" aria-label="Greenatics, inicio"><img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" /></Link><nav className={styles.nav} aria-label="Navegación pública"><Link href="/soluciones">Soluciones</Link><Link href="/proyectos">Proyectos</Link><Link href="/wondergreen">Wondergreen</Link><Link href="/biblioteca">Conocimiento</Link></nav><Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link></div></header>
-
       <main>
-        <section className={styles.detailHero}><div className={styles.container}><Link className={styles.back} href="/proyectos">← Proyectos</Link><div className={styles.detailGrid}><div><span className={styles.status}>{project.statusLabel}</span><span className={styles.eyebrow}>{project.region}</span><h1>{project.name}</h1><p className={styles.lead}>{project.summary}</p></div><aside className={styles.detailFact}><strong>Contexto de publicación</strong><p>{project.publicationContext}</p></aside></div></div></section>
+        <section className={styles.detailHero}>
+          <div className={styles.heroAccent} aria-hidden="true" />
+          <div className={styles.container}>
+            <Link className={styles.back} href="/proyectos">← Proyectos</Link>
+            <div className={styles.detailGrid}>
+              <div><span className={styles.status}>{project.statusLabel}</span><span className={styles.eyebrow}>{project.region}</span><h1>{project.name}</h1><p className={styles.lead}>{project.summary}</p></div>
+              <aside className={styles.detailFact}><span>Publicación gobernada</span><strong>Contexto de publicación</strong><p>{project.publicationContext}</p></aside>
+            </div>
+          </div>
+        </section>
 
         <ProjectEvidenceGallery slug={project.slug} />
 
-        <section className={`${styles.section} ${styles.white}`}><div className={styles.container}><div className={styles.sectionHead}><span className={styles.eyebrow}>Qué demuestra este caso</span><h2>Capacidades y problemas observados dentro de un sistema completo.</h2></div><div className={styles.capGrid}>{project.capabilities.map(([title,copy],index)=><article className={styles.capCard} key={title}><span>{String(index+1).padStart(2,"0")}</span><h3>{title}</h3><p>{copy}</p></article>)}</div></div></section>
+        <section className={`${styles.section} ${styles.white}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}><span className={styles.eyebrow}>Qué demuestra este caso</span><h2>Capacidades y problemas observados dentro de un sistema completo.</h2></div>
+            <div className={styles.capGrid}>{project.capabilities.map(([title, copy], index) => <article className={styles.capCard} key={title}><span>{String(index + 1).padStart(2, "0")}</span><div><h3>{title}</h3><p>{copy}</p></div></article>)}</div>
+          </div>
+        </section>
 
-        <section className={`${styles.section} ${styles.soft}`}><div className={styles.container}><div className={styles.sectionHead}><span className={styles.eyebrow}>{project.slug === "tamesis" ? "Modelo de intervención" : "De operación a conocimiento"}</span><h2>{project.slug === "tamesis" ? "Puesta en marcha → Estabilización → Escalabilidad." : "Registrar → Conectar → Aprender."}</h2></div><div className={styles.phaseGrid}>{phases.map(([number,title,copy])=><article className={styles.phase} key={number}><span>{number}</span><h3>{title}</h3><p>{copy}</p></article>)}</div></div></section>
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}><span className={styles.eyebrow}>{project.slug === "tamesis" ? "Modelo de intervención" : "De operación a conocimiento"}</span><h2>{project.slug === "tamesis" ? "Puesta en marcha → Estabilización → Escalabilidad." : "Registrar → Conectar → Aprender."}</h2></div>
+            <div className={styles.phaseGrid}>{phases.map(([number, title, copy]) => <article className={styles.phase} key={number}><span>{number}</span><div><h3>{title}</h3><p>{copy}</p></div></article>)}</div>
+          </div>
+        </section>
 
-        <section className={styles.section}><div className={styles.container}><div className={styles.sectionHead}><span className={styles.eyebrow}>Aprendizajes transferibles</span><h2>Lo que este caso puede enseñar al siguiente proyecto.</h2></div><div className={styles.capGrid}>{project.learnings.map(([title,copy],index)=><article className={styles.capCard} key={title}><span>{String(index+1).padStart(2,"0")}</span><h3>{title}</h3><p>{copy}</p></article>)}</div></div></section>
+        <section className={styles.section}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}><span className={styles.eyebrow}>Aprendizajes transferibles</span><h2>Lo que este caso puede enseñar al siguiente proyecto.</h2></div>
+            <div className={styles.capGrid}>{project.learnings.map(([title, copy], index) => <article className={styles.capCard} key={title}><span>{String(index + 1).padStart(2, "0")}</span><div><h3>{title}</h3><p>{copy}</p></div></article>)}</div>
+          </div>
+        </section>
 
-        <section className={styles.dark}><div className={`${styles.container} ${styles.darkGrid}`}><div><span className={styles.eyebrow}>Truth lock</span><h2>Experiencia documentada no significa estado actual certificado.</h2></div><div><p>Cuando necesitemos publicar producción, toneladas tratadas, rendimiento, capacidad, inversión o impacto, cada valor deberá tener fuente, periodo, unidad, responsable y fecha de corte. Esta página preserva el aprendizaje sin convertir información histórica en una afirmación vigente.</p><Link className={styles.button} style={{marginTop:20,background:"#fff",color:"#14352c"}} href={solutionHref}>{solutionLabel}</Link></div></div></section>
+        <section className={styles.dark}>
+          <div className={`${styles.container} ${styles.darkGrid}`}>
+            <div><span className={styles.eyebrow}>Truth lock</span><h2>Experiencia documentada no significa estado actual certificado.</h2></div>
+            <div><p>Cuando necesitemos publicar producción, toneladas tratadas, rendimiento, capacidad, inversión o impacto, cada valor deberá tener fuente, periodo, unidad, responsable y fecha de corte. Esta página preserva el aprendizaje sin convertir información histórica en una afirmación vigente.</p><Link className={`${styles.button} ${styles.light}`} href={solutionHref}>{solutionLabel}</Link></div>
+          </div>
+        </section>
       </main>
-
-      <footer className={styles.footer}><div className={`${styles.container} ${styles.footerInner}`}><span>Greenatics · caso {project.name}</span><div><Link href="/proyectos">Todos los proyectos</Link> · <Link href="/soluciones">Soluciones</Link></div></div></footer>
     </div>
   );
 }

--- a/src/app/proyectos/page.tsx
+++ b/src/app/proyectos/page.tsx
@@ -6,6 +6,7 @@ import styles from "./projects.module.css";
 export const metadata: Metadata = {
   title: "Proyectos | Greenatics",
   description: "Casos documentados y aprendizajes Greenatics en operación, rehabilitación, tratamiento biológico, rutas selectivas y trazabilidad.",
+  alternates: { canonical: "/proyectos" },
 };
 
 const transferable = [
@@ -28,27 +29,38 @@ const publicationFlow = [
 export default function ProjectsPage() {
   return (
     <div className={styles.page}>
-      <header className={styles.header}>
-        <div className={`${styles.container} ${styles.headerInner}`}>
-          <Link href="/" aria-label="Greenatics, inicio"><img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" /></Link>
-          <nav className={styles.nav} aria-label="Navegación pública"><Link href="/soluciones">Soluciones</Link><Link href="/proyectos">Proyectos</Link><Link href="/wondergreen">Wondergreen</Link><Link href="/biblioteca">Conocimiento</Link></nav>
-          <Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link>
-        </div>
-      </header>
-
       <main>
         <section className={styles.hero}>
+          <div className={styles.heroAccent} aria-hidden="true" />
           <div className={`${styles.container} ${styles.heroGrid}`}>
-            <div><span className={styles.eyebrow}>Proyectos Greenatics</span><h1>La experiencia no es una foto de una planta. Es saber qué hacer antes, durante y después de ponerla a operar.</h1><p className={styles.lead}>Nuestros casos documentan problemas de territorio, calidad del material, infraestructura, procesos biológicos, operación, productos y datos. Los usamos como evidencia de aprendizaje transferible, no como una vitrina de cifras sin contexto.</p></div>
-            <aside className={styles.truth}><strong>Caso real + periodo + alcance.</strong><p>Una propuesta, una capacidad nominal, una fotografía histórica o una cifra antigua no se convierten automáticamente en un resultado vigente. Cada caso explica qué está documentado y qué requiere una nueva validación.</p></aside>
+            <div>
+              <span className={styles.eyebrow}>Proyectos Greenatics · Evidencia con contexto</span>
+              <h1>La experiencia no es una foto de una planta. Es saber qué hacer antes, durante y después de ponerla a operar.</h1>
+              <p className={styles.lead}>Nuestros casos documentan problemas de territorio, calidad del material, infraestructura, procesos biológicos, operación, productos y datos. Los usamos como evidencia de aprendizaje transferible, no como una vitrina de cifras sin contexto.</p>
+            </div>
+            <aside className={styles.truth}>
+              <span>Truth lock de proyectos</span>
+              <strong>Caso real + periodo + alcance.</strong>
+              <p>Una propuesta, una capacidad nominal, una fotografía histórica o una cifra antigua no se convierten automáticamente en un resultado vigente. Cada caso explica qué está documentado y qué requiere una nueva validación.</p>
+            </aside>
           </div>
         </section>
 
         <section className={styles.section}>
           <div className={styles.container}>
-            <div className={styles.sectionHead}><span className={styles.eyebrow}>Casos documentados</span><h2>Dos plantas, aprendizajes diferentes.</h2><p>Yarumal permite mostrar aprendizajes de operación y trazabilidad. Támesis aporta un caso especialmente útil sobre diagnóstico, rehabilitación y puesta en marcha progresiva.</p></div>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Casos documentados</span>
+              <h2>Dos plantas, aprendizajes diferentes.</h2>
+              <p>Yarumal permite mostrar aprendizajes de operación y trazabilidad. Támesis aporta un caso especialmente útil sobre diagnóstico, rehabilitación y puesta en marcha progresiva.</p>
+            </div>
             <div className={styles.projectGrid}>
-              {publicProjects.map((project) => <article className={styles.projectCard} key={project.slug}><span className={styles.status}>{project.statusLabel}</span><h2>{project.name}</h2><span className={styles.region}>{project.region}</span><p>{project.summary}</p><Link href={`/proyectos/${project.slug}`}>Ver caso {project.name} →</Link></article>)}
+              {publicProjects.map((project, index) => (
+                <article className={styles.projectCard} key={project.slug}>
+                  <span className={styles.projectIndex}>{String(index + 1).padStart(2, "0")}</span>
+                  <div><span className={styles.status}>{project.statusLabel}</span><h2>{project.name}</h2><span className={styles.region}>{project.region}</span><p>{project.summary}</p></div>
+                  <Link href={`/proyectos/${project.slug}`}>Ver caso {project.name} →</Link>
+                </article>
+              ))}
             </div>
           </div>
         </section>
@@ -56,22 +68,31 @@ export default function ProjectsPage() {
         <section className={`${styles.section} ${styles.soft}`}>
           <div className={styles.container}>
             <div className={styles.sectionHead}><span className={styles.eyebrow}>Experiencia transferible</span><h2>Lo valioso de un proyecto es lo que enseña para el siguiente.</h2></div>
-            <div className={styles.capGrid}>{transferable.map(([title,copy],index)=><article className={styles.capCard} key={title}><span>{String(index+1).padStart(2,"0")}</span><h3>{title}</h3><p>{copy}</p></article>)}</div>
+            <div className={styles.capGrid}>{transferable.map(([title, copy], index) => <article className={styles.capCard} key={title}><span>{String(index + 1).padStart(2, "0")}</span><div><h3>{title}</h3><p>{copy}</p></div></article>)}</div>
           </div>
         </section>
 
         <section className={styles.dark}>
-          <div className={`${styles.container} ${styles.darkGrid}`}><div><span className={styles.eyebrow}>Proyectos en maduración</span><h2>Prefactibilidad y factibilidad también son proyectos.</h2></div><div><p>Mientras un proyecto está en diagnóstico, conversación comercial o prefactibilidad, no lo presentamos como planta adjudicada, construida u operativa. La madurez del proyecto se comunica sin exagerar avance.</p><Link className={styles.button} style={{marginTop:20,background:"#fff",color:"#14352c"}} href="/soluciones/prefactibilidad">Ver cómo estructuramos una prefactibilidad</Link></div></div>
+          <div className={`${styles.container} ${styles.darkGrid}`}>
+            <div><span className={styles.eyebrow}>Proyectos en maduración</span><h2>Prefactibilidad y factibilidad también son proyectos.</h2></div>
+            <div><p>Mientras un proyecto está en diagnóstico, conversación comercial o prefactibilidad, no lo presentamos como planta adjudicada, construida u operativa. La madurez del proyecto se comunica sin exagerar avance.</p><Link className={`${styles.button} ${styles.light}`} href="/soluciones/prefactibilidad">Ver cómo estructuramos una prefactibilidad</Link></div>
+          </div>
         </section>
 
         <section className={`${styles.section} ${styles.white}`}>
-          <div className={styles.container}><div className={styles.sectionHead}><span className={styles.eyebrow}>Cómo se vuelve público un resultado</span><h2>Del registro interno a una afirmación que se puede defender.</h2></div><div className={styles.capGrid}>{publicationFlow.map(([number,title,copy])=><article className={styles.capCard} key={number}><span>{number}</span><h3>{title}</h3><p>{copy}</p></article>)}</div></div>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}><span className={styles.eyebrow}>Cómo se vuelve público un resultado</span><h2>Del registro interno a una afirmación que se puede defender.</h2></div>
+            <div className={styles.flowList}>{publicationFlow.map(([number, title, copy]) => <article key={number}><span>{number}</span><div><h3>{title}</h3><p>{copy}</p></div></article>)}</div>
+          </div>
         </section>
 
-        <section className={styles.closing}><div className={`${styles.container} ${styles.closingInner}`}><div><span className={styles.eyebrow}>Construir el siguiente caso</span><h2>Cada territorio parte de condiciones distintas. El aprendizaje sí puede transferirse.</h2></div><Link className={`${styles.button} ${styles.primary}`} href="/soluciones/diagnostico-caracterizacion">Empezar por diagnóstico</Link></div></section>
+        <section className={styles.closing}>
+          <div className={`${styles.container} ${styles.closingInner}`}>
+            <div><span className={styles.eyebrow}>Construir el siguiente caso</span><h2>Cada territorio parte de condiciones distintas. El aprendizaje sí puede transferirse.</h2></div>
+            <Link className={`${styles.button} ${styles.darkButton}`} href="/soluciones/diagnostico-caracterizacion">Empezar por diagnóstico</Link>
+          </div>
+        </section>
       </main>
-
-      <footer className={styles.footer}><div className={`${styles.container} ${styles.footerInner}`}><span>Greenatics · proyectos con contexto</span><div><Link href="/soluciones">Soluciones</Link> · <Link href="/wondergreen">Wondergreen</Link> · <Link href="/app">GREENATICS OPS</Link></div></div></footer>
     </div>
   );
 }

--- a/src/app/proyectos/projects.module.css
+++ b/src/app/proyectos/projects.module.css
@@ -1,1 +1,100 @@
-.page{--green950:#14352c;--green800:#006b45;--green700:#008b4c;--lime:#98cf4f;--paper:#f7f8f3;--soft:#eef4eb;--line:#dfe5dc;--ink:#17201c;--muted:#637067;min-height:100vh;background:var(--paper);color:var(--ink);font-family:Arial,Helvetica,sans-serif}.page *{box-sizing:border-box}.page a{text-decoration:none;color:inherit}.container{width:min(1160px,calc(100% - 40px));margin:0 auto}.header{position:sticky;top:0;z-index:30;border-bottom:1px solid var(--line);background:rgba(247,248,243,.95);backdrop-filter:blur(14px)}.headerInner{min-height:72px;display:flex;align-items:center;gap:22px}.logo{width:168px;height:auto;margin-right:auto}.nav{display:flex;gap:18px;font-size:.86rem;font-weight:800}.nav a:hover{color:var(--green700)}.button{display:inline-flex;align-items:center;justify-content:center;min-height:44px;padding:0 18px;border-radius:999px;border:1px solid var(--line);font-weight:800}.primary{background:var(--green800);border-color:var(--green800);color:#fff!important}.hero{padding:84px 0 90px;background:linear-gradient(135deg,#f8faee,#e3f0dd)}.heroGrid{display:grid;grid-template-columns:1.15fr .85fr;gap:64px;align-items:end}.eyebrow{display:inline-block;margin-bottom:12px;color:var(--green700);font-size:.72rem;font-weight:900;letter-spacing:.11em;text-transform:uppercase}.page h1,.page h2,.page h3{margin:0;font-family:"Arial Rounded MT","Arial Rounded MT Bold",Arial,sans-serif;letter-spacing:-.03em;line-height:1.05}.page h1{font-size:clamp(3rem,6vw,5.4rem)}.page h2{font-size:clamp(2rem,4vw,3.4rem)}.page h3{font-size:1.3rem}.lead{max-width:780px;font-size:1.15rem;line-height:1.65;color:#506058}.truth{padding:26px;border:1px solid var(--line);border-radius:26px;background:#fff}.truth strong{display:block;font-size:1.25rem;margin-bottom:10px}.truth p{margin:0;color:var(--muted);line-height:1.6}.section{padding:88px 0}.section.white{background:#fff}.section.soft{background:var(--soft)}.sectionHead{max-width:820px;margin-bottom:34px}.sectionHead p{color:var(--muted);line-height:1.6}.projectGrid{display:grid;grid-template-columns:repeat(2,1fr);gap:18px}.projectCard{position:relative;overflow:hidden;min-height:390px;padding:32px;border-radius:28px;border:1px solid var(--line);background:#fff;display:flex;flex-direction:column}.projectCard::after{content:"";position:absolute;width:220px;height:220px;right:-70px;bottom:-90px;border-radius:50%;background:var(--soft)}.projectCard p{color:var(--muted);line-height:1.6;max-width:90%;z-index:1}.projectCard a{margin-top:auto;color:var(--green700);font-weight:900;z-index:1}.status{display:inline-flex;width:fit-content;padding:7px 10px;border-radius:999px;background:var(--soft);color:var(--green800);font-size:.68rem;font-weight:900;text-transform:uppercase;letter-spacing:.05em;margin-bottom:18px}.region{display:block;margin:8px 0 18px;color:var(--muted);font-size:.85rem;font-weight:800}.capGrid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}.capCard{padding:22px;border:1px solid var(--line);border-radius:20px;background:#fff}.capCard span{display:block;color:var(--green700);font-size:.72rem;font-weight:900}.capCard h3{margin-top:12px}.capCard p{color:var(--muted);font-size:.9rem;line-height:1.55}.dark{padding:78px 0;background:var(--green950);color:#fff}.darkGrid{display:grid;grid-template-columns:.8fr 1.2fr;gap:50px}.dark .eyebrow{color:#c8f5ad}.dark p{margin:0;color:#c5d3cc;line-height:1.7}.detailHero{padding:76px 0 80px;background:linear-gradient(135deg,#f8faee,#e3f0dd)}.back{display:inline-flex;margin-bottom:24px;color:var(--green700);font-weight:900}.detailGrid{display:grid;grid-template-columns:1.15fr .85fr;gap:60px}.detailFact{padding:25px;border-radius:24px;border:1px solid var(--line);background:#fff}.detailFact strong{display:block;margin-bottom:8px}.detailFact p{margin:0;color:var(--muted);line-height:1.6}.phaseGrid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}.phase{padding:24px;border-radius:22px;background:#fff;border:1px solid var(--line)}.phase span{display:block;color:var(--green700);font-size:.72rem;font-weight:900}.phase p{color:var(--muted);line-height:1.55}.closing{padding:68px 0;background:var(--lime)}.closingInner{display:flex;align-items:end;justify-content:space-between;gap:24px}.footer{padding:30px 0;background:#0d241d;color:#b9c8c0}.footerInner{display:flex;justify-content:space-between;gap:20px}.footer a{color:#daf7c7;font-weight:800}@media(max-width:900px){.nav{display:none}.heroGrid,.detailGrid,.darkGrid{grid-template-columns:1fr}.capGrid{grid-template-columns:repeat(2,1fr)}.phaseGrid{grid-template-columns:1fr}}@media(max-width:640px){.container{width:min(100% - 28px,1160px)}.projectGrid,.capGrid{grid-template-columns:1fr}.hero{padding:62px 0}.closingInner,.footerInner{flex-direction:column;align-items:flex-start}.projectCard{min-height:0}}
+.page {
+  --forest: #12372c;
+  --forest-deep: #0b241c;
+  --green: #0a7a4b;
+  --lime: #b8d65f;
+  --sun: #ddc952;
+  --ink: #18241f;
+  --muted: #69736d;
+  --paper: #fbfaf5;
+  --cream: #f0ede3;
+  --white: #ffffff;
+  --line: rgba(24, 36, 31, 0.16);
+  --line-dark: rgba(255, 255, 255, 0.18);
+  --display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Baskerville, Georgia, serif;
+  --sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  min-height: 100vh;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  line-height: 1.55;
+}
+.page *, .page *::before, .page *::after { box-sizing: border-box; }
+.page a { color: inherit; text-decoration: none; }
+.page a:focus-visible { outline: 3px solid var(--sun); outline-offset: 4px; }
+.container { width: min(1240px, calc(100% - 48px)); margin: 0 auto; }
+.page h1, .page h2, .page h3 { margin: 0; font-family: var(--display); font-weight: 600; line-height: 0.98; letter-spacing: -0.035em; }
+.page h1 { font-size: clamp(4rem, 7vw, 7.1rem); }
+.page h2 { font-size: clamp(2.8rem, 4.8vw, 5rem); }
+.page h3 { font-size: clamp(1.65rem, 2.1vw, 2.3rem); }
+.eyebrow { display: inline-block; margin-bottom: 15px; color: var(--green); font-size: .71rem; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+.hero, .detailHero { position: relative; background: var(--cream); border-bottom: 1px solid var(--line); }
+.heroAccent { height: 7px; background: var(--sun); }
+.heroGrid { min-height: 680px; display: grid; grid-template-columns: minmax(0,1.2fr) minmax(340px,.72fr); gap: 82px; align-items: center; padding: 82px 0 90px; }
+.lead { max-width: 820px; margin: 28px 0 0; color: #4f5d55; font-size: clamp(1.06rem,1.6vw,1.3rem); line-height: 1.7; }
+.truth, .detailFact { padding: 32px; background: var(--forest); color: var(--white); border-left: 8px solid var(--lime); }
+.truth > span, .detailFact > span { display: block; margin-bottom: 14px; color: #d8ed9c; font-size: .7rem; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+.truth strong, .detailFact strong { display: block; font-family: var(--display); font-size: 1.7rem; font-weight: 600; }
+.truth p, .detailFact p { margin: 12px 0 0; color: #b7c7bd; line-height: 1.7; }
+.section { padding: 110px 0; background: var(--paper); }
+.section.white { background: var(--paper); }
+.section.soft { background: var(--cream); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.sectionHead { max-width: 930px; margin-bottom: 52px; }
+.sectionHead p { max-width: 760px; margin: 22px 0 0; color: var(--muted); font-size: 1.04rem; line-height: 1.7; }
+.projectGrid { border-top: 1px solid var(--line); }
+.projectCard { min-height: 220px; display: grid; grid-template-columns: 70px minmax(0,1fr) auto; gap: 32px; align-items: center; padding: 34px 0; border-bottom: 1px solid var(--line); }
+.projectIndex { color: var(--green); font-size: .72rem; font-weight: 800; }
+.status { display: inline-block; width: fit-content; margin: 0 0 12px; color: var(--green); font-size: .68rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.region { display: block; margin: 9px 0 16px; color: #8a7929; font-size: .72rem; font-weight: 800; letter-spacing: .07em; text-transform: uppercase; }
+.projectCard p { max-width: 760px; margin: 0; color: var(--muted); line-height: 1.65; }
+.projectCard > a { min-height: 44px; display: inline-flex; align-items: center; color: var(--green); font-weight: 800; white-space: nowrap; }
+.capGrid { border-top: 1px solid var(--line); }
+.capCard { min-height: 128px; display: grid; grid-template-columns: 70px 1fr; gap: 28px; align-items: start; padding: 26px 0; border-bottom: 1px solid var(--line); }
+.capCard > span, .phase > span, .flowList article > span { color: var(--green); font-size: .72rem; font-weight: 800; }
+.capCard h3 { margin-bottom: 9px; }
+.capCard p, .phase p, .flowList p { margin: 0; color: var(--muted); line-height: 1.65; }
+.dark { padding: 100px 0; background: var(--forest-deep); color: var(--white); }
+.darkGrid { display: grid; grid-template-columns: minmax(0,.9fr) minmax(0,1.1fr); gap: 76px; align-items: start; }
+.dark .eyebrow { color: #d8ed9c; }
+.dark p { margin: 36px 0 0; color: #afc0b6; font-size: 1.02rem; line-height: 1.75; }
+.button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; margin-top: 26px; padding: 0 20px; border: 1px solid var(--line); border-radius: 4px; font-size: .78rem; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
+.light { background: var(--paper); border-color: var(--paper); color: var(--forest-deep) !important; }
+.darkButton { background: var(--forest-deep); border-color: var(--forest-deep); color: var(--white) !important; }
+.flowList { border-top: 1px solid var(--line); }
+.flowList article { min-height: 118px; display: grid; grid-template-columns: 70px 1fr; gap: 28px; align-items: center; border-bottom: 1px solid var(--line); }
+.flowList h3 { margin-bottom: 7px; }
+.detailHero { padding-bottom: 82px; }
+.detailHero .container { padding-top: 42px; }
+.back { min-height: 44px; display: inline-flex; align-items: center; margin-bottom: 34px; color: var(--green); font-size: .78rem; font-weight: 800; }
+.detailGrid { display: grid; grid-template-columns: minmax(0,1.15fr) minmax(320px,.65fr); gap: 72px; align-items: end; }
+.detailGrid .status { margin-right: 16px; }
+.detailGrid .eyebrow { color: #8a7929; }
+.phaseGrid { border-top: 1px solid var(--line); }
+.phase { min-height: 150px; display: grid; grid-template-columns: 70px 1fr; gap: 28px; align-items: start; padding: 28px 0; border-bottom: 1px solid var(--line); }
+.phase h3 { margin-bottom: 9px; }
+.closing { padding: 88px 0; background: var(--lime); }
+.closingInner { display: grid; grid-template-columns: minmax(0,1fr) auto; gap: 64px; align-items: end; }
+.closingInner h2 { max-width: 880px; }
+
+@media (max-width: 1060px) {
+  .heroGrid, .detailGrid, .darkGrid, .closingInner { grid-template-columns: 1fr; }
+  .heroGrid { min-height: auto; }
+  .projectCard { grid-template-columns: 60px 1fr; }
+  .projectCard > a { grid-column: 2; justify-self: start; }
+}
+@media (max-width: 760px) {
+  .container { width: min(100% - 28px,1240px); }
+  .page h1 { font-size: clamp(3.5rem,15vw,5rem); }
+  .page h2 { font-size: clamp(2.55rem,11vw,3.8rem); }
+  .heroGrid { padding: 62px 0 72px; gap: 46px; }
+  .truth, .detailFact { padding: 24px; border-left-width: 5px; }
+  .section, .dark { padding: 82px 0; }
+  .projectCard, .capCard, .phase, .flowList article { grid-template-columns: 42px 1fr; gap: 18px; }
+  .detailGrid { gap: 38px; }
+  .closingInner { gap: 24px; }
+}
+@media (max-width: 480px) {
+  .projectCard, .capCard, .phase, .flowList article { grid-template-columns: 1fr; }
+  .projectCard > a { grid-column: auto; }
+  .button { width: 100%; }
+}

--- a/src/app/soluciones/[slug]/page.tsx
+++ b/src/app/soluciones/[slug]/page.tsx
@@ -17,6 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: `${service.name} | Greenatics`,
     description: service.summary,
+    alternates: { canonical: `/soluciones/${service.slug}` },
   };
 }
 
@@ -27,21 +28,22 @@ export default async function SolutionDetailPage({ params }: Props) {
 
   return (
     <div className={styles.page}>
-      <header className={styles.header}>
-        <div className={`${styles.container} ${styles.headerInner}`}>
-          <Link href="/" aria-label="Greenatics, inicio"><img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" /></Link>
-          <nav className={styles.nav} aria-label="Navegación pública"><Link href="/soluciones">Soluciones</Link><Link href="/wondergreen">Wondergreen</Link><Link href="/biblioteca">Conocimiento</Link></nav>
-          <div className={styles.headerActions}><Link className={`${styles.button} ${styles.ghost}`} href="/#contacto">Contacto</Link><Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link></div>
-        </div>
-      </header>
-
       <main>
         <section className={styles.detailHero}>
+          <div className={styles.heroAccent} aria-hidden="true" />
           <div className={styles.container}>
             <div className={styles.breadcrumb}><Link href="/soluciones">Soluciones</Link><span>→</span><span>{service.category}</span></div>
             <div className={styles.detailGrid}>
-              <div><span className={styles.eyebrow}>{service.audience} · {service.category}</span><h1>{service.name}</h1><p className={styles.lead} style={{color:"#506058"}}>{service.summary}</p></div>
-              <aside className={styles.detailAside}><strong>Qué problema busca resolver</strong><p>{service.solves}</p></aside>
+              <div>
+                <span className={styles.eyebrow}>{service.audience} · {service.category}</span>
+                <h1>{service.name}</h1>
+                <p className={styles.detailLead}>{service.summary}</p>
+              </div>
+              <aside className={styles.detailAside}>
+                <span>Problema de partida</span>
+                <strong>Qué problema busca resolver</strong>
+                <p>{service.solves}</p>
+              </aside>
             </div>
           </div>
         </section>
@@ -49,15 +51,22 @@ export default async function SolutionDetailPage({ params }: Props) {
         <section className={styles.detailBody}>
           <div className={styles.container}>
             <div className={styles.detailColumns}>
-              <article className={styles.listBox}><span className={styles.eyebrow}>Alcance posible</span><h2>Qué puede incluir</h2><ul>{service.includes.map((item)=><li key={item}>{item}</li>)}</ul></article>
-              <article className={styles.listBox}><span className={styles.eyebrow}>Salida esperada</span><h2>Entregables típicos</h2><ul>{service.deliverables.map((item)=><li key={item}>{item}</li>)}</ul></article>
+              <article className={styles.listBox}>
+                <span className={styles.detailIndex}>01</span>
+                <div><span className={styles.eyebrow}>Alcance posible</span><h2>Qué puede incluir</h2><ul>{service.includes.map((item) => <li key={item}>{item}</li>)}</ul></div>
+              </article>
+              <article className={styles.listBox}>
+                <span className={styles.detailIndex}>02</span>
+                <div><span className={styles.eyebrow}>Salida esperada</span><h2>Entregables típicos</h2><ul>{service.deliverables.map((item) => <li key={item}>{item}</li>)}</ul></div>
+              </article>
             </div>
-            <div className={styles.detailCta}><div><span className={styles.eyebrow}>Siguiente paso</span><h3>{service.cta}</h3><p>El alcance final depende del diagnóstico, la información disponible y las responsabilidades acordadas para el proyecto.</p></div><Link className={`${styles.button} ${styles.primary}`} href="/#contacto">Hablar con Greenatics</Link></div>
+            <div className={styles.detailCta}>
+              <div><span className={styles.eyebrow}>Siguiente paso</span><h3>{service.cta}</h3><p>El alcance final depende del diagnóstico, la información disponible y las responsabilidades acordadas para el proyecto.</p></div>
+              <Link className={`${styles.button} ${styles.primary}`} href="/contacto">Hablar con Greenatics</Link>
+            </div>
           </div>
         </section>
       </main>
-
-      <footer className={styles.footer}><div className={`${styles.container} ${styles.footerInner}`}><span>Greenatics · soluciones circulares</span><div><Link href="/soluciones">Todas las soluciones</Link> · <Link href="/app">GREENATICS OPS</Link></div></div></footer>
     </div>
   );
 }

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -6,6 +6,7 @@ import styles from "./solutions.module.css";
 export const metadata: Metadata = {
   title: "Soluciones | Greenatics",
   description: "Diagnóstico, planeación, rutas selectivas, plantas, operación y trazabilidad para municipios, ESP, empresas y grandes generadores.",
+  alternates: { canonical: "/soluciones" },
 };
 
 const categoryIntro: Record<ServiceCategory, string> = {
@@ -21,30 +22,21 @@ const path = ["Entender", "Recolectar", "Transformar", "Operar", "Medir", "Devol
 export default function SolutionsPage() {
   return (
     <div className={styles.page}>
-      <header className={styles.header}>
-        <div className={`${styles.container} ${styles.headerInner}`}>
-          <Link href="/" aria-label="Greenatics, inicio"><img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" /></Link>
-          <nav className={styles.nav} aria-label="Navegación pública">
-            <Link href="/soluciones">Soluciones</Link>
-            <Link href="/wondergreen">Wondergreen</Link>
-            <Link href="/biblioteca">Conocimiento</Link>
-          </nav>
-          <div className={styles.headerActions}>
-            <Link className={`${styles.button} ${styles.ghost}`} href="/#contacto">Contacto</Link>
-            <Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link>
-          </div>
-        </div>
-      </header>
-
       <main>
         <section className={styles.hero}>
+          <div className={styles.heroAccent} aria-hidden="true" />
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Soluciones Greenatics</span>
+              <span className={styles.eyebrow}>Soluciones Greenatics · Del diagnóstico a la operación</span>
               <h1>El proyecto no empieza en la planta ni termina cuando se entrega un equipo.</h1>
               <p className={styles.lead}>Greenatics trabaja sobre toda la cadena: diagnosticar, planear, recolectar, transformar, operar, medir y devolver valor. Cada servicio puede contratarse como una fase independiente o integrarse dentro de un sistema territorial o empresarial.</p>
+              <div className={styles.heroLinks}>
+                <a href="#municipios">Municipios y ESP →</a>
+                <a href="#empresas">Empresas →</a>
+              </div>
             </div>
             <aside className={styles.heroProof}>
+              <span>Principio de diseño</span>
               <strong>Residuo → operación → producto → dato.</strong>
               <p>No partimos de una máquina predeterminada. Partimos del origen, volumen, composición, logística, infraestructura, actores, destino de productos y capacidad real de gestión.</p>
             </aside>
@@ -52,31 +44,54 @@ export default function SolutionsPage() {
         </section>
 
         <section className={styles.path} aria-label="Ruta de solución Greenatics">
-          <div className={`${styles.container} ${styles.pathGrid}`}>{path.map((item,index)=><div key={item}><span>{String(index+1).padStart(2,"0")}</span><strong>{item}</strong></div>)}</div>
+          <div className={`${styles.container} ${styles.pathGrid}`}>
+            {path.map((item, index) => <div key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>)}
+          </div>
         </section>
 
         <section className={styles.audience}>
           <div className={styles.container}>
-            <div className={styles.sectionHead}><span className={styles.eyebrow}>Empieza por tu contexto</span><h2>La misma corriente orgánica exige decisiones distintas según quién la genera y quién la opera.</h2><p>Por eso el portafolio distingue rutas para territorios y prestadores, y rutas para empresas o grandes generadores.</p></div>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Empieza por tu contexto</span>
+              <h2>La misma corriente orgánica exige decisiones distintas según quién la genera y quién la opera.</h2>
+              <p>Por eso el portafolio distingue rutas para territorios y prestadores, y rutas para empresas o grandes generadores.</p>
+            </div>
             <div className={styles.audienceGrid}>
-              <article className={styles.audienceCard} id="municipios"><span className={styles.eyebrow}>Municipios y ESP</span><h3>Del PGIRS a una operación sostenible.</h3><p>Planeación, rutas selectivas, infraestructura, rehabilitación, operación y trazabilidad para convertir metas territoriales en capacidad real.</p><ul><li>{municipalServices.length} servicios aplicables al contexto territorial</li><li>Diagnóstico antes de dimensionar infraestructura</li><li>Operación y datos como parte del sistema</li></ul><a href="#planeación">Ver ruta para municipios →</a></article>
-              <article className={styles.audienceCard} id="empresas"><span className={styles.eyebrow}>Empresas y grandes generadores</span><h3>De residuo operativo a flujo gestionado y trazable.</h3><p>Caracterización, PMIRS, separación, recolección, tratamiento, infraestructura y evidencia de gestión según el tipo de corriente.</p><ul><li>{companyServices.length} servicios aplicables a empresas</li><li>La logística se diseña desde el punto de generación</li><li>Tratamiento y evidencia permanecen conectados</li></ul><a href="#planeación">Ver ruta para empresas →</a></article>
+              <article className={styles.audienceCard} id="municipios">
+                <div className={styles.audienceIndex}>01</div>
+                <div><span className={styles.eyebrow}>Municipios y ESP</span><h3>Del PGIRS a una operación sostenible.</h3><p>Planeación, rutas selectivas, infraestructura, rehabilitación, operación y trazabilidad para convertir metas territoriales en capacidad real.</p></div>
+                <div className={styles.audienceFacts}><strong>{municipalServices.length}</strong><span>servicios aplicables</span><small>Diagnóstico antes de dimensionar · operación y datos dentro del sistema.</small></div>
+                <a href="#planeación">Ver ruta →</a>
+              </article>
+              <article className={styles.audienceCard} id="empresas">
+                <div className={styles.audienceIndex}>02</div>
+                <div><span className={styles.eyebrow}>Empresas y grandes generadores</span><h3>De residuo operativo a flujo gestionado y trazable.</h3><p>Caracterización, PMIRS, separación, recolección, tratamiento, infraestructura y evidencia de gestión según el tipo de corriente.</p></div>
+                <div className={styles.audienceFacts}><strong>{companyServices.length}</strong><span>servicios aplicables</span><small>Logística desde el origen · tratamiento y evidencia conectados.</small></div>
+                <a href="#planeación">Ver ruta →</a>
+              </article>
             </div>
           </div>
         </section>
 
-        {serviceCategories.map((category) => {
+        {serviceCategories.map((category, categoryIndex) => {
           const items = services.filter((service) => service.category === category);
           return (
             <section className={styles.category} key={category} id={category.toLocaleLowerCase("es")}>
               <div className={styles.container}>
-                <div className={styles.categoryHead}><div><span className={styles.eyebrow}>{category}</span><h2>{categoryIntro[category]}</h2></div><strong>{items.length} solución{items.length === 1 ? "" : "es"}</strong></div>
+                <div className={styles.categoryHead}>
+                  <span className={styles.categoryIndex}>{String(categoryIndex + 1).padStart(2, "0")}</span>
+                  <div><span className={styles.eyebrow}>{category}</span><h2>{categoryIntro[category]}</h2></div>
+                  <strong>{items.length} solución{items.length === 1 ? "" : "es"}</strong>
+                </div>
                 <div className={styles.serviceGrid}>
-                  {items.map((service) => (
+                  {items.map((service, index) => (
                     <article className={styles.card} key={service.slug}>
-                      <div className={styles.meta}><span>{service.audience}</span><em>{service.category}</em></div>
-                      <h3>{service.name}</h3>
-                      <p>{service.summary}</p>
+                      <span className={styles.serviceIndex}>{String(index + 1).padStart(2, "0")}</span>
+                      <div className={styles.serviceBody}>
+                        <div className={styles.meta}><span>{service.audience}</span><em>{service.category}</em></div>
+                        <h3>{service.name}</h3>
+                        <p>{service.summary}</p>
+                      </div>
                       <div className={styles.problem}><strong>Qué resuelve</strong><p>{service.solves}</p></div>
                       <Link href={`/soluciones/${service.slug}`}>Ver solución en profundidad →</Link>
                     </article>
@@ -88,11 +103,12 @@ export default function SolutionsPage() {
         })}
 
         <section className={styles.guardrail}>
-          <div className={`${styles.container} ${styles.guardrailGrid}`}><div><span className={styles.eyebrow}>Alcance responsable</span><h2>El portafolio es modular; el alcance contractual manda.</h2></div><p>Estas fichas describen capacidades y entregables posibles. Cada proyecto define expresamente estudios, ingeniería, construcción, permisos, operación, personal, certificaciones, informes y responsabilidades incluidas. La web no convierte una capacidad general en una obligación contractual automática.</p></div>
+          <div className={`${styles.container} ${styles.guardrailGrid}`}>
+            <div><span className={styles.eyebrow}>Alcance responsable</span><h2>El portafolio es modular; el alcance contractual manda.</h2></div>
+            <p>Estas fichas describen capacidades y entregables posibles. Cada proyecto define expresamente estudios, ingeniería, construcción, permisos, operación, personal, certificaciones, informes y responsabilidades incluidas. La web no convierte una capacidad general en una obligación contractual automática.</p>
+          </div>
         </section>
       </main>
-
-      <footer className={styles.footer}><div className={`${styles.container} ${styles.footerInner}`}><span>Greenatics · transformar residuos en vida</span><div><Link href="/wondergreen">Wondergreen</Link> · <Link href="/biblioteca">Biblioteca</Link> · <Link href="/app">GREENATICS OPS</Link></div></div></footer>
     </div>
   );
 }

--- a/src/app/soluciones/solutions.module.css
+++ b/src/app/soluciones/solutions.module.css
@@ -1,1 +1,210 @@
-.page{--green950:#14352c;--green800:#006b45;--green700:#008b4c;--lime:#98cf4f;--paper:#f7f8f3;--soft:#eef4eb;--line:#dfe5dc;--ink:#17201c;--muted:#637067;min-height:100vh;background:var(--paper);color:var(--ink);font-family:Arial,Helvetica,sans-serif}.page *{box-sizing:border-box}.page a{text-decoration:none;color:inherit}.container{width:min(1160px,calc(100% - 40px));margin:0 auto}.header{position:sticky;top:0;z-index:30;border-bottom:1px solid var(--line);background:rgba(247,248,243,.95);backdrop-filter:blur(14px)}.headerInner{min-height:72px;display:flex;align-items:center;gap:22px}.logo{width:168px;height:auto;margin-right:auto}.nav{display:flex;gap:18px;font-size:.86rem;font-weight:800}.nav a:hover{color:var(--green700)}.headerActions{display:flex;gap:8px}.button{display:inline-flex;align-items:center;justify-content:center;min-height:44px;padding:0 18px;border-radius:999px;border:1px solid var(--line);font-weight:800}.primary{background:var(--green800);border-color:var(--green800);color:#fff!important}.ghost{background:transparent}.hero{padding:86px 0 90px;background:linear-gradient(135deg,#15382e,#0c6040);color:#fff}.heroGrid{display:grid;grid-template-columns:1.2fr .8fr;gap:70px;align-items:end}.eyebrow{display:inline-block;margin-bottom:12px;font-size:.72rem;font-weight:900;letter-spacing:.11em;text-transform:uppercase;color:var(--green700)}.hero .eyebrow{color:#c8f5ad}.page h1,.page h2,.page h3{font-family:"Arial Rounded MT","Arial Rounded MT Bold",Arial,sans-serif;letter-spacing:-.03em;line-height:1.05;margin:0}.page h1{font-size:clamp(3rem,6vw,5.6rem)}.page h2{font-size:clamp(2rem,4vw,3.5rem)}.page h3{font-size:1.3rem}.lead{font-size:1.15rem;line-height:1.65;color:#d4e1db;max-width:790px}.heroProof{padding:26px;border-radius:26px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.16)}.heroProof strong{display:block;font-size:1.35rem;margin-bottom:10px}.heroProof p{margin:0;color:#d4e1db;line-height:1.55}.path{padding:26px 0;background:#fff;border-bottom:1px solid var(--line)}.pathGrid{display:grid;grid-template-columns:repeat(6,1fr);gap:10px}.pathGrid div{padding:10px 12px;border-left:1px solid var(--line)}.pathGrid span{display:block;font-size:.7rem;font-weight:900;color:var(--green700)}.pathGrid strong{display:block;margin-top:4px}.audience{padding:84px 0}.sectionHead{max-width:850px;margin-bottom:34px}.sectionHead p{color:var(--muted);font-size:1.04rem;line-height:1.6}.audienceGrid{display:grid;grid-template-columns:repeat(2,1fr);gap:18px}.audienceCard{padding:30px;border:1px solid var(--line);border-radius:28px;background:#fff}.audienceCard p{color:var(--muted);line-height:1.55}.audienceCard ul{padding-left:18px;color:#47544d;line-height:1.6}.audienceCard a{display:inline-flex;margin-top:14px;color:var(--green700);font-weight:900}.category{padding:86px 0}.category:nth-of-type(even){background:#fff}.categoryHead{display:grid;grid-template-columns:1fr auto;gap:30px;align-items:end;margin-bottom:28px}.categoryHead>strong{font-size:.85rem;color:var(--muted)}.serviceGrid{display:grid;grid-template-columns:repeat(2,1fr);gap:16px}.card{padding:26px;border:1px solid var(--line);border-radius:24px;background:#fff;display:flex;flex-direction:column;min-height:330px}.meta{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:15px}.meta span,.meta em{display:inline-flex;padding:6px 9px;border-radius:999px;background:var(--soft);font-size:.68rem;font-style:normal;font-weight:900;text-transform:uppercase;letter-spacing:.04em}.meta em{background:#f3f0da}.card p{color:var(--muted);line-height:1.55}.problem{margin:8px 0 18px;padding:16px;border-radius:16px;background:var(--soft)}.problem strong{display:block;font-size:.76rem;text-transform:uppercase;letter-spacing:.06em;color:var(--green700)}.problem p{margin:6px 0 0;font-size:.9rem}.card>a{margin-top:auto;color:var(--green700);font-weight:900}.guardrail{padding:74px 0;background:var(--green950);color:#fff}.guardrailGrid{display:grid;grid-template-columns:.8fr 1.2fr;gap:50px;align-items:start}.guardrail .eyebrow{color:#c8f5ad}.guardrail p{margin:0;color:#c2d0c9;line-height:1.7}.detailHero{padding:78px 0 72px;background:linear-gradient(135deg,#f8faee,#e4f1de)}.breadcrumb{display:flex;gap:8px;align-items:center;font-size:.82rem;color:var(--green700);font-weight:800;margin-bottom:24px}.detailGrid{display:grid;grid-template-columns:1.15fr .85fr;gap:60px}.detailAside{padding:24px;border-radius:24px;background:#fff;border:1px solid var(--line)}.detailAside strong{display:block;margin-bottom:8px}.detailAside p{margin:0;color:var(--muted);line-height:1.6}.detailBody{padding:82px 0}.detailColumns{display:grid;grid-template-columns:1fr 1fr;gap:34px}.listBox{padding:26px;border-radius:24px;background:#fff;border:1px solid var(--line)}.listBox ul{padding-left:19px;line-height:1.65;color:#4d5b53}.detailCta{margin-top:34px;padding:28px;border-radius:26px;background:var(--soft);display:flex;align-items:center;justify-content:space-between;gap:20px}.footer{padding:30px 0;background:#0d241d;color:#b9c8c0}.footerInner{display:flex;justify-content:space-between;gap:20px}.footer a{color:#d9f8c3;font-weight:800}@media(max-width:900px){.nav{display:none}.heroGrid,.guardrailGrid,.detailGrid,.detailColumns{grid-template-columns:1fr}.pathGrid{grid-template-columns:repeat(3,1fr)}.serviceGrid{grid-template-columns:1fr}}@media(max-width:640px){.container{width:min(100% - 28px,1160px)}.headerActions .ghost{display:none}.hero{padding:64px 0}.audienceGrid{grid-template-columns:1fr}.pathGrid{grid-template-columns:repeat(2,1fr)}.categoryHead{grid-template-columns:1fr}.detailCta,.footerInner{flex-direction:column;align-items:flex-start}.card{min-height:0}}
+.page {
+  --forest: #12372c;
+  --forest-deep: #0b241c;
+  --green: #0a7a4b;
+  --lime: #b8d65f;
+  --sun: #ddc952;
+  --ink: #18241f;
+  --muted: #69736d;
+  --paper: #fbfaf5;
+  --cream: #f0ede3;
+  --white: #ffffff;
+  --line: rgba(24, 36, 31, 0.16);
+  --line-dark: rgba(255, 255, 255, 0.18);
+  --display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Baskerville, Georgia, serif;
+  --sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  min-height: 100vh;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  line-height: 1.55;
+}
+
+.page *, .page *::before, .page *::after { box-sizing: border-box; }
+.page a { color: inherit; text-decoration: none; }
+.page a:focus-visible { outline: 3px solid var(--sun); outline-offset: 4px; }
+.container { width: min(1240px, calc(100% - 48px)); margin: 0 auto; }
+
+.page h1, .page h2, .page h3 {
+  margin: 0;
+  font-family: var(--display);
+  font-weight: 600;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+}
+.page h1 { font-size: clamp(4rem, 7vw, 7.2rem); }
+.page h2 { font-size: clamp(2.8rem, 4.8vw, 5rem); }
+.page h3 { font-size: clamp(1.65rem, 2.15vw, 2.35rem); }
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 15px;
+  color: var(--green);
+  font-size: 0.71rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.hero, .detailHero { position: relative; background: var(--cream); border-bottom: 1px solid var(--line); }
+.heroAccent { height: 7px; background: var(--lime); }
+.heroGrid {
+  min-height: 680px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(340px, 0.75fr);
+  gap: 82px;
+  align-items: center;
+  padding: 82px 0 90px;
+}
+.lead, .detailLead {
+  max-width: 800px;
+  margin: 28px 0 0;
+  color: #4f5d55;
+  font-size: clamp(1.06rem, 1.6vw, 1.3rem);
+  line-height: 1.7;
+}
+.heroLinks { display: flex; flex-wrap: wrap; gap: 22px; margin-top: 32px; }
+.heroLinks a { min-height: 44px; display: inline-flex; align-items: center; color: var(--green); font-weight: 800; border-bottom: 1px solid currentColor; }
+.heroProof {
+  padding: 32px;
+  background: var(--forest);
+  color: var(--white);
+  border-left: 8px solid var(--sun);
+}
+.heroProof > span, .detailAside > span {
+  display: block;
+  margin-bottom: 14px;
+  color: #d8ed9c;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.heroProof strong { display: block; margin-bottom: 12px; font-family: var(--display); font-size: 1.8rem; font-weight: 600; }
+.heroProof p { margin: 0; color: #b7c7bd; line-height: 1.7; }
+
+.path { background: var(--forest-deep); color: var(--white); }
+.pathGrid { display: grid; grid-template-columns: repeat(6, 1fr); }
+.pathGrid div { min-height: 104px; padding: 22px 18px 22px 0; border-right: 1px solid var(--line-dark); }
+.pathGrid div:not(:first-child) { padding-left: 18px; }
+.pathGrid div:last-child { border-right: 0; }
+.pathGrid span { display: block; margin-bottom: 15px; color: #d8ed9c; font-size: 0.7rem; font-weight: 800; }
+.pathGrid strong { font-family: var(--display); font-size: 1.25rem; font-weight: 600; }
+
+.audience { padding: 112px 0; background: var(--paper); }
+.sectionHead { max-width: 930px; margin-bottom: 52px; }
+.sectionHead p { max-width: 760px; margin: 22px 0 0; color: var(--muted); font-size: 1.04rem; line-height: 1.7; }
+.audienceGrid { border-top: 1px solid var(--line); }
+.audienceCard {
+  min-height: 190px;
+  display: grid;
+  grid-template-columns: 70px minmax(0, 1.2fr) minmax(180px, 0.38fr) auto;
+  gap: 30px;
+  align-items: center;
+  padding: 30px 0;
+  border-bottom: 1px solid var(--line);
+}
+.audienceIndex, .categoryIndex, .serviceIndex, .detailIndex { color: var(--green); font-size: 0.72rem; font-weight: 800; }
+.audienceCard p { margin: 10px 0 0; color: var(--muted); line-height: 1.65; }
+.audienceFacts { display: grid; gap: 2px; padding-left: 22px; border-left: 1px solid var(--line); }
+.audienceFacts strong { font-family: var(--display); font-size: 2.8rem; font-weight: 500; }
+.audienceFacts span { font-size: 0.78rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.05em; }
+.audienceFacts small { margin-top: 8px; color: var(--muted); line-height: 1.5; }
+.audienceCard > a { min-height: 44px; display: inline-flex; align-items: center; color: var(--green); font-weight: 800; white-space: nowrap; }
+
+.category { padding: 108px 0; background: var(--cream); border-top: 1px solid var(--line); }
+.category:nth-of-type(even) { background: var(--paper); }
+.categoryHead {
+  display: grid;
+  grid-template-columns: 70px minmax(0, 1fr) auto;
+  gap: 30px;
+  align-items: start;
+  margin-bottom: 42px;
+}
+.categoryHead > strong { color: var(--muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.07em; }
+.serviceGrid { border-top: 1px solid var(--line); }
+.card {
+  min-height: 178px;
+  display: grid;
+  grid-template-columns: 70px minmax(0, 1fr) minmax(240px, 0.7fr) auto;
+  gap: 28px;
+  align-items: center;
+  padding: 28px 0;
+  border-bottom: 1px solid var(--line);
+}
+.meta { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 10px; }
+.meta span, .meta em { color: var(--green); font-size: 0.68rem; font-style: normal; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; }
+.meta em { color: #8b7928; }
+.serviceBody p, .problem p { margin: 9px 0 0; color: var(--muted); line-height: 1.6; }
+.problem { padding-left: 24px; border-left: 1px solid var(--line); }
+.problem strong { color: var(--green); font-size: 0.7rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
+.card > a { min-height: 44px; display: inline-flex; align-items: center; color: var(--green); font-weight: 800; white-space: nowrap; }
+
+.guardrail { padding: 96px 0; background: var(--forest-deep); color: var(--white); }
+.guardrailGrid { display: grid; grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr); gap: 72px; align-items: start; }
+.guardrail .eyebrow { color: #d8ed9c; }
+.guardrail p { margin: 36px 0 0; color: #afc0b6; font-size: 1.02rem; line-height: 1.75; }
+
+.detailHero { padding-bottom: 82px; }
+.detailHero .container { padding-top: 42px; }
+.breadcrumb { min-height: 44px; display: flex; gap: 9px; align-items: center; margin-bottom: 40px; color: var(--green); font-size: 0.78rem; font-weight: 800; }
+.detailGrid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.65fr); gap: 72px; align-items: end; }
+.detailAside { padding: 30px; background: var(--forest); color: var(--white); border-left: 7px solid var(--sun); }
+.detailAside strong { display: block; font-family: var(--display); font-size: 1.55rem; font-weight: 600; }
+.detailAside p { margin: 10px 0 0; color: #b7c7bd; line-height: 1.65; }
+.detailBody { padding: 110px 0; }
+.detailColumns { border-top: 1px solid var(--line); }
+.listBox {
+  min-height: 240px;
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: 26px;
+  padding: 34px 0;
+  border-bottom: 1px solid var(--line);
+}
+.listBox ul { margin: 26px 0 0; padding: 0; list-style: none; }
+.listBox li { position: relative; padding: 13px 0 13px 22px; border-top: 1px solid var(--line); color: #4f5d55; }
+.listBox li::before { content: "→"; position: absolute; left: 0; color: var(--green); }
+.detailCta { margin-top: 46px; padding: 30px 0; display: flex; align-items: end; justify-content: space-between; gap: 40px; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.detailCta p { max-width: 720px; color: var(--muted); }
+.button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; padding: 0 20px; border: 1px solid var(--line); border-radius: 4px; font-size: 0.78rem; font-weight: 800; letter-spacing: 0.05em; text-transform: uppercase; }
+.primary { border-color: var(--forest-deep); background: var(--forest-deep); color: var(--white) !important; }
+
+@media (max-width: 1060px) {
+  .heroGrid, .detailGrid, .guardrailGrid { grid-template-columns: 1fr; }
+  .heroGrid { min-height: auto; }
+  .pathGrid { grid-template-columns: repeat(3, 1fr); }
+  .pathGrid div:nth-child(3) { border-right: 0; }
+  .pathGrid div:nth-child(n+4) { border-top: 1px solid var(--line-dark); }
+  .audienceCard, .card { grid-template-columns: 60px minmax(0, 1fr); }
+  .audienceFacts, .problem { grid-column: 2; padding: 18px 0 0; border-left: 0; border-top: 1px solid var(--line); }
+  .audienceCard > a, .card > a { grid-column: 2; justify-self: start; }
+}
+
+@media (max-width: 760px) {
+  .container { width: min(100% - 28px, 1240px); }
+  .page h1 { font-size: clamp(3.5rem, 15vw, 5rem); }
+  .page h2 { font-size: clamp(2.55rem, 11vw, 3.8rem); }
+  .heroGrid { padding: 62px 0 72px; gap: 46px; }
+  .heroProof, .detailAside { padding: 24px; border-left-width: 5px; }
+  .pathGrid { grid-template-columns: repeat(2, 1fr); }
+  .pathGrid div:nth-child(3) { border-right: 1px solid var(--line-dark); }
+  .pathGrid div:nth-child(even) { border-right: 0; }
+  .pathGrid div:nth-child(n+3) { border-top: 1px solid var(--line-dark); }
+  .audience, .category, .detailBody { padding: 82px 0; }
+  .audienceCard, .card { grid-template-columns: 42px 1fr; gap: 18px; }
+  .categoryHead { grid-template-columns: 42px 1fr; gap: 18px; }
+  .categoryHead > strong { grid-column: 2; }
+  .detailGrid { gap: 38px; }
+  .listBox { grid-template-columns: 42px 1fr; gap: 18px; }
+  .detailCta { align-items: flex-start; flex-direction: column; }
+}
+
+@media (max-width: 480px) {
+  .pathGrid { grid-template-columns: 1fr; }
+  .pathGrid div, .pathGrid div:not(:first-child) { padding-left: 0; border-right: 0; border-top: 1px solid var(--line-dark); }
+  .pathGrid div:first-child { border-top: 0; }
+  .audienceCard, .card, .categoryHead, .listBox { grid-template-columns: 1fr; }
+  .audienceFacts, .problem, .audienceCard > a, .card > a, .categoryHead > strong { grid-column: auto; }
+  .button { width: 100%; }
+}


### PR DESCRIPTION
## Objetivo
Extender el lenguaje editorial público ya certificado en HOME/Wondergreen a Soluciones y Proyectos, eliminando chrome heredado y reduciendo la dependencia de cards sin alterar catálogos, casos ni truth-locks.

## Cambios
- Soluciones y Proyectos confían exclusivamente en sus `layout.tsx` con `PublicShell`; se eliminan header/footer internos heredados.
- Soluciones pasa de card-grid a índice editorial por audiencia, categoría, problema y ruta de profundidad.
- Detalles de solución preservan problema, alcance y entregables con una lectura editorial más clara.
- Proyectos pasa de cards decorativas a índice de casos/evidencia con estado, región y contexto.
- Casos Yarumal/Támesis preservan galería, contexto de publicación, aprendizajes, fases y truth-lock.
- Canonicals explícitos en hubs y páginas de detalle.
- Nueva regresión Playwright para shell único y rutas públicas gobernadas.

## Guardrails
- Sin cambios en `services`, `projects-public` ni datos operacionales.
- Sin nuevos claims de capacidad, impacto o resultados.
- Sin cambios en OPS, auth, RLS, Supabase, SharePoint ni stores.
- Sin activos nuevos o inventados.

## Gate
Mantener draft hasta completar typecheck, lint, unit, build, headers privados, Playwright desktop/móvil y database gates.