### PR TITLE
Public v0.17 · Isolated Vercel preview modes

### DIFF
--- a/.github/workflows/hosted-pilot-preview.yml
+++ b/.github/workflows/hosted-pilot-preview.yml
@@ -2,6 +2,15 @@ name: hosted-pilot-preview
 
 on:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Preview surface to certify
+        required: true
+        type: choice
+        default: public-only
+        options:
+          - public-only
+          - full-ops
 
 permissions:
   contents: read
@@ -15,12 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      VERCEL_PROJECT_NAME: greenatics-ops
+      PILOT_PREVIEW_MODE: ${{ inputs.mode }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
-      SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
       DEPLOY_GIT_REF: develop
 
     steps:
@@ -42,19 +48,14 @@ jobs:
           sha="$(git rev-parse HEAD)"
           test "${#sha}" -eq 40
           echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
-          echo "Deploying develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Deploying ${PILOT_PREVIEW_MODE} preview from develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Require hosted pilot secrets
+      - name: Require Vercel preview secrets
         shell: bash
         run: |
           set -euo pipefail
           missing=0
-          for name in \
-            VERCEL_TOKEN \
-            VERCEL_ORG_ID \
-            NEXT_PUBLIC_SUPABASE_URL \
-            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
-            SUPABASE_SECRET_KEY
+          for name in VERCEL_TOKEN VERCEL_ORG_ID
           do
             if [ -z "${!name:-}" ]; then
               echo "::error::$name is not configured for the hosted pilot workflow."
@@ -63,14 +64,42 @@ jobs:
           done
           test "$missing" -eq 0
 
+      - name: Require full OPS backend secrets
+        if: ${{ inputs.mode == 'full-ops' }}
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+          SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY SUPABASE_SECRET_KEY
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is not configured for full-ops preview."
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
       - name: Install dependencies
         run: npm install --ignore-scripts
 
-      - name: Certify hosted Supabase before deployment
+      - name: Certify hosted Supabase before full OPS deployment
+        if: ${{ inputs.mode == 'full-ops' }}
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+          SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
         run: npm run pilot:backend-preflight -- --plants TAM,YAR --require-no-director
 
-      - name: Create or reuse Vercel project and deploy Preview
+      - name: Create or reuse isolated Vercel project and deploy Preview
         id: deploy
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ inputs.mode == 'full-ops' && secrets.PILOT_SUPABASE_URL || '' }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ inputs.mode == 'full-ops' && secrets.PILOT_SUPABASE_PUBLISHABLE_KEY || '' }}
+          SUPABASE_SECRET_KEY: ${{ inputs.mode == 'full-ops' && secrets.PILOT_SUPABASE_SECRET_KEY || '' }}
         run: npm run pilot:vercel-preview
 
       - name: Certify deployed Preview
@@ -82,5 +111,6 @@ jobs:
           test -n "$DEPLOYMENT_URL"
           npm run pilot:preflight -- \
             --base-url "$DEPLOYMENT_URL" \
+            --mode "$PILOT_PREVIEW_MODE" \
             --expected-branch "$DEPLOY_GIT_REF" \
             --expected-commit "$DEPLOY_GIT_SHA"

--- a/docs/deployment/HOSTED_PILOT_RUNBOOK.md
+++ b/docs/deployment/HOSTED_PILOT_RUNBOOK.md
@@ -1,25 +1,45 @@
 # GREENATICS · Hosted Pilot Runbook
 
 ## Objetivo
-Publicar un piloto multiusuario de la plataforma dual GREENATICS sin exponer secretos: la web pública permanece abierta y GREENATICS OPS exige sesión únicamente en sus rutas internas.
+Publicar y certificar la plataforma dual GREENATICS sin exponer secretos: la web pública permanece abierta y GREENATICS OPS solo se habilita cuando existe un backend hospedado certificado.
 
-## 1. Supabase hospedado
+## 1. Dos etapas de preview
+La validación hospedada se divide en dos modos explícitos:
+
+### `public-only` · primera etapa y modo predeterminado
+- proyecto Vercel canónico: `greenatics-public-preview`;
+- no requiere Supabase;
+- `NEXT_PUBLIC_DATA_MODE=local`;
+- OPS permanece en `configuration-block`;
+- sirve para QA visual/editorial, SEO, headers, navegación y frontera público/privado.
+
+### `full-ops` · segunda etapa
+- proyecto Vercel canónico: `greenatics-ops`;
+- requiere Supabase piloto certificado;
+- `NEXT_PUBLIC_DATA_MODE=supabase`;
+- OPS usa `supabase-auth` y RLS.
+
+Los proyectos son distintos por diseño. No reutilizar `greenatics-ops` como preview público ni `greenatics-public-preview` para pruebas con credenciales.
+
+## 2. Supabase hospedado para `full-ops`
 1. Crear un proyecto dedicado para GREENATICS OPS.
 2. Vincular el repositorio con Supabase CLI.
 3. Aplicar **todas** las migraciones versionadas de `supabase/migrations` sobre una base limpia.
 4. Verificar las plantas canónicas que se usarán en el piloto.
 5. No crear tablas, políticas ni RPC manualmente por fuera de migraciones.
 
-Para el piloto actual, los códigos canónicos son `TAM` (Támesis) y `YAR` (Yarumal). Los scripts aceptan los alias humanos `Támesis`/`Tamesis` y `Yarumal`, pero el runbook y la base deben usar los códigos canónicos.
+Para el piloto actual, los códigos canónicos son `TAM` (Támesis) y `YAR` (Yarumal). Los scripts aceptan alias humanos, pero el runbook y la base deben usar códigos canónicos.
 
-## 2. Frontera pública / interna
+## 3. Frontera pública / interna
 La misma base de producto contiene dos superficies:
-- públicas: `/`, `/wondergreen`, `/soluciones`, `/proyectos`, `/impacto`, `/biblioteca`, `/nosotros`, `/contacto` y sus descendientes;
+- públicas: `/`, `/wondergreen`, `/soluciones`, `/proyectos`, `/impacto`, `/biblioteca`, `/nosotros`, `/contacto` y descendientes;
 - internas: `/app`, operación, dashboard, importaciones, administración y cuenta.
 
-En modo Supabase, el proxy solo debe exigir sesión para rutas OPS. Una visita anónima a la web pública nunca debe terminar en `/login`.
+Una visita anónima a la web pública nunca debe terminar en `/login`.
 
-## 3. Auth URL y plantilla de invitación
+En `public-only`, `/app` debe redirigir a `/login?reason=configuration&next=/app`. En `full-ops`, `/app` anónimo debe redirigir al login sin `reason=configuration` y una sesión válida debe quedar sujeta a perfil, membresía y RLS.
+
+## 4. Auth URL y plantilla de invitación para `full-ops`
 Configurar en Supabase Auth:
 - Site URL = origen canónico del deployment Next.js.
 - Allowed Redirect URLs = el mismo origen y previews realmente autorizados.
@@ -34,48 +54,62 @@ Personalizar **Invite user** para que el token llegue al endpoint SSR:
 
 No usar el fragmento de sesión del flujo cliente como mecanismo principal del piloto.
 
-## 4. Variables del despliegue
-Configurar en el proveedor de runtime Next.js:
+## 5. GitHub Actions y secretos
+El workflow manual `.github/workflows/hosted-pilot-preview.yml` hace checkout explícito de `develop`, captura su SHA completo, crea o reutiliza el proyecto Vercel canónico del modo seleccionado y despliega **solo Preview**.
 
-```text
-NEXT_PUBLIC_DATA_MODE=supabase
-NEXT_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
-SUPABASE_SECRET_KEY=sb_secret_...
-APP_BASE_URL=https://<origen-canonico>
-```
-
-`SUPABASE_SECRET_KEY` es exclusivamente server-side. Nunca usar prefijo `NEXT_PUBLIC_`, imprimirla, retornarla por API ni versionarla.
-
-`APP_BASE_URL` debe ser un origen HTTP/HTTPS confiable. La API de invitaciones no usa el header `Host` como sustituto. En Preview de Vercel puede permanecer ausente: el runtime usa únicamente la URL de rama confiable expuesta por Vercel.
-
-### 4.1 Preview reproducible desde GitHub Actions
-El workflow manual `.github/workflows/hosted-pilot-preview.yml` es la ruta canónica para crear/reutilizar el proyecto Vercel y desplegar **solo Preview** desde el SHA exacto de `develop`.
-
-Configurar una sola vez estos GitHub Actions secrets, sin escribir sus valores en archivos, issues, logs ni commits:
+Secretos requeridos para ambos modos:
 
 ```text
 VERCEL_TOKEN
 VERCEL_ORG_ID
+```
+
+Secretos adicionales requeridos solo por `full-ops`:
+
+```text
 PILOT_SUPABASE_URL
 PILOT_SUPABASE_PUBLISHABLE_KEY
 PILOT_SUPABASE_SECRET_KEY
 ```
 
