### PR TITLE
CORE-004 · Hosted schema contract + drift gate

### DIFF
--- a/docs/deployment/HOSTED_PILOT_RUNBOOK.md
+++ b/docs/deployment/HOSTED_PILOT_RUNBOOK.md
@@ -50,7 +50,7 @@ APP_BASE_URL=https://<origen-canonico>
 `APP_BASE_URL` debe ser un origen HTTP/HTTPS confiable. La API de invitaciones no usa el header `Host` como sustituto.
 
 ## 5. Backend preflight + primer director
-Antes de enviar una invitación real, validar que Supabase, Auth Admin, las plantas canónicas y el estado de bootstrap sean coherentes:
+Antes de enviar una invitación real, validar que el esquema hospedado, RLS, Supabase Auth Admin, las plantas canónicas y el estado de bootstrap sean coherentes:
 
 ```bash
 npm run pilot:backend-preflight -- \
@@ -59,6 +59,8 @@ npm run pilot:backend-preflight -- \
 ```
 
 Este gate es de solo lectura: no crea usuarios, no cambia membresías y no imprime secretos. Debe pasar antes del primer bootstrap.
+
+El preflight consume `admin_hosted_schema_contract()` con `SUPABASE_SECRET_KEY` y falla cerrado si la base no reporta el contrato canónico esperado por el código, si alguna tabla pública queda sin RLS, si faltan plantas piloto o si el estado de Director cambia durante la comprobación. La RPC es server-only: `anon` y `authenticated` no tienen permiso de ejecución. Esto evita depender de timestamps o entradas históricas duplicadas del registro de migraciones para decidir si una base está lista.
 
 Con variables cargadas en un entorno administrativo y `APP_BASE_URL` ya fijado al deployment real:
 
@@ -144,7 +146,7 @@ Con dos perfiles de navegador distintos:
 ## 10. Gate de promoción
 Antes de promover el piloto:
 - CI de PR verde (`quality` + `database`);
-- `npm run pilot:backend-preflight -- --plants TAM,YAR` en PASS;
+- `npm run pilot:backend-preflight -- --plants TAM,YAR` en PASS, incluyendo schema contract + RLS completo;
 - `npm run pilot:preflight` en PASS contra el SHA exacto desplegado;
 - `npm run pilot:rls-smoke` en PASS con los dos usuarios de prueba;
 - smoke funcional multiusuario aprobado;

--- a/scripts/hosted-backend-preflight-lib.mjs
+++ b/scripts/hosted-backend-preflight-lib.mjs
@@ -1,6 +1,8 @@
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { DEFAULT_PILOT_PLANT_CODES, normalizePilotPlantCodes } from "./pilot-plant-codes.mjs";
 
