### PR TITLE
CORE-004 · Reproducible Vercel hosted pilot preview

### DIFF
--- a/.github/workflows/hosted-pilot-preview.yml
+++ b/.github/workflows/hosted-pilot-preview.yml
@@ -1,0 +1,86 @@
+name: hosted-pilot-preview
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: greenatics-hosted-pilot-preview
+  cancel-in-progress: false
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VERCEL_PROJECT_NAME: greenatics-ops
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+      SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+      DEPLOY_GIT_REF: develop
+
+    steps:
+      - name: Checkout canonical develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Resolve exact deployment commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          test "${#sha}" -eq 40
+          echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
+          echo "Deploying develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require hosted pilot secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            VERCEL_TOKEN \
+            VERCEL_ORG_ID \
+            NEXT_PUBLIC_SUPABASE_URL \
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
+            SUPABASE_SECRET_KEY
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is not configured for the hosted pilot workflow."
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Certify hosted Supabase before deployment
+        run: npm run pilot:backend-preflight -- --plants TAM,YAR --require-no-director
+
+      - name: Create or reuse Vercel project and deploy Preview
+        id: deploy
+        run: npm run pilot:vercel-preview
+
+      - name: Certify deployed Preview
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$DEPLOYMENT_URL"
+          npm run pilot:preflight -- \
+            --base-url "$DEPLOYMENT_URL" \
+            --expected-branch "$DEPLOY_GIT_REF" \
+            --expected-commit "$DEPLOY_GIT_SHA"

--- a/docs/deployment/HOSTED_PILOT_RUNBOOK.md
+++ b/docs/deployment/HOSTED_PILOT_RUNBOOK.md
@@ -47,7 +47,32 @@ APP_BASE_URL=https://<origen-canonico>
 
 `SUPABASE_SECRET_KEY` es exclusivamente server-side. Nunca usar prefijo `NEXT_PUBLIC_`, imprimirla, retornarla por API ni versionarla.
 
-`APP_BASE_URL` debe ser un origen HTTP/HTTPS confiable. La API de invitaciones no usa el header `Host` como sustituto.
+`APP_BASE_URL` debe ser un origen HTTP/HTTPS confiable. La API de invitaciones no usa el header `Host` como sustituto. En Preview de Vercel puede permanecer ausente: el runtime usa únicamente la URL de rama confiable expuesta por Vercel.
+
+### 4.1 Preview reproducible desde GitHub Actions
+El workflow manual `.github/workflows/hosted-pilot-preview.yml` es la ruta canónica para crear/reutilizar el proyecto Vercel y desplegar **solo Preview** desde el SHA exacto de `develop`.
+
+Configurar una sola vez estos GitHub Actions secrets, sin escribir sus valores en archivos, issues, logs ni commits:
+
+```text
+VERCEL_TOKEN
+VERCEL_ORG_ID
+PILOT_SUPABASE_URL
+PILOT_SUPABASE_PUBLISHABLE_KEY
+PILOT_SUPABASE_SECRET_KEY
+```
+
+Al ejecutarse manualmente, el workflow:
+1. hace checkout explícito de `develop` y captura su SHA completo;
+2. exige todos los secretos antes de cualquier provisión;
+3. corre `pilot:backend-preflight -- --plants TAM,YAR --require-no-director`;
+4. crea o reutiliza `greenatics-ops` mediante la API oficial de Vercel;
+5. hace upsert únicamente de variables con target `preview`;
+6. crea un deployment Git del SHA exacto, sin `target=production`;
+7. espera estado `READY` y falla cerrado ante `BLOCKED`, `CANCELED` o `ERROR`;
+8. ejecuta `pilot:preflight` contra la URL resultante verificando rama y commit.
+
+El cliente `scripts/vercel-pilot-deploy.mjs` nunca imprime `VERCEL_TOKEN`, `VERCEL_ORG_ID` ni claves Supabase. Los errores remotos se reducen a códigos seguros para evitar que un mensaje del proveedor pueda reflejar credenciales. Producción no se despliega ni se promueve con este workflow.
 
 ## 5. Backend preflight + primer director
 Antes de enviar una invitación real, validar que el esquema hospedado, RLS, Supabase Auth Admin, las plantas canónicas y el estado de bootstrap sean coherentes:
@@ -146,13 +171,15 @@ Con dos perfiles de navegador distintos:
 ## 10. Gate de promoción
 Antes de promover el piloto:
 - CI de PR verde (`quality` + `database`);