-Al ejecutarse manualmente, el workflow:
-1. hace checkout explícito de `develop` y captura su SHA completo;
-2. exige todos los secretos antes de cualquier provisión;
-3. corre `pilot:backend-preflight -- --plants TAM,YAR --require-no-director`;
-4. crea o reutiliza `greenatics-ops` mediante la API oficial de Vercel;
-5. hace upsert únicamente de variables con target `preview`;
-6. crea un deployment Git del SHA exacto, sin `target=production`;
-7. espera estado `READY` y falla cerrado ante `BLOCKED`, `CANCELED` o `ERROR`;
-8. ejecuta `pilot:preflight` contra la URL resultante verificando rama y commit.
+### Contrato `public-only`
+El workflow:
+1. selecciona `public-only` por defecto;
+2. no exige secretos Supabase;
+3. no ejecuta `pilot:backend-preflight`;
+4. crea o reutiliza `greenatics-public-preview`;
+5. hace upsert únicamente de `NEXT_PUBLIC_DATA_MODE=local` con target `preview`;
+6. despliega el SHA exacto de `develop` sin `target=production`;
+7. espera `READY` y falla cerrado ante estados terminales;
+8. ejecuta `pilot:preflight -- --mode public-only`.
 
-El cliente `scripts/vercel-pilot-deploy.mjs` nunca imprime `VERCEL_TOKEN`, `VERCEL_ORG_ID` ni claves Supabase. Los errores remotos se reducen a códigos seguros para evitar que un mensaje del proveedor pueda reflejar credenciales. Producción no se despliega ni se promueve con este workflow.
+El preflight exige que `/api/health` reporte `backend=missing` y `admin=missing`. Si aparecen configurados, el gate falla para detectar contaminación de credenciales.
 
-## 5. Backend preflight + primer director
-Antes de enviar una invitación real, validar que el esquema hospedado, RLS, Supabase Auth Admin, las plantas canónicas y el estado de bootstrap sean coherentes:
+### Contrato `full-ops`
+El workflow:
+1. exige los secretos Supabase;
+2. corre `pilot:backend-preflight -- --plants TAM,YAR --require-no-director`;
+3. crea o reutiliza `greenatics-ops`;
+4. configura únicamente en target `preview`:
+
+```text
+NEXT_PUBLIC_DATA_MODE=supabase
+NEXT_PUBLIC_SUPABASE_URL=<project-url>
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<publishable-key>
+SUPABASE_SECRET_KEY=<server-only-secret>
+```
+
+5. despliega el SHA exacto y espera `READY`;
+6. ejecuta `pilot:preflight -- --mode full-ops`.
+
+`SUPABASE_SECRET_KEY` es exclusivamente server-side. Nunca usar prefijo `NEXT_PUBLIC_`, imprimirla, retornarla por API ni versionarla.
+
+El cliente `scripts/vercel-pilot-deploy.mjs` reduce errores remotos a códigos seguros y no imprime tokens ni claves. Producción no se despliega ni se promueve con este workflow.
+
+## 6. Backend preflight + primer director
+Este bloque aplica únicamente a `full-ops`.
+
+Antes de enviar una invitación real:
 
 ```bash
 npm run pilot:backend-preflight -- \
@@ -83,11 +117,9 @@ npm run pilot:backend-preflight -- \
   --require-no-director
 ```
 
-Este gate es de solo lectura: no crea usuarios, no cambia membresías y no imprime secretos. Debe pasar antes del primer bootstrap.
+El gate es de solo lectura: valida contrato de esquema, RLS, Supabase Auth Admin, plantas canónicas y estado de bootstrap sin crear usuarios ni cambiar membresías.
 
-El preflight consume `admin_hosted_schema_contract()` con `SUPABASE_SECRET_KEY` y falla cerrado si la base no reporta el contrato canónico esperado por el código, si alguna tabla pública queda sin RLS, si faltan plantas piloto o si el estado de Director cambia durante la comprobación. La RPC es server-only: `anon` y `authenticated` no tienen permiso de ejecución. Esto evita depender de timestamps o entradas históricas duplicadas del registro de migraciones para decidir si una base está lista.
-
-Con variables cargadas en un entorno administrativo y `APP_BASE_URL` ya fijado al deployment real:
+Con el backend certificado y `APP_BASE_URL`/origen confiable resuelto:
 
 ```bash
 npm run bootstrap:director -- \
@@ -96,9 +128,9 @@ npm run bootstrap:director -- \
   --plants TAM,YAR
 ```
 
-El bootstrap usa una RPC atómica y se niega a operar si ya existe cualquier membresía activa con rol `director`. Después de ese punto, las invitaciones y cambios de rol se hacen desde `/admin/users`.
+El bootstrap usa una RPC atómica y se niega a operar si ya existe cualquier membresía activa con rol `director`. Después, invitaciones y cambios de rol se realizan desde `/admin/users`.
 
-## 6. Activación del usuario invitado
+## 7. Activación del usuario invitado
 1. Dirección invita desde `/admin/users`.
 2. Supabase envía el correo.
 3. El usuario abre `/auth/confirm?...`.
@@ -107,36 +139,45 @@ El bootstrap usa una RPC atómica y se niega a operar si ya existe cualquier mem
 6. Al completar la activación se entra a `/app`.
 7. RLS limita lectura y escritura a plantas/membresías autorizadas.
 
-## 7. Readiness ejecutable
+## 8. Readiness ejecutable
 `GET /api/health` es público y no devuelve credenciales.
 
-Estados:
-- `200 ready`: modo local, o backend + Auth Admin + origen canónico operativos.
-- `503 degraded`: falta configuración o falla el backend remoto.
-
-Antes de habilitar el acceso real a OPS, exigir `200 ready` en el dominio final y ejecutar el gate anónimo del deployment:
+### Certificar `public-only`
 
 ```bash
 npm run pilot:preflight -- \
-  --base-url https://<deployment> \
+  --base-url https://<deployment-publico> \
+  --mode public-only \
   --expected-branch develop \
   --expected-commit <sha-desplegado>
 ```
 
-El preflight falla si:
-- `/api/health` no reporta `ready`, `supabase`, `supabase-auth` y checks remotos `ok`;
-- el runtime no reporta Vercel `preview` o `production`;
-- rama o commit no coinciden con lo esperado;
-- faltan headers de seguridad o privacidad;
-- `/app` anónimo no redirige al login canónico conservando `next=/app`;
-- el deployment sigue en `configuration-block`;
-- el sitemap expone rutas internas;
-- `robots.txt` deja de bloquear `/app`, `/login` o `/api/`.
+Debe reportar:
+- `status=ready`;
+- `mode=local`;
+- `opsAccess=configuration-block`;
+- `checks.backend=missing`;
+- `checks.admin=missing`;
+- Vercel + branch + commit esperados;
+- `/app` bloqueado con `reason=configuration`;
+- sitemap/robots/headers correctos.
 
-Este gate no usa correos, contraseñas ni tokens de usuarios y no sustituye el smoke multiusuario.
+### Certificar `full-ops`
 
-## 8. Smoke RLS multiusuario de solo lectura
-Una vez existan el director y un operario de prueba de Támesis, cargar sus credenciales como variables efímeras del shell o secretos de CI; nunca guardarlas en archivos versionados, historial de comandos ni argumentos CLI:
+```bash
+npm run pilot:preflight -- \
+  --base-url https://<deployment-ops> \
+  --mode full-ops \
+  --expected-branch develop \
+  --expected-commit <sha-desplegado>
+```
+
+Debe reportar `ready`, `supabase`, `supabase-auth`, checks remotos `ok` y `/app` anónimo redirigido al login sin bloqueo de configuración.
+
+## 9. Smoke RLS multiusuario de solo lectura
+Aplica a `full-ops` una vez existan director y operario de prueba.
+
+Variables efímeras/secretos de CI:
 
 ```text
 PILOT_DIRECTOR_EMAIL=...
@@ -145,17 +186,15 @@ PILOT_OPERATOR_EMAIL=...
 PILOT_OPERATOR_PASSWORD=...
 ```
 
-Con `NEXT_PUBLIC_SUPABASE_URL` y `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` disponibles:
+Con URL y publishable key Supabase disponibles:
 
 ```bash
 npm run pilot:rls-smoke
 ```
 
-El gate usa dos sesiones independientes y únicamente la clave publicable/anon. Falla si recibe una `sb_secret_` o un JWT `service_role`. Por defecto exige que Dirección vea exactamente `TAM,YAR`, que el operario vea exactamente `TAM`, y que una lectura explícita de `YAR` como operario devuelva cero filas por RLS. Puede ajustarse el alcance esperado con `PILOT_DIRECTOR_PLANTS` y `PILOT_OPERATOR_PLANTS`.
+El gate usa dos sesiones independientes y únicamente la clave publicable/anon. Falla si recibe una `sb_secret_` o JWT `service_role`. Por defecto exige Dirección `TAM,YAR`, operario `TAM` y cero filas de `YAR` para ese operario.
 
