### PR TITLE
Public v0.16 · Shell cleanup + image performance

### DIFF
--- a/e2e/public-shell-seo.spec.ts
+++ b/e2e/public-shell-seo.spec.ts
@@ -1,5 +1,21 @@
 import { test, expect } from "@playwright/test";
 
+const shellRoutes = [
+  "/",
+  "/wondergreen",
+  "/wondergreen/cultivos",
+  "/wondergreen/cultivos/cafe",
+  "/soluciones",
+  "/soluciones/diagnostico-caracterizacion",
+  "/proyectos",
+  "/proyectos/yarumal",
+  "/impacto",
+  "/biblioteca",
+  "/biblioteca/guia-deficiencias",
+  "/nosotros",
+  "/contacto",
+];
+
 test("public home uses the shared navigation and real routes", async ({ page }) => {
   await page.goto("/");
 
@@ -23,6 +39,16 @@ test("nested public routes inherit the same shell", async ({ page }) => {
   await expect(page.getByRole("heading", { name: /Diagnóstico y caracterización/i })).toBeVisible();
   await expect(footer.getByText(/Centro Empresarial Alcalá/)).toBeVisible();
   await expect(footer.getByRole("link", { name: "GREENATICS OPS" })).toHaveAttribute("href", "/app");
+});
+
+test("every governed public route renders exactly one shared shell", async ({ page }) => {
+  for (const route of shellRoutes) {
+    await page.goto(route);
+    await expect(page.locator("header"), `${route} should have one header`).toHaveCount(1);
+    await expect(page.locator("footer"), `${route} should have one footer`).toHaveCount(1);
+    await expect(page.getByRole("navigation", { name: "Navegación pública" }), `${route} should expose the shared navigation`).toBeVisible();
+    await expect(page.getByRole("contentinfo").getByRole("link", { name: "GREENATICS OPS" }), `${route} should expose the OPS bridge`).toHaveAttribute("href", "/app");
+  }
 });
 
 test("sitemap exposes public routes and robots blocks OPS", async ({ request }) => {

--- a/src/app/biblioteca/guia-deficiencias/page.tsx
+++ b/src/app/biblioteca/guia-deficiencias/page.tsx
@@ -11,17 +11,6 @@ export const metadata: Metadata = {
 export default function DeficiencyGuidePage() {
   return (
     <div className={styles.page}>
-      <header className={styles.header}>
-        <div className={`${styles.container} ${styles.headerInner}`}>
-          <Link href="/" aria-label="Greenatics">
-            <img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
-          </Link>
-          <Link className={styles.headerLink} href="/biblioteca">Biblioteca</Link>
-          <Link className={styles.headerLink} href="/wondergreen/cultivos">Cultivos</Link>
-          <Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link>
-        </div>
-      </header>
-
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
@@ -120,10 +109,6 @@ export default function DeficiencyGuidePage() {
           </div>
         </section>
       </main>
-
-      <footer className={styles.footer}>
-        <div className={`${styles.container} ${styles.footerInner}`}><span>© Greenatics S.A.S. · Wondergreen · Guía de deficiencias</span><Link href="/biblioteca">Volver a Biblioteca</Link></div>
-      </footer>
     </div>
   );
 }

--- a/src/app/biblioteca/page.tsx
+++ b/src/app/biblioteca/page.tsx
@@ -55,16 +55,6 @@ const resources = [
 export default function LibraryPage() {
   return (
     <div className={styles.page}>
-      <header className={styles.header}>
-        <div className={`${styles.container} ${styles.headerInner}`}>
-          <Link href="/" aria-label="Greenatics">
-            <img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
-          </Link>
-          <Link className={styles.headerLink} href="/wondergreen">Wondergreen</Link>
-          <Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link>
-        </div>
-      </header>
-
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
@@ -107,10 +97,6 @@ export default function LibraryPage() {
           </div>
         </section>
       </main>
-
-      <footer className={styles.footer}>
-        <div className={`${styles.container} ${styles.footerInner}`}><span>© Greenatics S.A.S. · Biblioteca</span><Link href="/">Volver a Greenatics</Link></div>
-      </footer>
     </div>
   );
 }

--- a/src/app/contacto/page.tsx
+++ b/src/app/contacto/page.tsx
@@ -29,8 +29,6 @@ const preparation = [
 export default function ContactPage() {
   return (
     <div className={styles.page}>
-      <header className={styles.header}><div className={`${styles.container} ${styles.headerInner}`}><Link href="/" aria-label="Greenatics, inicio"><img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" /></Link><nav className={styles.nav} aria-label="Navegación pública"><Link href="/soluciones">Soluciones</Link><Link href="/proyectos">Proyectos</Link><Link href="/impacto">Impacto</Link><Link href="/wondergreen">Wondergreen</Link><Link href="/nosotros">Nosotros</Link></nav><Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link></div></header>
-
       <main>
         <section className={styles.contactHero}><div className={`${styles.container} ${styles.contactGrid}`}><div><span className={styles.eyebrow} style={{color:"#c8f5ad"}}>Contacto Greenatics</span><h1>Cuéntanos qué quieres transformar.</h1><p className={styles.lead}>Podemos hablar de Wondergreen, gestión de residuos, proyectos municipales, plantas, rehabilitación, operación o soluciones para grandes generadores.</p></div><aside className={styles.contactPanel}><span>Reunión técnica</span><h2>Agenda directamente con el equipo.</h2><p>La conversación funciona mejor cuando llegamos con contexto mínimo. Usa la guía inferior y trae lo que ya tengas; no necesitas tener toda la información resuelta.</p><a className={`${styles.button} ${styles.primary}`} href={publicSite.bookingUrl} target="_blank" rel="noreferrer">Agendar reunión</a></aside></div></section>
 
@@ -40,8 +38,6 @@ export default function ContactPage() {
 
         <section className={styles.section}><div className={styles.container}><div className={styles.sectionHead}><span className={styles.eyebrow}>No sabes por dónde empezar</span><h2>Elige el problema antes que la solución.</h2></div><div className={styles.ecosystem}><Link href="/soluciones/diagnostico-caracterizacion"><strong>Tengo residuos</strong><span>Empezar por caracterización, generación, logística y alternativas.</span></Link><Link href="/wondergreen/cultivos"><strong>Tengo un cultivo</strong><span>Entrar por cultivo, etapa, necesidad y conocimiento Wondergreen.</span></Link><Link href="/soluciones/prefactibilidad"><strong>Tengo un proyecto</strong><span>Madurar la idea antes de comprometer ingeniería o inversión.</span></Link></div><div className={styles.note} style={{marginTop:24}}><strong>Privacidad práctica:</strong> evita incluir datos sensibles, secretos industriales o información personal innecesaria en la primera descripción. Podemos definir después el canal adecuado para documentación técnica.</div></div></section>
       </main>
-
-      <footer className={styles.footer}><div className={`${styles.container} ${styles.footerInner}`}><span>Greenatics · Medellín, Colombia</span><div><Link href="/nosotros">Nosotros</Link> · <Link href="/soluciones">Soluciones</Link> · <Link href="/app">GREENATICS OPS</Link></div></div></footer>
     </div>
   );
 }

--- a/src/app/impacto/page.tsx
+++ b/src/app/impacto/page.tsx
@@ -18,8 +18,6 @@ const steps = [
 export default function ImpactPage() {
   return (
     <div className={styles.page}>
-      <header className={styles.header}><div className={`${styles.container} ${styles.headerInner}`}><Link href="/" aria-label="Greenatics, inicio"><img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" /></Link><nav className={styles.nav} aria-label="Navegación pública"><Link href="/soluciones">Soluciones</Link><Link href="/proyectos">Proyectos</Link><Link href="/impacto">Impacto</Link><Link href="/wondergreen">Wondergreen</Link><Link href="/biblioteca">Conocimiento</Link></nav><Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link></div></header>
-
       <main>
         <section className={styles.hero}><div className={`${styles.container} ${styles.heroGrid}`}><div><span className={styles.eyebrow}>Impacto verificable</span><h1>No basta con decir que aprovechamos residuos. Hay que demostrarlo.</h1><p className={styles.lead}>La capa pública de impacto se alimenta desde GREENATICS OPS bajo un contrato de publicación: cada cifra debe tener fuente, periodo, estado de validación y metodología cuando aplique.</p></div><aside className={styles.rule}><strong>Medido → revisado → aprobado → publicado.</strong><p>Nunca mostramos un KPI operativo en vivo sin control de calidad ni reutilizamos una cifra histórica como si describiera el estado actual.</p></aside></div></section>
 
@@ -31,8 +29,6 @@ export default function ImpactPage() {
 
         <section className={styles.guard}><div className={`${styles.container} ${styles.guardGrid}`}><div><span className={styles.eyebrow}>Impacto climático</span><h2>CO₂-eq no es una cifra decorativa.</h2></div><p>Un indicador climático solo podrá publicarse cuando estén definidos el escenario de referencia, los límites del sistema, los factores de emisión, el periodo, las fuentes de actividad y los supuestos. Hasta entonces permanece explícitamente en validación.</p></div></section>
       </main>
-
-      <footer className={styles.footer}><div className={`${styles.container} ${styles.footerInner}`}><span>Greenatics · impacto con evidencia</span><div><Link href="/proyectos">Proyectos</Link> · <Link href="/soluciones">Soluciones</Link> · <Link href="/app">GREENATICS OPS</Link></div></div></footer>
     </div>
   );
 }

--- a/src/app/nosotros/page.tsx
+++ b/src/app/nosotros/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import styles from "../company-public.module.css";
 
@@ -43,10 +44,8 @@ const ecosystem = [
 export default function AboutPage() {
   return (
     <div className={styles.page}>
-      <header className={styles.header}><div className={`${styles.container} ${styles.headerInner}`}><Link href="/" aria-label="Greenatics, inicio"><img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" /></Link><nav className={styles.nav} aria-label="Navegación pública"><Link href="/soluciones">Soluciones</Link><Link href="/proyectos">Proyectos</Link><Link href="/impacto">Impacto</Link><Link href="/wondergreen">Wondergreen</Link><Link href="/biblioteca">Conocimiento</Link></nav><Link className={`${styles.button} ${styles.primary}`} href="/contacto">Contacto</Link></div></header>
-
       <main>
-        <section className={styles.hero}><div className={`${styles.container} ${styles.heroGrid}`}><div><span className={styles.eyebrow}>Greenatics</span><h1>No somos solo una planta, una consultora ni una marca de fertilizantes.</h1><p className={styles.lead}>Greenatics construye sistemas de economía circular para residuos orgánicos. Conectamos gestión en la fuente, logística, tratamiento biológico, ingeniería, operación, productos agrícolas y datos para que el ciclo pueda funcionar de extremo a extremo.</p><div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/soluciones">Ver lo que hacemos</Link><Link className={`${styles.button} ${styles.ghost}`} href="/proyectos">Ver experiencia</Link></div></div><div className={styles.mark}><img src="/brand/greenatics-symbol.svg" alt="Símbolo Greenatics" /></div></div></section>
+        <section className={styles.hero}><div className={`${styles.container} ${styles.heroGrid}`}><div><span className={styles.eyebrow}>Greenatics</span><h1>No somos solo una planta, una consultora ni una marca de fertilizantes.</h1><p className={styles.lead}>Greenatics construye sistemas de economía circular para residuos orgánicos. Conectamos gestión en la fuente, logística, tratamiento biológico, ingeniería, operación, productos agrícolas y datos para que el ciclo pueda funcionar de extremo a extremo.</p><div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/soluciones">Ver lo que hacemos</Link><Link className={`${styles.button} ${styles.ghost}`} href="/proyectos">Ver experiencia</Link></div></div><div className={styles.mark}><Image src="/brand/greenatics-symbol.svg" alt="Símbolo Greenatics" width={180} height={180} /></div></div></section>
 
         <section className={`${styles.section} ${styles.white}`}><div className={styles.container}><div className={styles.sectionHead}><span className={styles.eyebrow}>Cinco capacidades conectadas</span><h2>La ventaja está en trabajar la cadena completa.</h2><p>Podemos intervenir una fase puntual o articular varias cuando el proyecto requiere un sistema integral.</p></div><div className={styles.grid5}>{capabilities.map(([title,copy],index)=><article className={styles.card} key={title}><span>{String(index+1).padStart(2,"0")}</span><h3>{title}</h3><p>{copy}</p></article>)}</div></div></section>
 
@@ -58,8 +57,6 @@ export default function AboutPage() {
 
         <section className={`${styles.section} ${styles.soft}`}><div className={styles.container}><div className={styles.sectionHead}><span className={styles.eyebrow}>Ecosistema Greenatics</span><h2>Una empresa, varias capas que se alimentan entre sí.</h2><p>La operación genera conocimiento; el conocimiento mejora la ingeniería; los proyectos producen nuevos aprendizajes; y Wondergreen conecta parte de ese valor con el agro.</p></div><div className={styles.ecosystem}>{ecosystem.map(([title,href,copy])=><Link href={href} key={title}><strong>{title}</strong><span>{copy}</span></Link>)}</div></div></section>
       </main>
-
-      <footer className={styles.footer}><div className={`${styles.container} ${styles.footerInner}`}><span>Greenatics · transformar residuos en vida</span><div><Link href="/contacto">Contacto</Link> · <Link href="/app">GREENATICS OPS</Link></div></div></footer>
     </div>
   );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,10 +1,11 @@
+import Image from "next/image";
 import Link from "next/link";
 
 export default function NotFound() {
   return (
     <main className="mx-auto grid min-h-[70vh] w-full max-w-3xl place-items-center px-5 py-20 text-center">
       <section>
-        <img className="mx-auto mb-6 h-auto w-20" src="/brand/greenatics-symbol.svg" alt="" aria-hidden="true" />
+        <Image className="mx-auto mb-6 h-auto w-20" src="/brand/greenatics-symbol.svg" alt="" aria-hidden="true" width={80} height={80} />
         <p className="eyebrow">404 · Greenatics</p>
         <h1 className="mt-3 text-4xl font-bold tracking-tight text-[var(--ink)] sm:text-5xl">Esta ruta no existe o cambió.</h1>
         <p className="lede mx-auto mt-5 max-w-2xl">Puedes volver al sitio público, explorar Wondergreen o regresar a GREENATICS OPS.</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import { PublicShell } from "@/components/public-shell";
 import styles from "./public-home.module.css";
@@ -115,7 +116,7 @@ export default function Home() {
             <aside className={styles.cycleLedger} aria-label="Ciclo Greenatics: residuo, bioproceso, recurso, suelo y datos">
               <div className={styles.cycleLedgerTop}>
                 <div className={styles.cycleSymbol}>
-                  <img src="/brand/greenatics-symbol.svg" alt="" aria-hidden="true" />
+                  <Image src="/brand/greenatics-symbol.svg" alt="" aria-hidden="true" width={68} height={68} />
                 </div>
                 <div>
                   <span>El ciclo Greenatics</span>
@@ -157,7 +158,7 @@ export default function Home() {
             <div className={styles.wgHeader}>
               <div>
                 <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Wondergreen · Producto agrícola</span>
-                <img className={styles.wgLogo} src="/brand/wondergreen-nutrients.webp" alt="Wondergreen Nutrients" width="420" height="221" />
+                <Image className={styles.wgLogo} src="/brand/wondergreen-nutrients.webp" alt="Wondergreen Nutrients" width={420} height={221} sizes="(max-width: 720px) 78vw, 420px" />
                 <h2>Más que NPK.</h2>
               </div>
               <div className={styles.wgLead}>
@@ -224,11 +225,12 @@ export default function Home() {
         <section className={styles.evidence}>
           <div className={`${styles.container} ${styles.evidenceGrid}`}>
             <figure className={styles.evidenceMedia}>
-              <img
+              <Image
                 src="/projects/yarumal/aerial-01.webp"
                 alt="Vista aérea documentada de la planta de Yarumal"
-                width="1200"
-                height="900"
+                width={1200}
+                height={900}
+                sizes="(max-width: 900px) 100vw, 56vw"
               />
               <figcaption>Archivo de proyecto · Yarumal · experiencia documentada</figcaption>
             </figure>

--- a/src/app/wondergreen/cultivos/[slug]/page.tsx
+++ b/src/app/wondergreen/cultivos/[slug]/page.tsx
@@ -34,17 +34,6 @@ export default async function WondergreenCropPage({ params }: { params: Promise<
 
   return (
     <div className={styles.page}>
-      <header className={styles.header}>
-        <div className={`${styles.container} ${styles.headerInner}`}>
-          <Link href="/" aria-label="Greenatics">
-            <img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
-          </Link>
-          <Link className={styles.headerLink} href="/wondergreen">Wondergreen</Link>
-          <Link className={styles.headerLink} href="/wondergreen/cultivos">Cultivos</Link>
-          <Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link>
-        </div>
-      </header>
-
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
@@ -141,10 +130,6 @@ export default async function WondergreenCropPage({ params }: { params: Promise<
           </div>
         </section>
       </main>
-
-      <footer className={styles.footer}>
-        <div className={`${styles.container} ${styles.footerInner}`}><span>© Greenatics S.A.S. · Wondergreen · {crop.name}</span><Link href="/wondergreen/cultivos">Ver todos los cultivos</Link></div>
-      </footer>
     </div>
   );
 }

--- a/src/app/wondergreen/cultivos/page.tsx
+++ b/src/app/wondergreen/cultivos/page.tsx
@@ -11,16 +11,6 @@ export const metadata: Metadata = {
 export default function WondergreenCropsPage() {
   return (
     <div className={styles.page}>
-      <header className={styles.header}>
-        <div className={`${styles.container} ${styles.headerInner}`}>
-          <Link href="/wondergreen" aria-label="Volver a Wondergreen">
-            <img className={styles.logo} src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
-          </Link>
-          <Link className={styles.headerLink} href="/wondergreen">Wondergreen</Link>
-          <Link className={`${styles.button} ${styles.primary}`} href="/app">Acceder a Greenatics</Link>
-        </div>
-      </header>
-
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
@@ -74,10 +64,6 @@ export default function WondergreenCropsPage() {
           </div>
         </section>
       </main>
-
-      <footer className={styles.footer}>
-        <div className={`${styles.container} ${styles.footerInner}`}><span>© Greenatics S.A.S. · Wondergreen</span><Link href="/">Volver a Greenatics</Link></div>
-      </footer>
     </div>
   );
 }

--- a/src/components/public-shell.module.css
+++ b/src/components/public-shell.module.css
@@ -141,14 +141,6 @@
   min-height: 60vh;
 }
 
-/* Transitional shell migration: legacy public pages still contain their own
-   direct header/footer. The shared shell is canonical, so only those outer
-   legacy chrome nodes are suppressed while page content/main is preserved. */
-.main > div > header:first-child,
-.main > div > footer:last-child {
-  display: none;
-}
-
 .footer {
   margin-top: 0;
   border-top: 8px solid #b8d65f;

--- a/src/components/public-shell.tsx
+++ b/src/components/public-shell.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 import { OrganizationJsonLd } from "@/components/organization-json-ld";
 import { publicFooterNav, publicNav, publicSite } from "@/data/public-site";
@@ -12,7 +13,7 @@ export function PublicShell({ children }: { children: React.ReactNode }) {
       <header className={styles.header}>
         <div className={styles.headerInner}>
           <Link className={styles.brand} href="/" aria-label="Greenatics, inicio">
-            <img src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
+            <Image src="/brand/greenatics-horizontal.webp" alt="Greenatics" width={360} height={66} priority sizes="(max-width: 720px) 180px, 205px" />
           </Link>
 
           <nav className={styles.nav} aria-label="Navegación pública">
@@ -35,7 +36,7 @@ export function PublicShell({ children }: { children: React.ReactNode }) {
         <div className={styles.footerGrid}>
           <div className={styles.footerBrand}>
             <Link href="/" aria-label="Greenatics, inicio">
-              <img src="/brand/greenatics-horizontal.webp" alt="Greenatics" width="360" height="66" />
+              <Image src="/brand/greenatics-horizontal.webp" alt="Greenatics" width={360} height={66} sizes="180px" />
             </Link>
             <p>{publicSite.description}</p>
             <address>


### PR DESCRIPTION
## Objetivo
Cerrar deuda técnica del frente público después del rediseño editorial, sin tocar GREENATICS OPS ni contratos internos.

## Cambios
- elimina headers/footers locales duplicados en Impacto, Contacto, Nosotros, Biblioteca, guía de deficiencias y rutas Wondergreen por cultivo;
- deja esas rutas dependiendo únicamente del `PublicShell` canónico;
- migra imágenes críticas del HOME, shell, Nosotros y 404 a `next/image`;
- añade `sizes` y prioridad donde aporta a LCP/bandwidth;
- mantiene intactos contenidos, Product Truth, truth-locks de proyectos y puente público → OPS;
- amplía Playwright para exigir exactamente un header y un footer en 13 rutas públicas representativas.

## Alcance excluido
- OPS / app interna
- Supabase / migraciones / RLS
- auth
- Product Master y claims
- contenido comercial nuevo

## Validación esperada
- typecheck/lint/unit/build
- seguridad y DB gates existentes
- Playwright desktop + mobile
- reducción de warnings `@next/next/no-img-element`