+- Preview creado por el workflow manual y `pilot:preflight` en PASS para el SHA exacto de `develop`;
 - `npm run pilot:backend-preflight -- --plants TAM,YAR` en PASS, incluyendo schema contract + RLS completo;
-- `npm run pilot:preflight` en PASS contra el SHA exacto desplegado;
 - `npm run pilot:rls-smoke` en PASS con los dos usuarios de prueba;
 - smoke funcional multiusuario aprobado;
 - redirects Auth configurados;
 - ningún secreto presente en GitHub, bundle cliente o logs;
 - web pública validada sin autenticación.
+
+Solo después de esos gates se permite configurar `APP_BASE_URL` canónico y promover/desplegar a producción.
 
 ## 11. Siguiente integración
 SharePoint permanece como fuente documental e histórica. GREENATICS OPS es el sistema transaccional. La integración documental debe añadir referencias/lectura sin devolver las transacciones diarias a SharePoint.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "bootstrap:director": "node scripts/bootstrap-director.mjs",
     "pilot:backend-preflight": "node scripts/hosted-backend-preflight.mjs",
     "pilot:rls-smoke": "node scripts/hosted-rls-smoke.mjs",
-    "pilot:preflight": "node scripts/hosted-pilot-preflight.mjs"
+    "pilot:preflight": "node scripts/hosted-pilot-preflight.mjs",
+    "pilot:vercel-preview": "node scripts/vercel-pilot-deploy.mjs"
   },
   "dependencies": {
     "@supabase/ssr": "latest",

--- a/scripts/vercel-pilot-deploy-lib.mjs
+++ b/scripts/vercel-pilot-deploy-lib.mjs
@@ -1,0 +1,286 @@
+const VERCEL_API_ORIGIN = "https://api.vercel.com";
+const DEFAULT_PROJECT_NAME = "greenatics-ops";
+const TERMINAL_FAILURE_STATES = new Set(["BLOCKED", "CANCELED", "ERROR"]);
+
+export class VercelPilotError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "VercelPilotError";
+  }
+}
+
+function clean(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requireValue(env, name, { max = 8192 } = {}) {
+  const value = clean(env[name]);
+  if (!value || value.length > max) {
+    throw new VercelPilotError(`${name} falta o tiene una longitud inválida.`);
+  }
+  return value;
+}
+
+function parseRepository(value) {
+  const repository = clean(value);
+  const match = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(repository);
+  if (!match) throw new VercelPilotError("GITHUB_REPOSITORY debe tener formato owner/repo.");
+  return Object.freeze({ fullName: repository, owner: match[1], repo: match[2] });
+}
+
+function parseCommitSha(value) {
+  const sha = clean(value).toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new VercelPilotError("DEPLOY_GIT_SHA debe ser un SHA Git completo de 40 caracteres.");
+  }
+  return sha;
+}
+
+function parseGitRef(value) {
+  const ref = clean(value);
+  if (!ref || ref.length > 255 || /[\s~^:?*[\\]/.test(ref) || ref.includes("..") || ref.endsWith(".")) {
+    throw new VercelPilotError("DEPLOY_GIT_REF no es una referencia Git segura.");
+  }
+  return ref;
+}
+
+export function parseVercelPilotConfig(env = process.env) {
+  const projectName = clean(env.VERCEL_PROJECT_NAME) || DEFAULT_PROJECT_NAME;
+  if (!/^[a-z0-9][a-z0-9-]{0,99}$/.test(projectName)) {
+    throw new VercelPilotError("VERCEL_PROJECT_NAME debe ser un slug seguro en minúsculas.");
+  }
+
+  return Object.freeze({
+    token: requireValue(env, "VERCEL_TOKEN"),
+    teamId: requireValue(env, "VERCEL_ORG_ID", { max: 256 }),
+    projectName,
+    repository: parseRepository(requireValue(env, "GITHUB_REPOSITORY", { max: 256 })),
+    gitRef: parseGitRef(requireValue(env, "DEPLOY_GIT_REF", { max: 255 })),
+    gitSha: parseCommitSha(requireValue(env, "DEPLOY_GIT_SHA", { max: 40 })),
+    supabaseUrl: requireValue(env, "NEXT_PUBLIC_SUPABASE_URL", { max: 2048 }),
+    supabasePublishableKey: requireValue(env, "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", { max: 4096 }),
+    supabaseSecretKey: requireValue(env, "SUPABASE_SECRET_KEY", { max: 4096 }),
+  });
+}
+
+function apiUrl(path, teamId, query = {}) {
+  const url = new URL(path, VERCEL_API_ORIGIN);
+  url.searchParams.set("teamId", teamId);
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null && String(value) !== "") {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url;
+}
+
+async function parseResponseBody(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+async function vercelRequest(config, fetchImpl, path, {
+  method = "GET",
+  query,
+  body,
+  allowNotFound = false,
+} = {}) {
+  let response;
+  try {
+    response = await fetchImpl(apiUrl(path, config.teamId, query), {
+      method,
+      headers: {
+        Authorization: `Bearer ${config.token}`,
+        Accept: "application/json",
+        ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+  } catch {
+    throw new VercelPilotError(`Vercel API ${method} ${path}: error de red.`);
+  }
+
+  const data = await parseResponseBody(response);
+  if (allowNotFound && response.status === 404) return null;
+  if (!response.ok) {
+    const code = clean(data?.error?.code) || `http_${response.status}`;
+    throw new VercelPilotError(`Vercel API ${method} ${path}: ${code}.`);
+  }
+  return data;
+}
+
+function validateProject(project, expectedName) {
+  const id = clean(project?.id);
+  const name = clean(project?.name);
+  if (!id.startsWith("prj_") || name !== expectedName) {
+    throw new VercelPilotError("Vercel devolvió un proyecto con identidad inválida.");
+  }
+  return Object.freeze({ id, name });
+}
+
+export async function ensureVercelPilotProject(config, { fetchImpl = fetch } = {}) {
+  const encodedName = encodeURIComponent(config.projectName);
+  const existing = await vercelRequest(config, fetchImpl, `/v9/projects/${encodedName}`, {
+    allowNotFound: true,
+  });
+  if (existing) return Object.freeze({ ...validateProject(existing, config.projectName), created: false });
+
+  const created = await vercelRequest(config, fetchImpl, "/v11/projects", {
+    method: "POST",
+    body: {
+      name: config.projectName,
+      framework: "nextjs",
+      gitRepository: {
+        type: "github",
+        repo: config.repository.fullName,
+      },
+    },
+  });
+  return Object.freeze({ ...validateProject(created, config.projectName), created: true });
+}
+
+function previewEnvironmentVariables(config) {
+  return [
+    {
+      key: "NEXT_PUBLIC_DATA_MODE",
+      value: "supabase",
+      type: "plain",
+      target: ["preview"],
+      comment: "GREENATICS hosted pilot preview data mode",
+    },
+    {
+      key: "NEXT_PUBLIC_SUPABASE_URL",
+      value: config.supabaseUrl,
+      type: "plain",
+      target: ["preview"],
+      comment: "GREENATICS hosted pilot preview backend origin",
+    },
+    {
+      key: "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+      value: config.supabasePublishableKey,
+      type: "plain",
+      target: ["preview"],
+      comment: "GREENATICS hosted pilot preview publishable key",
+    },
+    {
+      key: "SUPABASE_SECRET_KEY",
+      value: config.supabaseSecretKey,
+      type: "sensitive",
+      target: ["preview"],
+      comment: "GREENATICS hosted pilot preview server-only key",
+    },
+  ];
+}
+
+export async function upsertVercelPilotPreviewEnvironment(config, project, { fetchImpl = fetch } = {}) {
+  await vercelRequest(config, fetchImpl, `/v10/projects/${encodeURIComponent(project.id)}/env`, {
+    method: "POST",
+    query: { upsert: "true" },
+    body: previewEnvironmentVariables(config),
+  });
+  return Object.freeze({ target: "preview", keys: Object.freeze(previewEnvironmentVariables(config).map((item) => item.key)) });
+}
+
+function deploymentState(deployment) {
+  return clean(deployment?.status || deployment?.readyState).toUpperCase();
+}
+
+function validateDeployment(deployment) {
+  const id = clean(deployment?.id);
+  const url = clean(deployment?.url);
+  if (!id.startsWith("dpl_") || !url || /[\s/]/.test(url)) {
+    throw new VercelPilotError("Vercel devolvió un deployment con identidad inválida.");
+  }
+  return { id, url, state: deploymentState(deployment) };
+}
+
+export async function createVercelPilotPreviewDeployment(config, project, { fetchImpl = fetch } = {}) {
+  const deployment = await vercelRequest(config, fetchImpl, "/v13/deployments", {
+    method: "POST",
+    query: { forceNew: "1" },
+    body: {
+      name: project.name,
+      project: project.id,
+      gitSource: {
+        type: "github",
+        org: config.repository.owner,
+        repo: config.repository.repo,
+        ref: config.gitRef,
+        sha: config.gitSha,
+      },
+      gitMetadata: {
+        remoteUrl: `https://github.com/${config.repository.fullName}`,
+        commitRef: config.gitRef,
+        commitSha: config.gitSha,
+        dirty: false,
+        ci: true,
+        ciType: "github-actions",
+      },
+      meta: {
+        greenaticsHostedPilot: "true",
+        greenaticsGitSha: config.gitSha,
+      },
+    },
+  });
+  return Object.freeze(validateDeployment(deployment));
+}
+
+export async function waitForVercelPilotDeployment(config, deployment, {
+  fetchImpl = fetch,
+  sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  maxAttempts = 120,
+  pollIntervalMs = 3000,
+} = {}) {
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1 || maxAttempts > 600) {
+    throw new VercelPilotError("maxAttempts fuera de rango.");
+  }
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const current = await vercelRequest(config, fetchImpl, `/v13/deployments/${encodeURIComponent(deployment.id)}`);
+    const validated = validateDeployment(current);
+    if (validated.state === "READY") {
+      return Object.freeze({
+        ...validated,
+        origin: `https://${validated.url}`,
+      });
+    }
+    if (TERMINAL_FAILURE_STATES.has(validated.state)) {
+      throw new VercelPilotError(`Vercel deployment terminó en estado ${validated.state}.`);
+    }
+    if (attempt + 1 < maxAttempts) await sleepImpl(pollIntervalMs);
+  }
+
+  throw new VercelPilotError("Vercel deployment no alcanzó READY dentro del límite del gate.");
+}
+
+export async function runVercelPilotPreviewDeployment({
+  env = process.env,
+  fetchImpl = fetch,
+  sleepImpl,
+  maxAttempts,
+  pollIntervalMs,
+} = {}) {
+  const config = parseVercelPilotConfig(env);
+  const project = await ensureVercelPilotProject(config, { fetchImpl });
+  const environment = await upsertVercelPilotPreviewEnvironment(config, project, { fetchImpl });
+  const createdDeployment = await createVercelPilotPreviewDeployment(config, project, { fetchImpl });
+  const deployment = await waitForVercelPilotDeployment(config, createdDeployment, {
+    fetchImpl,
+    sleepImpl,
+    maxAttempts,
+    pollIntervalMs,
+  });
+
+  return Object.freeze({
+    project,
+    environment,
+    deployment,
+    gitRef: config.gitRef,
+    gitSha: config.gitSha,
+  });
+}

--- a/scripts/vercel-pilot-deploy.mjs
+++ b/scripts/vercel-pilot-deploy.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import { appendFile } from "node:fs/promises";
+import { runVercelPilotPreviewDeployment } from "./vercel-pilot-deploy-lib.mjs";
+
+async function writeOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) return;
+  await appendFile(outputFile, `${name}=${value}\n`, { encoding: "utf8" });
+}
+
+async function writeSummary(result) {
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryFile) return;
+  const summary = [
+    "## GREENATICS hosted pilot preview",
+    "",
+    `- Project: \`${result.project.name}\``,
+    `- Project created in this run: \`${result.project.created ? "yes" : "no"}\``,
+    `- Git ref: \`${result.gitRef}\``,
+    `- Git commit: \`${result.gitSha.slice(0, 12)}\``,
+    `- Deployment: ${result.deployment.origin}`,
+    `- State: \`${result.deployment.state}\``,
+    "- Environment target: `preview` only",
+    "",
+  ].join("\n");
+  await appendFile(summaryFile, summary, { encoding: "utf8" });
+}
+
+async function main() {
+  const result = await runVercelPilotPreviewDeployment();
+
+  await writeOutput("project_id", result.project.id);
+  await writeOutput("deployment_id", result.deployment.id);
+  await writeOutput("deployment_url", result.deployment.origin);
+  await writeSummary(result);
+
+  console.log("GREENATICS Vercel hosted pilot: READY");
+  console.log(`project: ${result.project.name}`);
+  console.log(`project-created: ${result.project.created ? "yes" : "no"}`);
+  console.log(`deployment: ${result.deployment.origin}`);
+  console.log(`git: ${result.gitRef}@${result.gitSha.slice(0, 12)}`);
+  console.log("target: preview");
+}
+
+main().catch((error) => {
+  console.error(`GREENATICS Vercel hosted pilot: FAIL · ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/vercel-pilot-deploy.test.mjs
+++ b/scripts/vercel-pilot-deploy.test.mjs
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  VercelPilotError,
+  parseVercelPilotConfig,
+  runVercelPilotPreviewDeployment,
+} from "./vercel-pilot-deploy-lib.mjs";
+
+const env = {
+  VERCEL_TOKEN: "vercel-test-token-never-log",
+  VERCEL_ORG_ID: "team_test_scope",
+  VERCEL_PROJECT_NAME: "greenatics-ops",
+  GITHUB_REPOSITORY: "arendon7/GTCS-WEB",
+  DEPLOY_GIT_REF: "develop",
+  DEPLOY_GIT_SHA: "a".repeat(40),
+  NEXT_PUBLIC_SUPABASE_URL: "https://sanitized-project.supabase.co",
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_sanitized",
+  SUPABASE_SECRET_KEY: "sb_secret_sanitized_server_only",
+};
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function requestBody(init) {
+  return init?.body ? JSON.parse(String(init.body)) : undefined;
+}
+
+describe("Vercel hosted pilot preview deployment", () => {
+  it("requires explicit infrastructure and backend configuration", () => {
+    expect(() => parseVercelPilotConfig({ ...env, VERCEL_TOKEN: "" })).toThrow(/VERCEL_TOKEN/);
+    expect(() => parseVercelPilotConfig({ ...env, DEPLOY_GIT_SHA: "abc" })).toThrow(/40 caracteres/);
+    expect(() => parseVercelPilotConfig({ ...env, DEPLOY_GIT_REF: "bad ref" })).toThrow(/referencia Git segura/);
+  });
+
+  it("creates the project when absent, upserts preview-only env and deploys the exact SHA", async () => {
+    const calls = [];
+    let deploymentPolls = 0;
+    const fetchImpl = vi.fn(async (url, init = {}) => {
+      const parsed = new URL(url);
+      const method = init.method || "GET";
+      calls.push({ method, parsed, body: requestBody(init), authorization: init.headers?.Authorization });
+
+      if (method === "GET" && parsed.pathname === "/v9/projects/greenatics-ops") {
+        return jsonResponse({ error: { code: "not_found" } }, 404);
+      }
+      if (method === "POST" && parsed.pathname === "/v11/projects") {
+        return jsonResponse({ id: "prj_greenatics_test", name: "greenatics-ops" });
+      }
+      if (method === "POST" && parsed.pathname === "/v10/projects/prj_greenatics_test/env") {
+        return jsonResponse({ created: [] });
+      }
+      if (method === "POST" && parsed.pathname === "/v13/deployments") {
+        return jsonResponse({ id: "dpl_greenatics_test", url: "greenatics-ops-preview.vercel.app", status: "QUEUED" });
+      }
+      if (method === "GET" && parsed.pathname === "/v13/deployments/dpl_greenatics_test") {
+        deploymentPolls += 1;
+        return jsonResponse({
+          id: "dpl_greenatics_test",
+          url: "greenatics-ops-preview.vercel.app",
+          status: deploymentPolls === 1 ? "BUILDING" : "READY",
+        });
+      }
+      throw new Error(`Unexpected ${method} ${parsed.pathname}`);
+    });
+
+    const result = await runVercelPilotPreviewDeployment({
+      env,
+      fetchImpl,
+      sleepImpl: vi.fn(async () => {}),
+      maxAttempts: 3,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.project).toEqual({ id: "prj_greenatics_test", name: "greenatics-ops", created: true });
+    expect(result.deployment.origin).toBe("https://greenatics-ops-preview.vercel.app");
+    expect(result.deployment.state).toBe("READY");
+
+    for (const call of calls) {
+      expect(call.parsed.searchParams.get("teamId")).toBe(env.VERCEL_ORG_ID);
+      expect(call.authorization).toBe(`Bearer ${env.VERCEL_TOKEN}`);
+    }
+
+    const createProject = calls.find((call) => call.method === "POST" && call.parsed.pathname === "/v11/projects");
+    expect(createProject.body).toMatchObject({
+      name: "greenatics-ops",
+      framework: "nextjs",
+      gitRepository: { type: "github", repo: "arendon7/GTCS-WEB" },
+    });
+
+    const envCall = calls.find((call) => call.parsed.pathname.endsWith("/env"));
+    expect(envCall.parsed.searchParams.get("upsert")).toBe("true");
+    expect(envCall.body.map((item) => item.key)).toEqual([
+      "NEXT_PUBLIC_DATA_MODE",
+      "NEXT_PUBLIC_SUPABASE_URL",
+      "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+      "SUPABASE_SECRET_KEY",
+    ]);
+    expect(envCall.body.every((item) => JSON.stringify(item.target) === JSON.stringify(["preview"]))).toBe(true);
+    expect(envCall.body.find((item) => item.key === "SUPABASE_SECRET_KEY")?.type).toBe("sensitive");
+
+    const deployCall = calls.find((call) => call.method === "POST" && call.parsed.pathname === "/v13/deployments");
+    expect(deployCall.parsed.searchParams.get("forceNew")).toBe("1");
+    expect(deployCall.body).not.toHaveProperty("target");
+    expect(deployCall.body.gitSource).toEqual({
+      type: "github",
+      org: "arendon7",
+      repo: "GTCS-WEB",
+      ref: "develop",
+      sha: env.DEPLOY_GIT_SHA,
+    });
+  });
+
+  it("reuses an existing project and fails closed on a terminal deployment state", async () => {
+    const fetchImpl = vi.fn(async (url, init = {}) => {
+      const parsed = new URL(url);
+      const method = init.method || "GET";
+      if (method === "GET" && parsed.pathname === "/v9/projects/greenatics-ops") {
+        return jsonResponse({ id: "prj_greenatics_test", name: "greenatics-ops" });
+      }
+      if (method === "POST" && parsed.pathname.endsWith("/env")) return jsonResponse({ created: [] });
+      if (method === "POST" && parsed.pathname === "/v13/deployments") {
+        return jsonResponse({ id: "dpl_greenatics_test", url: "greenatics-ops-preview.vercel.app", status: "QUEUED" });
+      }
+      if (method === "GET" && parsed.pathname === "/v13/deployments/dpl_greenatics_test") {
+        return jsonResponse({ id: "dpl_greenatics_test", url: "greenatics-ops-preview.vercel.app", status: "ERROR" });
+      }
+      throw new Error(`Unexpected ${method} ${parsed.pathname}`);
+    });
+
+    await expect(runVercelPilotPreviewDeployment({
+      env,
+      fetchImpl,
+      sleepImpl: vi.fn(async () => {}),
+      maxAttempts: 2,
+      pollIntervalMs: 0,
+    })).rejects.toThrow(/estado ERROR/);
+
+    expect(fetchImpl.mock.calls.filter(([url, init]) => (init?.method || "GET") === "POST" && new URL(url).pathname === "/v11/projects")).toHaveLength(0);
+  });
+
+  it("never echoes a remote error message that could contain credentials", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      error: {
+        code: "forbidden",
+        message: `credential=${env.VERCEL_TOKEN}`,
+      },
+    }, 403));
+
+    let thrown;
+    try {
+      await runVercelPilotPreviewDeployment({ env, fetchImpl, maxAttempts: 1, pollIntervalMs: 0 });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(VercelPilotError);
+    expect(thrown.message).toContain("forbidden");
+    expect(thrown.message).not.toContain(env.VERCEL_TOKEN);
+  });
+});


### PR DESCRIPTION
## Objetivo
Eliminar la dependencia del conector Vercel para materializar el primer piloto hospedado, sin abrir producción antes del UAT.

## Cambios
- Workflow manual `hosted-pilot-preview.yml`; nunca corre en push/PR.
- Checkout canónico de `develop` y deployment del SHA exacto.
- Cliente REST Vercel fail-closed para crear/reutilizar `greenatics-ops`, configurar variables **Preview-only**, crear deployment Git y esperar `READY`.
- Backend preflight antes del deployment y `pilot:preflight` contra la URL resultante.
- Tests verifican que no exista `target=production`, que el secreto Supabase sea `sensitive`, que se reutilicen proyectos existentes y que errores remotos no reflejen credenciales.
- Runbook documenta secretos y promoción posterior.

## Secretos requeridos en GitHub Actions
Solo nombres, nunca valores:
- `VERCEL_TOKEN`
- `VERCEL_ORG_ID`
- `PILOT_SUPABASE_URL`
- `PILOT_SUPABASE_PUBLISHABLE_KEY`
- `PILOT_SUPABASE_SECRET_KEY`

## Seguridad
- Preview únicamente; no hay promoción ni deployment de producción.
- No se versionan IDs de equipo, URLs privadas ni credenciales.
- Sin secretos configurados el workflow falla antes de provisionar.
- Los mensajes remotos de Vercel se reducen a códigos seguros.

## Gate
Merge únicamente con `quality` + `database` verdes.