-Este smoke no crea usuarios ni escribe datos. Certifica autenticación + aislamiento de lectura, pero no sustituye las transacciones funcionales siguientes.
-
-## 9. Smoke funcional multiusuario obligatorio
+## 10. Smoke funcional multiusuario obligatorio
 Con dos perfiles de navegador distintos:
 1. La web pública abre sin sesión.
 2. `/app` redirige a `/login` sin sesión.
@@ -168,18 +207,15 @@ Con dos perfiles de navegador distintos:
 9. Consumo superior al lote es rechazado.
 10. Cerrar sesión invalida la navegación protegida y redirige a `/login`.
 
-## 10. Gate de promoción
-Antes de promover el piloto:
+## 11. Gate de promoción
+Antes de asociar dominio o promover a producción:
 - CI de PR verde (`quality` + `database`);
-- Preview creado por el workflow manual y `pilot:preflight` en PASS para el SHA exacto de `develop`;
-- `npm run pilot:backend-preflight -- --plants TAM,YAR` en PASS, incluyendo schema contract + RLS completo;
-- `npm run pilot:rls-smoke` en PASS con los dos usuarios de prueba;
-- smoke funcional multiusuario aprobado;
+- `public-only` Preview en PASS para el SHA exacto de `develop`;
+- `full-ops` Preview en PASS cuando se vaya a habilitar OPS remoto;
+- backend preflight, smoke RLS y smoke funcional aprobados para `full-ops`;
 - redirects Auth configurados;
-- ningún secreto presente en GitHub, bundle cliente o logs;
-- web pública validada sin autenticación.
+- ningún secreto presente en GitHub, bundle cliente, proyecto público o logs;
+- web pública validada sin autenticación;
+- decisión explícita de convergencia `main` / `develop`, rama productiva y dominio.
 
-Solo después de esos gates se permite configurar `APP_BASE_URL` canónico y promover/desplegar a producción.
-
-## 11. Siguiente integración
-SharePoint permanece como fuente documental e histórica. GREENATICS OPS es el sistema transaccional. La integración documental debe añadir referencias/lectura sin devolver las transacciones diarias a SharePoint.
+SharePoint permanece como fuente documental e histórica. GREENATICS OPS es el sistema transaccional; la integración documental debe añadir referencias/lectura sin devolver las transacciones diarias a SharePoint.

--- a/docs/deployment/PREVIEW-GATE.md
+++ b/docs/deployment/PREVIEW-GATE.md
@@ -11,16 +11,25 @@ Definir el mínimo verificable antes de asociar `greenatics.com.co` a un deploym
 - `robots.txt` y `X-Robots-Tag` complementan la seguridad; no sustituyen autenticación.
 - `/api/health` expone provenance mínima para comprobar que el preview corresponde al branch/SHA esperado.
 
-## Variables de entorno
-### Preview público sin OPS remoto
-No activar un bypass local. En Vercel, el gate de v0.11 bloquea OPS si no existe configuración Supabase completa.
+## Dos previews, dos fronteras
+El workflow manual `hosted-pilot-preview` ofrece dos modos explícitos y no comparte el mismo proyecto Vercel entre ellos:
 
-### Preview con OPS remoto
-Configurar:
-- `NEXT_PUBLIC_DATA_MODE=supabase`
-- `NEXT_PUBLIC_SUPABASE_URL=<project-url>`
-- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<publishable-key>`
-- `SUPABASE_SECRET_KEY=<server-only-secret>` cuando se prueben administración, invitaciones o health completo.
+### `public-only` · predeterminado
+- proyecto canónico: `greenatics-public-preview`;
+- única variable funcional creada por el deployer: `NEXT_PUBLIC_DATA_MODE=local` con target `preview`;
+- no requiere ni inyecta credenciales Supabase;
+- no ejecuta backend preflight;
+- `/api/health` debe reportar `mode=local`, `opsAccess=configuration-block`, `checks.backend=missing` y `checks.admin=missing`;
+- `/app` debe redirigir a `/login?reason=configuration&next=/app`.
+
+El gate falla si detecta backend/admin configurados: un preview público contaminado con credenciales no es aceptable aunque `NEXT_PUBLIC_DATA_MODE=local` pudiera impedir su uso.
+
+### `full-ops`
+- proyecto canónico: `greenatics-ops`;
+- requiere `NEXT_PUBLIC_DATA_MODE=supabase`, URL Supabase, publishable key y secret key server-side;
+- ejecuta backend preflight antes del deployment;
+- `/api/health` debe reportar `mode=supabase`, `opsAccess=supabase-auth` y los checks remotos en `ok`;
+- `/app` anónimo debe redirigir al login sin `reason=configuration`.
 
 Para redirects de autenticación:
 - `APP_BASE_URL` es la autoridad explícita cuando está definido.
@@ -38,10 +47,25 @@ Nunca exponer `SUPABASE_SECRET_KEY` ni ninguna credencial administrativa mediant
 5. `/robots.txt` bloquea rutas internas y `/api/`.
 6. Respuestas públicas incluyen `nosniff`, `DENY` para framing, política de referrer y permisos restringidos.
 7. `/app` y demás familias OPS incluyen `private, no-store` y `X-Robots-Tag: noindex, nofollow, noarchive`.
-8. Preview sin Supabase: `/app` redirige a `/login?reason=configuration` y no muestra datos OPS; `/api/health` reporta `opsAccess=configuration-block`.
-9. Preview con Supabase: usuario sin sesión va a login; usuario válido necesita perfil activo y membresía activa de planta; `/api/health` reporta `opsAccess=supabase-auth`.
+8. `public-only`: `/app` queda bloqueado por configuración y el health demuestra ausencia de credenciales backend.
+9. `full-ops`: usuario sin sesión va a login; usuario válido necesita perfil activo y membresía activa de planta.
 10. Un usuario autorizado entra a `/app`; RLS conserva aislamiento por planta/rol.
 11. Salir de OPS hacia la web pública y entrar desde la web pública a OPS cruza una frontera documental, no depende de preservar el árbol de providers del cliente.
+
+## Ejecución reproducible
+Desde GitHub Actions, ejecutar `hosted-pilot-preview` y elegir el modo. `public-only` es la opción segura inicial para QA visual y editorial. `full-ops` se usa únicamente cuando el backend piloto esté listo y sus secretos existan en GitHub Actions.
+
+El preflight desplegado recibe el mismo modo:
+
+```bash
+npm run pilot:preflight -- \
+  --base-url https://<deployment> \
+  --mode public-only \
+  --expected-branch develop \
+  --expected-commit <sha>
+```
+
+Cambiar a `--mode full-ops` únicamente para el proyecto OPS completo.
 
 ## Gate de observabilidad
 - Revisar build logs sin errores.

--- a/docs/deployment/VERCEL-GIT-INTEGRATION.md
+++ b/docs/deployment/VERCEL-GIT-INTEGRATION.md
@@ -6,33 +6,57 @@ Vincular `arendon7/GTCS-WEB` a Vercel mediante Git Integration para obtener prev
 ## Estado de release
 A 2026-08-12 `main` y `develop` están divergidas. `develop` contiene la plataforma pública + GREENATICS OPS vigente, mientras `main` conserva commits propios no reconciliados.
 
-**Regla:** no definir todavía una rama productiva ni asociar `greenatics.com.co`. La primera integración se usa exclusivamente para Preview Deployments de branches/PRs hasta que exista una decisión explícita de release y convergencia.
+**Regla:** no definir todavía una rama productiva ni asociar `greenatics.com.co`. La primera integración se usa exclusivamente para Preview Deployments hasta que exista una decisión explícita de release y convergencia.
 
-## Configuración única en Vercel
-1. Importar el repositorio GitHub `arendon7/GTCS-WEB` en el team autorizado.
-2. Mantener Framework Preset `Next.js` y Root Directory en la raíz del repositorio.
-3. No sobrescribir Build Command, Output Directory ni Install Command salvo que un gate posterior demuestre que es necesario.
-4. Mantener Git Integration activa para que cada branch/PR genere su Preview Deployment.
-5. No asociar dominio productivo durante esta fase.
-6. No configurar `GREENATICS_OPS_LOCAL_BYPASS` en Vercel.
+## Ruta canónica automatizada
+El workflow manual `.github/workflows/hosted-pilot-preview.yml` despliega siempre el SHA exacto de `develop` y ofrece dos modos explícitos:
 
-No se requiere `vercel.json` para este contrato inicial.
+| Modo | Proyecto Vercel canónico | Backend | Uso |
+| --- | --- | --- | --- |
+| `public-only` | `greenatics-public-preview` | ninguno | QA público, visual, editorial, SEO, headers y frontera OPS |
+| `full-ops` | `greenatics-ops` | Supabase piloto | autenticación, perfiles, membresías y operación multiusuario |
 
-## Preview público sin OPS remoto
-Puede desplegarse sin credenciales Supabase para validar la superficie pública.
+`public-only` es el modo predeterminado. Los nombres de proyecto están fijados por código para impedir que un preview público reutilice accidentalmente el proyecto que contiene secretos de OPS.
 
-Estado esperado en `/api/health`:
+## Secretos de GitHub Actions
+Ambos modos requieren únicamente:
+
+```text
+VERCEL_TOKEN
+VERCEL_ORG_ID
+```
+
+`full-ops` requiere además:
+
+```text
+PILOT_SUPABASE_URL
+PILOT_SUPABASE_PUBLISHABLE_KEY
+PILOT_SUPABASE_SECRET_KEY
+```
+
+El workflow público no ejecuta backend preflight y no entrega las credenciales Supabase al proyecto `greenatics-public-preview`.
+
+## Preview `public-only`
+El deployer crea o reutiliza exclusivamente `greenatics-public-preview` y configura en target `preview`:
+
+```text
+NEXT_PUBLIC_DATA_MODE=local
+```
+
+Estado exigido por `/api/health`:
+- `status = "ready"`
 - `deployment.platform = "vercel"`
 - `deployment.environment = "preview"`
-- `deployment.branch` = branch desplegada
-- `deployment.commit` = SHA abreviado del commit desplegado
+- branch y commit coinciden con el SHA desplegado
 - `mode = "local"`
 - `opsAccess = "configuration-block"`
+- `checks.backend = "missing"`
+- `checks.admin = "missing"`
 
-Esto significa: la web pública puede validarse, pero las rutas OPS permanecen cerradas por el gate de producción. `mode=local` no implica bypass en Vercel.
+El preflight falla si detecta credenciales backend en este proyecto. `/app` debe redirigir a `/login?reason=configuration&next=/app`.
 
-## Preview con OPS remoto
-Configurar en el entorno Preview únicamente lo necesario:
+## Preview `full-ops`
+El deployer crea o reutiliza exclusivamente `greenatics-ops` y configura en target `preview`:
 
 ```text
 NEXT_PUBLIC_DATA_MODE=supabase