+export const HOSTED_SCHEMA_CONTRACT_VERSION = "0026";
+
 export class BackendPreflightError extends Error {
   constructor(message) {
     super(message);
@@ -42,6 +44,60 @@ function requireRows(data, error, label) {
   return data;
 }
 
+function parseNonNegativeInteger(value, label) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 0) {
+    throw new BackendPreflightError(`${label}: conteo inválido.`);
+  }
+  return number;
+}
+
+function validateSchemaContract(data, error, requestedCodes) {
+  const rows = requireRows(data, error, "No fue posible validar el contrato de esquema hospedado");
+  if (rows.length !== 1 || !rows[0] || typeof rows[0] !== "object") {
+    throw new BackendPreflightError("Contrato de esquema hospedado: se esperaba exactamente una fila.");
+  }
+
+  const row = rows[0];
+  const version = clean(row.schema_contract);
+  if (version !== HOSTED_SCHEMA_CONTRACT_VERSION) {
+    throw new BackendPreflightError(
+      `Contrato de esquema hospedado desactualizado: esperado ${HOSTED_SCHEMA_CONTRACT_VERSION}, recibido ${version || "vacío"}.`,
+    );
+  }
+
+  const publicTableCount = parseNonNegativeInteger(row.public_table_count, "Contrato de esquema hospedado");
+  const rlsEnabledTableCount = parseNonNegativeInteger(row.rls_enabled_table_count, "Contrato de esquema hospedado");
+  if (publicTableCount === 0 || rlsEnabledTableCount !== publicTableCount) {
+    throw new BackendPreflightError(
+      `Contrato de esquema hospedado: RLS incompleto (${rlsEnabledTableCount}/${publicTableCount} tablas públicas).`,
+    );
+  }
+
+  let pilotPlantCodes;
+  try {
+    pilotPlantCodes = normalizePilotPlantCodes(Array.isArray(row.pilot_plant_codes) ? row.pilot_plant_codes : []);
+  } catch (error_) {
+    throw new BackendPreflightError(
+      `Contrato de esquema hospedado: plantas inválidas (${error_ instanceof Error ? error_.message : String(error_)}).`,
+    );
+  }
+  const missingContractPlants = requestedCodes.filter((code) => !pilotPlantCodes.includes(code));
+  if (missingContractPlants.length) {
+    throw new BackendPreflightError(
+      `Contrato de esquema hospedado no contiene las plantas solicitadas: ${missingContractPlants.join(", ")}.`,
+    );
+  }
+
+  return Object.freeze({
+    version,
+    publicTableCount,
+    rlsEnabledTableCount,
+    pilotPlantCodes,
+    activeDirectors: parseNonNegativeInteger(row.active_directors, "Contrato de esquema hospedado"),
+  });
+}
+
 export async function runHostedBackendPreflight({
   env = process.env,
   plants = DEFAULT_PILOT_PLANT_CODES,
@@ -53,6 +109,13 @@ export async function runHostedBackendPreflight({
   const admin = createClientImpl(config.url, config.secret, {
     auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false },
   });
+
+  const schemaContractResponse = await admin.rpc("admin_hosted_schema_contract");
+  const schemaContract = validateSchemaContract(
+    schemaContractResponse.data,
+    schemaContractResponse.error,
+    requestedCodes,
+  );
 
   const plantResponse = await admin
     .from("plants")
@@ -84,9 +147,11 @@ export async function runHostedBackendPreflight({
   if (directorResponse.error) {
     throw new BackendPreflightError(`No fue posible validar el estado del director: ${directorResponse.error.message || "error remoto"}.`);
   }
-  const activeDirectors = Number(directorResponse.count ?? 0);
-  if (!Number.isInteger(activeDirectors) || activeDirectors < 0) {
-    throw new BackendPreflightError("Supabase devolvió un conteo de directores inválido.");
+  const activeDirectors = parseNonNegativeInteger(directorResponse.count ?? 0, "Estado del director");
+  if (schemaContract.activeDirectors !== activeDirectors) {
+    throw new BackendPreflightError(
+      `Estado del director cambió durante el preflight (${schemaContract.activeDirectors} → ${activeDirectors}); vuelve a ejecutar el gate.`,
+    );
   }
   if (requireNoDirector && activeDirectors > 0) {
     throw new BackendPreflightError(`Ya existe ${activeDirectors} director activo; el bootstrap inicial debe permanecer bloqueado.`);
@@ -94,6 +159,7 @@ export async function runHostedBackendPreflight({
 
   return Object.freeze({
     projectOrigin: config.url,
+    schemaContract,
     plants: Object.freeze(requestedCodes.map((code) => Object.freeze({
       code,
       name: String(byCode.get(code)?.name || code),
@@ -101,6 +167,6 @@ export async function runHostedBackendPreflight({
     }))),
     activeDirectors,
     directorState: activeDirectors === 0 ? "empty" : "present",
-    checks: Object.freeze(["database", "auth-admin", "plants", "director-state"]),
+    checks: Object.freeze(["schema-contract", "database", "auth-admin", "plants", "director-state"]),
   });
 }

--- a/scripts/hosted-backend-preflight.mjs
+++ b/scripts/hosted-backend-preflight.mjs
@@ -41,6 +41,9 @@ async function main() {
 
   console.log("GREENATICS hosted backend preflight: PASS");
   console.log(`project: ${new URL(result.projectOrigin).hostname}`);
+  console.log(
+    `schema: ${result.schemaContract.version} · RLS ${result.schemaContract.rlsEnabledTableCount}/${result.schemaContract.publicTableCount}`,
+  );
   console.log(`plants: ${result.plants.map((plant) => `${plant.code}=${plant.name}`).join(", ")}`);
   console.log(`director-state: ${result.directorState} (${result.activeDirectors})`);
   console.log(`checks: ${result.checks.join(", ")}`);

--- a/scripts/hosted-backend-preflight.test.mjs
+++ b/scripts/hosted-backend-preflight.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   BackendPreflightError,
+  HOSTED_SCHEMA_CONTRACT_VERSION,
   normalizeHostedSupabaseUrl,
   runHostedBackendPreflight,
 } from "./hosted-backend-preflight-lib.mjs";
@@ -11,6 +12,17 @@ const env = {
   SUPABASE_SECRET_KEY: "sanitized-server-secret",
 };
 
+function schemaContract(overrides = {}) {
+  return {
+    schema_contract: HOSTED_SCHEMA_CONTRACT_VERSION,
+    public_table_count: 30,
+    rls_enabled_table_count: 30,
+    pilot_plant_codes: ["TAM", "YAR"],
+    active_directors: 0,
+    ...overrides,
+  };
+}
+
 function fakeClient({
   plants = [
     { code: "TAM", name: "Támesis", active: true },
@@ -18,8 +30,15 @@ function fakeClient({
   ],
   activeDirectors = 0,
   authError = null,
+  contract = null,
+  schemaError = null,
 } = {}) {
+  const effectiveContract = contract ?? schemaContract({ active_directors: activeDirectors });
   return {
+    rpc: vi.fn(async (name) => {
+      if (name !== "admin_hosted_schema_contract") throw new Error(`Unexpected RPC ${name}`);
+      return { data: schemaError ? null : [effectiveContract], error: schemaError };
+    }),
     auth: {
       admin: {
         listUsers: vi.fn(async () => ({ data: { users: [] }, error: authError })),
@@ -67,7 +86,7 @@ describe("hosted backend preflight", () => {
     expect(() => normalizeHostedSupabaseUrl("https://sanitized-project.supabase.co/rest/v1")).toThrow(BackendPreflightError);
   });
 
-  it("passes without mutating data when backend, auth and pilot plants are ready", async () => {
+  it("passes without mutating data when schema, backend, auth and pilot plants are ready", async () => {
     const createClientImpl = vi.fn(() => fakeClient());
     const result = await runHostedBackendPreflight({
       env,
@@ -76,15 +95,37 @@ describe("hosted backend preflight", () => {
       createClientImpl,
     });
 
+    expect(result.schemaContract.version).toBe(HOSTED_SCHEMA_CONTRACT_VERSION);
+    expect(result.schemaContract.publicTableCount).toBe(30);
+    expect(result.schemaContract.rlsEnabledTableCount).toBe(30);
     expect(result.plants.map((plant) => plant.code)).toEqual(["TAM", "YAR"]);
     expect(result.activeDirectors).toBe(0);
     expect(result.directorState).toBe("empty");
+    expect(result.checks).toContain("schema-contract");
     expect(result).not.toHaveProperty("secret");
     expect(createClientImpl).toHaveBeenCalledWith(
       env.NEXT_PUBLIC_SUPABASE_URL,
       env.SUPABASE_SECRET_KEY,
       expect.any(Object),
     );
+  });
+
+  it("fails closed when the hosted database is behind the canonical schema contract", async () => {
+    await expect(runHostedBackendPreflight({
+      env,
+      createClientImpl: () => fakeClient({
+        contract: schemaContract({ schema_contract: "0025" }),
+      }),
+    })).rejects.toThrow(/desactualizado.*0026.*0025/);
+  });
+
+  it("fails closed when any public table escapes RLS", async () => {
+    await expect(runHostedBackendPreflight({
+      env,
+      createClientImpl: () => fakeClient({
+        contract: schemaContract({ public_table_count: 30, rls_enabled_table_count: 29 }),
+      }),
+    })).rejects.toThrow(/RLS incompleto \(29\/30/);
   });
 
   it("fails closed when a requested plant is missing or inactive", async () => {
@@ -110,5 +151,15 @@ describe("hosted backend preflight", () => {
       requireNoDirector: true,
       createClientImpl: () => fakeClient({ activeDirectors: 1 }),
     })).rejects.toThrow(/Ya existe 1 director activo/);
+  });
+
+  it("fails closed if director state changes while the preflight is running", async () => {
+    await expect(runHostedBackendPreflight({
+      env,
+      createClientImpl: () => fakeClient({
+        activeDirectors: 1,
+        contract: schemaContract({ active_directors: 0 }),
+      }),
+    })).rejects.toThrow(/cambió durante el preflight/);
   });
 });

--- a/supabase/migrations/0026_hosted_schema_contract.sql
+++ b/supabase/migrations/0026_hosted_schema_contract.sql
@@ -1,0 +1,55 @@
+-- CORE-004I · Hosted schema contract.
+-- Gives the server-side pilot preflight one canonical, versioned read-only contract
+-- without depending on Supabase migration-history timestamps or duplicate legacy rows.
+
+create or replace function public.admin_hosted_schema_contract()
+returns table(
+  schema_contract text,
+  public_table_count bigint,
+  rls_enabled_table_count bigint,
+  pilot_plant_codes text[],
+  active_directors bigint
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    '0026'::text as schema_contract,
+    (
+      select count(*)
+      from pg_catalog.pg_class c
+      join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public'
+        and c.relkind = 'r'
+    ) as public_table_count,
+    (
+      select count(*)
+      from pg_catalog.pg_class c
+      join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public'
+        and c.relkind = 'r'
+        and c.relrowsecurity
+    ) as rls_enabled_table_count,
+    coalesce(
+      (
+        select array_agg(p.code order by p.code)
+        from public.plants p
+        where p.active
+          and p.code in ('TAM', 'YAR')
+      ),
+      '{}'::text[]
+    ) as pilot_plant_codes,
+    (
+      select count(distinct pm.user_id)
+      from public.plant_memberships pm
+      where pm.role = 'director'
+        and pm.active
+    ) as active_directors;
+$$;
+
+revoke all on function public.admin_hosted_schema_contract() from public;
+revoke all on function public.admin_hosted_schema_contract() from anon;
+revoke all on function public.admin_hosted_schema_contract() from authenticated;
+grant execute on function public.admin_hosted_schema_contract() to service_role;

--- a/supabase/migrations/0026_hosted_schema_contract.sql
+++ b/supabase/migrations/0026_hosted_schema_contract.sql
@@ -12,7 +12,7 @@ returns table(
 )
 language sql
 stable
-security definer
+security invoker
 set search_path = ''
 as $$
   select

--- a/supabase/tests/database/hosted_schema_contract.test.sql
+++ b/supabase/tests/database/hosted_schema_contract.test.sql
@@ -1,0 +1,43 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+select plan(8);
+
+select ok(
+  to_regprocedure('public.admin_hosted_schema_contract()') is not null,
+  'hosted schema contract RPC exists'
+);
+select ok(
+  not has_function_privilege('anon','public.admin_hosted_schema_contract()','EXECUTE'),
+  'anon cannot execute hosted schema contract'
+);
+select ok(
+  not has_function_privilege('authenticated','public.admin_hosted_schema_contract()','EXECUTE'),
+  'authenticated cannot execute hosted schema contract'
+);
+select ok(
+  has_function_privilege('service_role','public.admin_hosted_schema_contract()','EXECUTE'),
+  'service_role can execute hosted schema contract'
+);
+select is(
+  (select schema_contract from public.admin_hosted_schema_contract()),
+  '0026',
+  'hosted schema contract reports its canonical version'
+);
+select ok(
+  (select public_table_count > 0 and public_table_count = rls_enabled_table_count from public.admin_hosted_schema_contract()),
+  'every public table in the hosted contract has RLS enabled'
+);
+select is(
+  (select array_to_string(pilot_plant_codes, ',') from public.admin_hosted_schema_contract()),
+  'TAM,YAR',
+  'hosted schema contract exposes the canonical pilot plants'
+);
+select is(
+  (select active_directors from public.admin_hosted_schema_contract()),
+  0::bigint,
+  'fresh database starts without an active director'
+);
+
+select finish();
+rollback;

--- a/supabase/tests/database/hosted_schema_contract.test.sql
+++ b/supabase/tests/database/hosted_schema_contract.test.sql
@@ -1,11 +1,19 @@
 begin;
 
 create extension if not exists pgtap with schema extensions;
-select plan(8);
+select plan(9);
 
 select ok(
   to_regprocedure('public.admin_hosted_schema_contract()') is not null,
   'hosted schema contract RPC exists'
+);
+select ok(
+  not (
+    select p.prosecdef
+    from pg_catalog.pg_proc p
+    where p.oid = to_regprocedure('public.admin_hosted_schema_contract()')
+  ),
+  'hosted schema contract remains SECURITY INVOKER'
 );
 select ok(
   not has_function_privilege('anon','public.admin_hosted_schema_contract()','EXECUTE'),


### PR DESCRIPTION
## Objetivo
Evitar que el piloto hospedado arranque contra un Supabase rezagado o con RLS incompleto, sin depender del historial de migraciones del proveedor.

## Cambios
- `0026_hosted_schema_contract.sql`: RPC read-only y versionada, ejecutable solo por `service_role` y explícitamente `SECURITY INVOKER`.
- Reporta versión canónica, tablas públicas, tablas con RLS, plantas piloto y directores activos.
- `pilot:backend-preflight` exige contrato `0026`, RLS completo, plantas solicitadas y estado coherente del primer Director.
- pgTAP cubre ACL, modo invoker, versión, RLS, plantas y estado inicial.
- Vitest cubre drift de versión, RLS incompleto y cambio concurrente de Director.
- Runbook documenta el gate de deriva hospedada.

## Seguridad
- Sin secretos ni IDs de infraestructura en el repo.
- `anon` y `authenticated` no pueden ejecutar la RPC.
- No introduce un nuevo `SECURITY DEFINER`.
- No modifica datos operativos.
- No toca ni repara manualmente el historial de migraciones existente.

## Gate
Requiere quality + database CI verdes antes de merge.