@@ -41,6 +65,14 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<publishable-key>
 SUPABASE_SECRET_KEY=<server-only-secret>
 ```
 
+Antes del deployment, el workflow ejecuta `pilot:backend-preflight`. Estado exigido por `/api/health`:
+- `status = "ready"`
+- `mode = "supabase"`
+- `opsAccess = "supabase-auth"`
+- `checks.backend = "ok"`
+- `checks.admin = "ok"`
+- `checks.appOrigin = "ok"`
+
 `SUPABASE_SECRET_KEY` nunca debe usar prefijo `NEXT_PUBLIC_`.
 
 ### Origen de autenticación
@@ -48,13 +80,6 @@ SUPABASE_SECRET_KEY=<server-only-secret>
 - Si `APP_BASE_URL` no está definido y `VERCEL_ENV=preview`, el servidor puede usar la variable de sistema `VERCEL_BRANCH_URL` como origen HTTPS estable de la rama.
 - En producción **no existe ese fallback**: `APP_BASE_URL` debe configurarse explícitamente con el origen canónico aprobado.
 - El origen de preview utilizado por Auth debe estar permitido también en la configuración de redirects del proyecto Supabase antes de probar invitaciones/confirmaciones.
-
-Estado esperado en `/api/health` con backend completo:
-- `status = "ready"`
-- `opsAccess = "supabase-auth"`
-- `checks.backend = "ok"`
-- `checks.admin = "ok"`
-- `checks.appOrigin = "ok"`
 
 ## Provenance segura
 `/api/health` publica únicamente:
@@ -66,15 +91,17 @@ Estado esperado en `/api/health` con backend completo:
 No publica `VERCEL_URL`, IDs de proyecto/team, mensajes de commit, secretos ni valores de configuración.
 
 ## Preview Gate
+El mismo modo seleccionado para desplegar se entrega a `pilot:preflight`.
+
 Antes de aprobar un preview:
-1. Confirmar que branch y SHA de `/api/health` coinciden con el commit GitHub esperado.
-2. Validar `/`, `/wondergreen`, `/soluciones`, `/proyectos`, `/impacto`, `/biblioteca`, `/nosotros` y `/contacto`.
-3. Verificar `sitemap.xml` y `robots.txt`.
-4. Verificar headers públicos e internos.
-5. Confirmar que `/app` está bloqueado sin Supabase o exige sesión válida con Supabase.
-6. Ejecutar login, perfil y membresía si el preview usa OPS remoto.
-7. Revisar logs de build/runtime y ausencia de 5xx/bucles de redirect.
-8. Probar desktop y móvil.
+1. confirmar branch y SHA de `/api/health`;
+2. validar `/`, `/wondergreen`, `/soluciones`, `/proyectos`, `/impacto`, `/biblioteca`, `/nosotros` y `/contacto`;
+3. verificar `sitemap.xml`, `robots.txt` y headers;
+4. confirmar el comportamiento OPS correspondiente al modo;
+5. en `public-only`, confirmar además ausencia de configuración backend;
+6. en `full-ops`, ejecutar login, perfil, membresía y los smokes RLS/funcionales;
+7. revisar logs de build/runtime y ausencia de 5xx/bucles de redirect;
+8. probar desktop y móvil.
 
 El gate completo continúa definido en `docs/deployment/PREVIEW-GATE.md`.
 

--- a/scripts/hosted-pilot-preflight-lib.mjs
+++ b/scripts/hosted-pilot-preflight-lib.mjs
@@ -9,6 +9,8 @@ const PRIVATE_HEADERS = {
   "x-robots-tag": "noindex, nofollow, noarchive",
 };
 
+const PILOT_MODES = new Set(["public-only", "full-ops"]);
+
 export class PreflightError extends Error {
   constructor(message) {
     super(message);
@@ -35,6 +37,12 @@ export function normalizeHostedBaseUrl(value) {
   if (url.pathname !== "/" || url.search || url.hash) fail("Usa únicamente el origen del deployment, sin ruta, query ni fragmento.");
 
   return url.origin;
+}
+
+export function normalizePilotMode(value) {
+  const mode = typeof value === "string" && value.trim() ? value.trim() : "full-ops";
+  if (!PILOT_MODES.has(mode)) fail("El modo esperado debe ser public-only o full-ops.");
+  return mode;
 }
 
 function requireStatus(response, expected, label) {
@@ -69,15 +77,35 @@ function normalizeCommit(value) {
   return value.toLowerCase();
 }
 
-export function assertHostedHealth(payload, { expectedBranch, expectedCommit } = {}) {
+export function assertHostedHealth(payload, {
+  expectedBranch,
+  expectedCommit,
+  expectedMode = "full-ops",
+} = {}) {
+  const pilotMode = normalizePilotMode(expectedMode);
   if (!payload || typeof payload !== "object") fail("health: respuesta JSON inválida.");
   if (payload.status !== "ready") fail(`health: status=${String(payload.status)}; se esperaba ready.`);
-  if (payload.mode !== "supabase") fail(`health: mode=${String(payload.mode)}; se esperaba supabase.`);
-  if (payload.opsAccess !== "supabase-auth") fail(`health: opsAccess=${String(payload.opsAccess)}; se esperaba supabase-auth.`);
 
   const checks = payload.checks ?? {};
-  for (const key of ["backend", "admin", "appOrigin"]) {
-    if (checks[key] !== "ok") fail(`health: check ${key}=${String(checks[key])}; se esperaba ok.`);
+  if (pilotMode === "public-only") {
+    if (payload.mode !== "local") fail(`health: mode=${String(payload.mode)}; se esperaba local para public-only.`);
+    if (payload.opsAccess !== "configuration-block") {
+      fail(`health: opsAccess=${String(payload.opsAccess)}; se esperaba configuration-block para public-only.`);
+    }
+    for (const key of ["backend", "admin"]) {
+      if (checks[key] !== "missing") {
+        fail(`health: check ${key}=${String(checks[key])}; public-only no debe recibir credenciales Supabase.`);
+      }
+    }
+    if (!["ok", "missing"].includes(checks.appOrigin)) {
+      fail(`health: check appOrigin=${String(checks.appOrigin)}; se esperaba ok o missing.`);
+    }
+  } else {
+    if (payload.mode !== "supabase") fail(`health: mode=${String(payload.mode)}; se esperaba supabase.`);
+    if (payload.opsAccess !== "supabase-auth") fail(`health: opsAccess=${String(payload.opsAccess)}; se esperaba supabase-auth.`);
+    for (const key of ["backend", "admin", "appOrigin"]) {
+      if (checks[key] !== "ok") fail(`health: check ${key}=${String(checks[key])}; se esperaba ok.`);
+    }
   }
 
   const deployment = payload.deployment ?? {};
@@ -142,10 +170,12 @@ export async function runHostedPilotPreflight({
   baseUrl,
   expectedBranch,
   expectedCommit,
+  expectedMode = "full-ops",
   fetchImpl = globalThis.fetch,
 }) {
   if (typeof fetchImpl !== "function") fail("No existe una implementación fetch disponible.");
   const origin = normalizeHostedBaseUrl(baseUrl);
+  const pilotMode = normalizePilotMode(expectedMode);
 
   const healthResponse = await get(fetchImpl, `${origin}/api/health`);
   requireStatus(healthResponse, 200, "health");
@@ -157,7 +187,7 @@ export async function runHostedPilotPreflight({
   } catch {
     fail("health: el endpoint no devolvió JSON válido.");
   }
-  const deployment = assertHostedHealth(health, { expectedBranch, expectedCommit });
+  const deployment = assertHostedHealth(health, { expectedBranch, expectedCommit, expectedMode: pilotMode });
 
   const publicResponse = await get(fetchImpl, `${origin}/`);
   requireStatus(publicResponse, 200, "home pública");
@@ -180,7 +210,13 @@ export async function runHostedPilotPreflight({
   const loginTarget = new URL(location, origin);
   if (loginTarget.origin !== origin || loginTarget.pathname !== "/login") fail("OPS anónimo: redirect fuera del login canónico.");
   if (loginTarget.searchParams.get("next") !== "/app") fail("OPS anónimo: redirect no conserva next=/app.");
-  if (loginTarget.searchParams.has("reason")) fail("OPS anónimo: el deployment sigue en bloqueo de configuración.");
+  if (pilotMode === "public-only") {
+    if (loginTarget.searchParams.get("reason") !== "configuration") {
+      fail("OPS public-only: falta reason=configuration en el bloqueo esperado.");
+    }
+  } else if (loginTarget.searchParams.has("reason")) {
+    fail("OPS full-ops: el deployment sigue en bloqueo de configuración.");
+  }
 
   const sitemapResponse = await get(fetchImpl, `${origin}/sitemap.xml`);
   requireStatus(sitemapResponse, 200, "sitemap");
@@ -192,7 +228,15 @@ export async function runHostedPilotPreflight({
 
   return {
     origin,
+    mode: pilotMode,
     deployment,
-    checks: ["health", "public-boundary", "login-private", "ops-anonymous", "sitemap", "robots"],
+    checks: [
+      "health",
+      "public-boundary",
+      "login-private",
+      pilotMode === "public-only" ? "ops-configuration-block" : "ops-anonymous",
+      "sitemap",
+      "robots",
+    ],
   };
 }

--- a/scripts/hosted-pilot-preflight.mjs
+++ b/scripts/hosted-pilot-preflight.mjs
@@ -18,6 +18,7 @@ Uso:
 
 Opciones:
   --base-url <origin>        Origen HTTPS del deployment. APP_BASE_URL es fallback.
+  --mode <mode>              public-only o full-ops. Default: full-ops.
   --expected-branch <name>   Exige que /api/health reporte esta rama.
   --expected-commit <sha>    Exige que /api/health reporte este commit (12 primeros caracteres).
   --help                     Muestra esta ayuda.
@@ -32,12 +33,14 @@ async function main() {
 
   const result = await runHostedPilotPreflight({
     baseUrl: readArg("--base-url") ?? process.env.APP_BASE_URL,
+    expectedMode: readArg("--mode") ?? process.env.PILOT_PREVIEW_MODE,
     expectedBranch: readArg("--expected-branch"),
     expectedCommit: readArg("--expected-commit"),
   });
 
   console.log("GREENATICS hosted pilot preflight: PASS");
   console.log(`origin: ${result.origin}`);
+  console.log(`mode: ${result.mode}`);
   console.log(`deployment: ${result.deployment.platform}/${result.deployment.environment}`);
   console.log(`branch: ${result.deployment.branch ?? "n/a"}`);
   console.log(`commit: ${result.deployment.commit ?? "n/a"}`);

--- a/scripts/hosted-pilot-preflight.test.mjs
+++ b/scripts/hosted-pilot-preflight.test.mjs
@@ -3,6 +3,7 @@ import {
   PreflightError,
   assertHostedHealth,
   normalizeHostedBaseUrl,
+  normalizePilotMode,
   runHostedPilotPreflight,
 } from "./hosted-pilot-preflight-lib.mjs";
 
@@ -20,17 +21,27 @@ const privateHeaders = {
   "x-robots-tag": "noindex, nofollow, noarchive",
 };
 
-const healthPayload = {
+const deployment = {
+  platform: "vercel",
+  environment: "preview",
+  branch: "develop",
+  commit: "850ffcea0800",
+};
+
+const fullOpsHealth = {
   status: "ready",
   mode: "supabase",
   opsAccess: "supabase-auth",
   checks: { backend: "ok", admin: "ok", appOrigin: "ok" },
-  deployment: {
-    platform: "vercel",
-    environment: "preview",
-    branch: "develop",
-    commit: "850ffcea0800",
-  },
+  deployment,
+};
+
+const publicHealth = {
+  status: "ready",
+  mode: "local",
+  opsAccess: "configuration-block",
+  checks: { backend: "missing", admin: "missing", appOrigin: "ok" },
+  deployment,
 };
 
 function jsonResponse(payload, init = {}) {
@@ -41,15 +52,21 @@ function jsonResponse(payload, init = {}) {
   });
 }
 
-function hostedFixture(overrides = {}) {
+function hostedFixture({ mode = "full-ops", overrides = {} } = {}) {
   const origin = "https://greenatics-pilot.vercel.app";
+  const publicOnly = mode === "public-only";
   const responses = {
-    [`${origin}/api/health`]: jsonResponse(healthPayload, { headers: privateHeaders }),
+    [`${origin}/api/health`]: jsonResponse(publicOnly ? publicHealth : fullOpsHealth, { headers: privateHeaders }),
     [`${origin}/`]: new Response("home", { status: 200, headers: baselineHeaders }),
     [`${origin}/login`]: new Response("login", { status: 200, headers: privateHeaders }),
     [`${origin}/app`]: new Response(null, {
       status: 307,
-      headers: { ...privateHeaders, location: `${origin}/login?next=%2Fapp` },
+      headers: {
+        ...privateHeaders,
+        location: publicOnly
+          ? `${origin}/login?reason=configuration&next=%2Fapp`
+          : `${origin}/login?next=%2Fapp`,
+      },
     }),
     [`${origin}/sitemap.xml`]: new Response(
       `<?xml version="1.0"?><urlset><url><loc>${origin}/</loc></url><url><loc>${origin}/wondergreen</loc></url></urlset>`,
@@ -70,48 +87,99 @@ function hostedFixture(overrides = {}) {
 }
 
 describe("hosted pilot preflight", () => {
-  it("normalizes only HTTPS origins without embedded paths or credentials", () => {
+  it("normalizes only HTTPS origins and accepted pilot modes", () => {
     expect(normalizeHostedBaseUrl("https://pilot.example.com")).toBe("https://pilot.example.com");
     expect(() => normalizeHostedBaseUrl("http://pilot.example.com")).toThrow(PreflightError);
     expect(() => normalizeHostedBaseUrl("https://user:pass@pilot.example.com")).toThrow(PreflightError);
     expect(() => normalizeHostedBaseUrl("https://pilot.example.com/app")).toThrow(PreflightError);
+    expect(normalizePilotMode(undefined)).toBe("full-ops");
+    expect(normalizePilotMode("public-only")).toBe("public-only");
+    expect(() => normalizePilotMode("unknown")).toThrow(/public-only o full-ops/);
   });
 
-  it("accepts a ready Supabase deployment with matching branch and commit", async () => {
+  it("accepts a ready full-ops deployment with matching branch and commit", async () => {
     const fixture = hostedFixture();
     const result = await runHostedPilotPreflight({
       baseUrl: fixture.origin,
+      expectedMode: "full-ops",
       expectedBranch: "develop",
       expectedCommit: "850ffcea08008f40f7d6747a39a122259b5ccbf9",
       fetchImpl: fixture.fetchImpl,
     });
 
     expect(result.origin).toBe(fixture.origin);
+    expect(result.mode).toBe("full-ops");
     expect(result.deployment.environment).toBe("preview");
     expect(result.checks).toContain("ops-anonymous");
   });
 
-  it("rejects a deployment that still reports configuration-block", () => {
-    expect(() => assertHostedHealth({ ...healthPayload, opsAccess: "configuration-block" })).toThrow(/supabase-auth/);
+  it("accepts a public-only deployment only when OPS is configuration-blocked and Supabase is absent", async () => {
+    const fixture = hostedFixture({ mode: "public-only" });
+    const result = await runHostedPilotPreflight({
+      baseUrl: fixture.origin,
+      expectedMode: "public-only",
+      expectedBranch: "develop",
+      expectedCommit: "850ffcea08008f40f7d6747a39a122259b5ccbf9",
+      fetchImpl: fixture.fetchImpl,
+    });
+
+    expect(result.mode).toBe("public-only");
+    expect(result.checks).toContain("ops-configuration-block");
+  });
+
+  it("rejects backend credential contamination in public-only", () => {
+    expect(() => assertHostedHealth({
+      ...publicHealth,
+      checks: { ...publicHealth.checks, backend: "ok" },
+    }, { expectedMode: "public-only" })).toThrow(/no debe recibir credenciales Supabase/);
+  });
+
+  it("rejects configuration-block when full-ops is expected", () => {
+    expect(() => assertHostedHealth({ ...fullOpsHealth, opsAccess: "configuration-block" }, { expectedMode: "full-ops" })).toThrow(/supabase-auth/);
+  });
+
+  it("rejects an OPS redirect that does not match the selected mode", async () => {
+    const origin = "https://greenatics-pilot.vercel.app";
+    const fixture = hostedFixture({
+      mode: "public-only",
+      overrides: {
+        [`${origin}/app`]: new Response(null, {
+          status: 307,
+          headers: { ...privateHeaders, location: `${origin}/login?next=%2Fapp` },
+        }),
+      },
+    });
+
+    await expect(runHostedPilotPreflight({
+      baseUrl: fixture.origin,
+      expectedMode: "public-only",
+      fetchImpl: fixture.fetchImpl,
+    })).rejects.toThrow(/reason=configuration/);
   });
 
   it("rejects anonymous OPS redirects that leave the canonical origin", async () => {
+    const origin = "https://greenatics-pilot.vercel.app";
     const fixture = hostedFixture({
-      "https://greenatics-pilot.vercel.app/app": new Response(null, {
-        status: 307,
-        headers: { ...privateHeaders, location: "https://evil.example/login?next=%2Fapp" },
-      }),
+      overrides: {
+        [`${origin}/app`]: new Response(null, {
+          status: 307,
+          headers: { ...privateHeaders, location: "https://evil.example/login?next=%2Fapp" },
+        }),
+      },
     });
 
     await expect(runHostedPilotPreflight({ baseUrl: fixture.origin, fetchImpl: fixture.fetchImpl })).rejects.toThrow(/login canónico/);
   });
 
   it("rejects internal routes leaked into the public sitemap", async () => {
+    const origin = "https://greenatics-pilot.vercel.app";
     const fixture = hostedFixture({
-      "https://greenatics-pilot.vercel.app/sitemap.xml": new Response(
-        `<?xml version="1.0"?><urlset><url><loc>https://greenatics-pilot.vercel.app/app</loc></url></urlset>`,
-        { status: 200 },
-      ),
+      overrides: {
+        [`${origin}/sitemap.xml`]: new Response(
+          `<?xml version="1.0"?><urlset><url><loc>${origin}/app</loc></url></urlset>`,
+          { status: 200 },
+        ),
+      },
     });
 
     await expect(runHostedPilotPreflight({ baseUrl: fixture.origin, fetchImpl: fixture.fetchImpl })).rejects.toThrow(/ruta interna/);

--- a/scripts/vercel-pilot-deploy-lib.mjs
+++ b/scripts/vercel-pilot-deploy-lib.mjs
@@ -1,5 +1,9 @@
 const VERCEL_API_ORIGIN = "https://api.vercel.com";
-const DEFAULT_PROJECT_NAME = "greenatics-ops";
+const PILOT_MODES = new Set(["public-only", "full-ops"]);
+const PROJECT_BY_MODE = Object.freeze({
+  "public-only": "greenatics-public-preview",
+  "full-ops": "greenatics-ops",
+});
 const TERMINAL_FAILURE_STATES = new Set(["BLOCKED", "CANCELED", "ERROR"]);
 
 export class VercelPilotError extends Error {
@@ -44,19 +48,48 @@ function parseGitRef(value) {
   return ref;
 }
 
-export function parseVercelPilotConfig(env = process.env) {
-  const projectName = clean(env.VERCEL_PROJECT_NAME) || DEFAULT_PROJECT_NAME;
-  if (!/^[a-z0-9][a-z0-9-]{0,99}$/.test(projectName)) {
-    throw new VercelPilotError("VERCEL_PROJECT_NAME debe ser un slug seguro en minúsculas.");
+function parsePilotMode(value) {
+  const mode = clean(value) || "public-only";
+  if (!PILOT_MODES.has(mode)) {
+    throw new VercelPilotError("PILOT_PREVIEW_MODE debe ser public-only o full-ops.");
   }
+  return mode;
+}
 
-  return Object.freeze({
+function canonicalProjectName(mode, override) {
+  const expected = PROJECT_BY_MODE[mode];
+  const requested = clean(override) || expected;
+  if (requested !== expected) {
+    throw new VercelPilotError(`VERCEL_PROJECT_NAME para ${mode} debe ser ${expected}.`);
+  }
+  return expected;
+}
+
+export function parseVercelPilotConfig(env = process.env) {
+  const mode = parsePilotMode(env.PILOT_PREVIEW_MODE);
+  const projectName = canonicalProjectName(mode, env.VERCEL_PROJECT_NAME);
+
+  const base = {
+    mode,
     token: requireValue(env, "VERCEL_TOKEN"),
     teamId: requireValue(env, "VERCEL_ORG_ID", { max: 256 }),
     projectName,
     repository: parseRepository(requireValue(env, "GITHUB_REPOSITORY", { max: 256 })),
     gitRef: parseGitRef(requireValue(env, "DEPLOY_GIT_REF", { max: 255 })),
     gitSha: parseCommitSha(requireValue(env, "DEPLOY_GIT_SHA", { max: 40 })),
+  };
+
+  if (mode === "public-only") {
+    return Object.freeze({
+      ...base,
+      supabaseUrl: null,
+      supabasePublishableKey: null,
+      supabaseSecretKey: null,
+    });
+  }
+
+  return Object.freeze({
+    ...base,
     supabaseUrl: requireValue(env, "NEXT_PUBLIC_SUPABASE_URL", { max: 2048 }),
     supabasePublishableKey: requireValue(env, "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", { max: 4096 }),
     supabaseSecretKey: requireValue(env, "SUPABASE_SECRET_KEY", { max: 4096 }),
@@ -145,45 +178,62 @@ export async function ensureVercelPilotProject(config, { fetchImpl = fetch } = {
 }
 
 function previewEnvironmentVariables(config) {
+  if (config.mode === "public-only") {
+    return [
+      {
+        key: "NEXT_PUBLIC_DATA_MODE",
+        value: "local",
+        type: "plain",
+        target: ["preview"],
+        comment: "GREENATICS public-only preview data mode",
+      },
+    ];
+  }
+
   return [
     {
       key: "NEXT_PUBLIC_DATA_MODE",
       value: "supabase",
       type: "plain",
       target: ["preview"],
-      comment: "GREENATICS hosted pilot preview data mode",
+      comment: "GREENATICS full OPS preview data mode",
     },
     {
       key: "NEXT_PUBLIC_SUPABASE_URL",
       value: config.supabaseUrl,
       type: "plain",
       target: ["preview"],
-      comment: "GREENATICS hosted pilot preview backend origin",
+      comment: "GREENATICS full OPS preview backend origin",
     },
     {
       key: "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
       value: config.supabasePublishableKey,
       type: "plain",
       target: ["preview"],
-      comment: "GREENATICS hosted pilot preview publishable key",
+      comment: "GREENATICS full OPS preview publishable key",
     },
     {
       key: "SUPABASE_SECRET_KEY",
       value: config.supabaseSecretKey,
       type: "sensitive",
       target: ["preview"],
-      comment: "GREENATICS hosted pilot preview server-only key",
+      comment: "GREENATICS full OPS preview server-only key",
     },
   ];
 }
 
 export async function upsertVercelPilotPreviewEnvironment(config, project, { fetchImpl = fetch } = {}) {
+  const variables = previewEnvironmentVariables(config);
   await vercelRequest(config, fetchImpl, `/v10/projects/${encodeURIComponent(project.id)}/env`, {
     method: "POST",
     query: { upsert: "true" },
-    body: previewEnvironmentVariables(config),
+    body: variables,
   });
-  return Object.freeze({ target: "preview", keys: Object.freeze(previewEnvironmentVariables(config).map((item) => item.key)) });
+  return Object.freeze({
+    target: "preview",
+    mode: config.mode,
+    keys: Object.freeze(variables.map((item) => item.key)),
+  });
 }
 
 function deploymentState(deployment) {
@@ -223,6 +273,7 @@ export async function createVercelPilotPreviewDeployment(config, project, { fetc
       },
       meta: {
         greenaticsHostedPilot: "true",
+        greenaticsPilotMode: config.mode,
         greenaticsGitSha: config.gitSha,
       },
     },
@@ -277,6 +328,7 @@ export async function runVercelPilotPreviewDeployment({
   });
 
   return Object.freeze({
+    mode: config.mode,
     project,
     environment,
     deployment,

--- a/scripts/vercel-pilot-deploy.mjs
+++ b/scripts/vercel-pilot-deploy.mjs
@@ -15,6 +15,7 @@ async function writeSummary(result) {
   const summary = [
     "## GREENATICS hosted pilot preview",
     "",
+    `- Mode: \`${result.mode}\``,
     `- Project: \`${result.project.name}\``,
     `- Project created in this run: \`${result.project.created ? "yes" : "no"}\``,
     `- Git ref: \`${result.gitRef}\``,
@@ -30,12 +31,14 @@ async function writeSummary(result) {
 async function main() {
   const result = await runVercelPilotPreviewDeployment();
 
+  await writeOutput("pilot_mode", result.mode);
   await writeOutput("project_id", result.project.id);
   await writeOutput("deployment_id", result.deployment.id);
   await writeOutput("deployment_url", result.deployment.origin);
   await writeSummary(result);
 
   console.log("GREENATICS Vercel hosted pilot: READY");
+  console.log(`mode: ${result.mode}`);
   console.log(`project: ${result.project.name}`);
   console.log(`project-created: ${result.project.created ? "yes" : "no"}`);
   console.log(`deployment: ${result.deployment.origin}`);

--- a/scripts/vercel-pilot-deploy.test.mjs
+++ b/scripts/vercel-pilot-deploy.test.mjs
@@ -5,13 +5,22 @@ import {
   runVercelPilotPreviewDeployment,
 } from "./vercel-pilot-deploy-lib.mjs";
 
-const env = {
+const baseEnv = {
   VERCEL_TOKEN: "vercel-test-token-never-log",
   VERCEL_ORG_ID: "team_test_scope",
-  VERCEL_PROJECT_NAME: "greenatics-ops",
   GITHUB_REPOSITORY: "arendon7/GTCS-WEB",
   DEPLOY_GIT_REF: "develop",
   DEPLOY_GIT_SHA: "a".repeat(40),
+};
+
+const publicEnv = {
+  ...baseEnv,
+  PILOT_PREVIEW_MODE: "public-only",
+};
+
+const fullOpsEnv = {
+  ...baseEnv,
+  PILOT_PREVIEW_MODE: "full-ops",
   NEXT_PUBLIC_SUPABASE_URL: "https://sanitized-project.supabase.co",
   NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_sanitized",
   SUPABASE_SECRET_KEY: "sb_secret_sanitized_server_only",
@@ -28,78 +37,106 @@ function requestBody(init) {
   return init?.body ? JSON.parse(String(init.body)) : undefined;
 }
 
+function successfulFetch({ projectName, deploymentUrl }) {
+  const calls = [];
+  let deploymentPolls = 0;
+  const fetchImpl = vi.fn(async (url, init = {}) => {
+    const parsed = new URL(url);
+    const method = init.method || "GET";
+    calls.push({ method, parsed, body: requestBody(init), authorization: init.headers?.Authorization });
+
+    if (method === "GET" && parsed.pathname === `/v9/projects/${projectName}`) {
+      return jsonResponse({ error: { code: "not_found" } }, 404);
+    }
+    if (method === "POST" && parsed.pathname === "/v11/projects") {
+      return jsonResponse({ id: "prj_greenatics_test", name: projectName });
+    }
+    if (method === "POST" && parsed.pathname === "/v10/projects/prj_greenatics_test/env") {
+      return jsonResponse({ created: [] });
+    }
+    if (method === "POST" && parsed.pathname === "/v13/deployments") {
+      return jsonResponse({ id: "dpl_greenatics_test", url: deploymentUrl, status: "QUEUED" });
+    }
+    if (method === "GET" && parsed.pathname === "/v13/deployments/dpl_greenatics_test") {
+      deploymentPolls += 1;
+      return jsonResponse({
+        id: "dpl_greenatics_test",
+        url: deploymentUrl,
+        status: deploymentPolls === 1 ? "BUILDING" : "READY",
+      });
+    }
+    throw new Error(`Unexpected ${method} ${parsed.pathname}`);
+  });
+  return { calls, fetchImpl };
+}
+
 describe("Vercel hosted pilot preview deployment", () => {
-  it("requires explicit infrastructure and backend configuration", () => {
-    expect(() => parseVercelPilotConfig({ ...env, VERCEL_TOKEN: "" })).toThrow(/VERCEL_TOKEN/);
-    expect(() => parseVercelPilotConfig({ ...env, DEPLOY_GIT_SHA: "abc" })).toThrow(/40 caracteres/);
-    expect(() => parseVercelPilotConfig({ ...env, DEPLOY_GIT_REF: "bad ref" })).toThrow(/referencia Git segura/);
+  it("defaults to an isolated public-only project without backend credentials", () => {
+    const config = parseVercelPilotConfig(baseEnv);
+    expect(config.mode).toBe("public-only");
+    expect(config.projectName).toBe("greenatics-public-preview");
+    expect(config.supabaseUrl).toBeNull();
+    expect(config.supabasePublishableKey).toBeNull();
+    expect(config.supabaseSecretKey).toBeNull();
   });
 
-  it("creates the project when absent, upserts preview-only env and deploys the exact SHA", async () => {
-    const calls = [];
-    let deploymentPolls = 0;
-    const fetchImpl = vi.fn(async (url, init = {}) => {
-      const parsed = new URL(url);
-      const method = init.method || "GET";
-      calls.push({ method, parsed, body: requestBody(init), authorization: init.headers?.Authorization });
+  it("requires infrastructure, safe Git provenance and canonical mode/project identity", () => {
+    expect(() => parseVercelPilotConfig({ ...publicEnv, VERCEL_TOKEN: "" })).toThrow(/VERCEL_TOKEN/);
+    expect(() => parseVercelPilotConfig({ ...publicEnv, DEPLOY_GIT_SHA: "abc" })).toThrow(/40 caracteres/);
+    expect(() => parseVercelPilotConfig({ ...publicEnv, DEPLOY_GIT_REF: "bad ref" })).toThrow(/referencia Git segura/);
+    expect(() => parseVercelPilotConfig({ ...publicEnv, PILOT_PREVIEW_MODE: "unknown" })).toThrow(/public-only o full-ops/);
+    expect(() => parseVercelPilotConfig({ ...publicEnv, VERCEL_PROJECT_NAME: "greenatics-ops" })).toThrow(/greenatics-public-preview/);
+  });
 
-      if (method === "GET" && parsed.pathname === "/v9/projects/greenatics-ops") {
-        return jsonResponse({ error: { code: "not_found" } }, 404);
-      }
-      if (method === "POST" && parsed.pathname === "/v11/projects") {
-        return jsonResponse({ id: "prj_greenatics_test", name: "greenatics-ops" });
-      }
-      if (method === "POST" && parsed.pathname === "/v10/projects/prj_greenatics_test/env") {
-        return jsonResponse({ created: [] });
-      }
-      if (method === "POST" && parsed.pathname === "/v13/deployments") {
-        return jsonResponse({ id: "dpl_greenatics_test", url: "greenatics-ops-preview.vercel.app", status: "QUEUED" });
-      }
-      if (method === "GET" && parsed.pathname === "/v13/deployments/dpl_greenatics_test") {
-        deploymentPolls += 1;
-        return jsonResponse({
-          id: "dpl_greenatics_test",
-          url: "greenatics-ops-preview.vercel.app",
-          status: deploymentPolls === 1 ? "BUILDING" : "READY",
-        });
-      }
-      throw new Error(`Unexpected ${method} ${parsed.pathname}`);
+  it("requires Supabase credentials only for full-ops", () => {
+    expect(() => parseVercelPilotConfig({ ...baseEnv, PILOT_PREVIEW_MODE: "full-ops" })).toThrow(/NEXT_PUBLIC_SUPABASE_URL/);
+    const config = parseVercelPilotConfig(fullOpsEnv);
+    expect(config.mode).toBe("full-ops");
+    expect(config.projectName).toBe("greenatics-ops");
+    expect(config.supabaseSecretKey).toBe(fullOpsEnv.SUPABASE_SECRET_KEY);
+  });
+
+  it("creates an isolated public project, injects only local mode and deploys the exact SHA", async () => {
+    const { calls, fetchImpl } = successfulFetch({
+      projectName: "greenatics-public-preview",
+      deploymentUrl: "greenatics-public-preview.vercel.app",
     });
 
     const result = await runVercelPilotPreviewDeployment({
-      env,
+      env: publicEnv,
       fetchImpl,
       sleepImpl: vi.fn(async () => {}),
       maxAttempts: 3,
       pollIntervalMs: 0,
     });
 
-    expect(result.project).toEqual({ id: "prj_greenatics_test", name: "greenatics-ops", created: true });
-    expect(result.deployment.origin).toBe("https://greenatics-ops-preview.vercel.app");
+    expect(result.mode).toBe("public-only");
+    expect(result.project).toEqual({ id: "prj_greenatics_test", name: "greenatics-public-preview", created: true });
+    expect(result.deployment.origin).toBe("https://greenatics-public-preview.vercel.app");
     expect(result.deployment.state).toBe("READY");
 
     for (const call of calls) {
-      expect(call.parsed.searchParams.get("teamId")).toBe(env.VERCEL_ORG_ID);
-      expect(call.authorization).toBe(`Bearer ${env.VERCEL_TOKEN}`);
+      expect(call.parsed.searchParams.get("teamId")).toBe(publicEnv.VERCEL_ORG_ID);
+      expect(call.authorization).toBe(`Bearer ${publicEnv.VERCEL_TOKEN}`);
     }
 
     const createProject = calls.find((call) => call.method === "POST" && call.parsed.pathname === "/v11/projects");
     expect(createProject.body).toMatchObject({
-      name: "greenatics-ops",
+      name: "greenatics-public-preview",
       framework: "nextjs",
       gitRepository: { type: "github", repo: "arendon7/GTCS-WEB" },
     });
 
     const envCall = calls.find((call) => call.parsed.pathname.endsWith("/env"));
     expect(envCall.parsed.searchParams.get("upsert")).toBe("true");
-    expect(envCall.body.map((item) => item.key)).toEqual([
-      "NEXT_PUBLIC_DATA_MODE",
-      "NEXT_PUBLIC_SUPABASE_URL",
-      "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
-      "SUPABASE_SECRET_KEY",
+    expect(envCall.body).toEqual([
+      expect.objectContaining({
+        key: "NEXT_PUBLIC_DATA_MODE",
+        value: "local",
+        type: "plain",
+        target: ["preview"],
+      }),
     ]);
-    expect(envCall.body.every((item) => JSON.stringify(item.target) === JSON.stringify(["preview"]))).toBe(true);
-    expect(envCall.body.find((item) => item.key === "SUPABASE_SECRET_KEY")?.type).toBe("sensitive");
 
     const deployCall = calls.find((call) => call.method === "POST" && call.parsed.pathname === "/v13/deployments");
     expect(deployCall.parsed.searchParams.get("forceNew")).toBe("1");
@@ -109,29 +146,58 @@ describe("Vercel hosted pilot preview deployment", () => {
       org: "arendon7",
       repo: "GTCS-WEB",
       ref: "develop",
-      sha: env.DEPLOY_GIT_SHA,
+      sha: publicEnv.DEPLOY_GIT_SHA,
     });
+    expect(deployCall.body.meta.greenaticsPilotMode).toBe("public-only");
   });
 
-  it("reuses an existing project and fails closed on a terminal deployment state", async () => {
+  it("injects Supabase secrets only into the dedicated full-ops Preview project", async () => {
+    const { calls, fetchImpl } = successfulFetch({
+      projectName: "greenatics-ops",
+      deploymentUrl: "greenatics-ops-preview.vercel.app",
+    });
+
+    const result = await runVercelPilotPreviewDeployment({
+      env: fullOpsEnv,
+      fetchImpl,
+      sleepImpl: vi.fn(async () => {}),
+      maxAttempts: 3,
+      pollIntervalMs: 0,
+    });
+
+    expect(result.mode).toBe("full-ops");
+    expect(result.project.name).toBe("greenatics-ops");
+    const envCall = calls.find((call) => call.parsed.pathname.endsWith("/env"));
+    expect(envCall.body.map((item) => item.key)).toEqual([
+      "NEXT_PUBLIC_DATA_MODE",
+      "NEXT_PUBLIC_SUPABASE_URL",
+      "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+      "SUPABASE_SECRET_KEY",
+    ]);
+    expect(envCall.body.every((item) => JSON.stringify(item.target) === JSON.stringify(["preview"]))).toBe(true);
+    expect(envCall.body.find((item) => item.key === "NEXT_PUBLIC_DATA_MODE")?.value).toBe("supabase");
+    expect(envCall.body.find((item) => item.key === "SUPABASE_SECRET_KEY")?.type).toBe("sensitive");
+  });
+
+  it("reuses the canonical project and fails closed on a terminal deployment state", async () => {
     const fetchImpl = vi.fn(async (url, init = {}) => {
       const parsed = new URL(url);
       const method = init.method || "GET";
-      if (method === "GET" && parsed.pathname === "/v9/projects/greenatics-ops") {
-        return jsonResponse({ id: "prj_greenatics_test", name: "greenatics-ops" });
+      if (method === "GET" && parsed.pathname === "/v9/projects/greenatics-public-preview") {
+        return jsonResponse({ id: "prj_greenatics_test", name: "greenatics-public-preview" });
       }
       if (method === "POST" && parsed.pathname.endsWith("/env")) return jsonResponse({ created: [] });
       if (method === "POST" && parsed.pathname === "/v13/deployments") {
-        return jsonResponse({ id: "dpl_greenatics_test", url: "greenatics-ops-preview.vercel.app", status: "QUEUED" });
+        return jsonResponse({ id: "dpl_greenatics_test", url: "greenatics-public-preview.vercel.app", status: "QUEUED" });
       }
       if (method === "GET" && parsed.pathname === "/v13/deployments/dpl_greenatics_test") {
-        return jsonResponse({ id: "dpl_greenatics_test", url: "greenatics-ops-preview.vercel.app", status: "ERROR" });
+        return jsonResponse({ id: "dpl_greenatics_test", url: "greenatics-public-preview.vercel.app", status: "ERROR" });
       }
       throw new Error(`Unexpected ${method} ${parsed.pathname}`);
     });
 
     await expect(runVercelPilotPreviewDeployment({
-      env,
+      env: publicEnv,
       fetchImpl,
       sleepImpl: vi.fn(async () => {}),
       maxAttempts: 2,
@@ -145,19 +211,20 @@ describe("Vercel hosted pilot preview deployment", () => {
     const fetchImpl = vi.fn(async () => jsonResponse({
       error: {
         code: "forbidden",
-        message: `credential=${env.VERCEL_TOKEN}`,
+        message: `credential=${fullOpsEnv.VERCEL_TOKEN}`,
       },
     }, 403));
 
     let thrown;
     try {
-      await runVercelPilotPreviewDeployment({ env, fetchImpl, maxAttempts: 1, pollIntervalMs: 0 });
+      await runVercelPilotPreviewDeployment({ env: fullOpsEnv, fetchImpl, maxAttempts: 1, pollIntervalMs: 0 });
     } catch (error) {
       thrown = error;
     }
 
     expect(thrown).toBeInstanceOf(VercelPilotError);
     expect(thrown.message).toContain("forbidden");
-    expect(thrown.message).not.toContain(env.VERCEL_TOKEN);
+    expect(thrown.message).not.toContain(fullOpsEnv.VERCEL_TOKEN);
+    expect(thrown.message).not.toContain(fullOpsEnv.SUPABASE_SECRET_KEY);
   });
 });


### PR DESCRIPTION
## Objetivo
Eliminar la contradicción entre el contrato de preview público y la automatización hospedada: QA público debe poder desplegarse sin Supabase y sin compartir el proyecto que contiene secretos de OPS.

## Diseño
- `public-only` (default) → proyecto canónico `greenatics-public-preview`.
  - solo `NEXT_PUBLIC_DATA_MODE=local` en Preview;
  - no exige ni inyecta secretos Supabase;
  - no ejecuta backend preflight;
  - exige `/api/health`: `local`, `configuration-block`, backend/admin `missing`;
  - exige `/app -> /login?reason=configuration&next=/app`.
- `full-ops` → proyecto canónico `greenatics-ops`.
  - exige Supabase URL/publishable/secret;
  - backend preflight obligatorio;
  - exige `supabase`, `supabase-auth` y checks remotos `ok`.

## Seguridad
- identidad de proyecto fijada por modo; un override cruzado falla cerrado;
- el preflight público falla si detecta configuración backend, aunque el runtime esté en `local`;
- secretos Supabase solo se entregan a pasos `full-ops` o como valores vacíos en el paso público;
- deployment sigue siendo Preview del SHA exacto de `develop`, nunca Production;
- errores remotos continúan sanitizados.

## Tests/documentación
- tests unitarios para ambos modos, aislamiento de proyecto, inyección de env, contaminación backend y redirects;
- workflow `workflow_dispatch` con selector de modo y `public-only` como default;
- Runbook, Preview Gate y Vercel Integration reconciliados con el contrato ejecutable.

## Fuera de alcance
- dominio productivo;
- convergencia `main`/`develop`;
- cambios a OPS, RLS, auth o Product Truth.