### PR TITLE
Public v0.18 · Governed legacy-site cutover

### DIFF
--- a/docs/deployment/LEGACY-PUBLIC-CUTOVER.md
+++ b/docs/deployment/LEGACY-PUBLIC-CUTOVER.md
@@ -10,7 +10,7 @@ Cada URL legado queda en una de tres categorías:
 
 - `redirect`: intención útil y compatible con una superficie gobernada nueva;
 - `quarantine`: contenido contaminado, inseguro o que no debe heredar autoridad mediante redirect;
-- `manual-review`: contenido que requiere revisión jurídica/editorial antes de volver a publicarse.
+- `manual-review`: contenido que requiere revisión jurídica/editorial o una decisión de producto antes de volver a publicarse.
 
 El registro ejecutable vive en `src/data/legacy-public-migration.ts`.
 
@@ -18,11 +18,13 @@ El registro ejecutable vive en `src/data/legacy-public-migration.ts`.
 | Legacy path | Destino | Motivo |
 | --- | --- | --- |
 | `/blog` | `/biblioteca` | Conserva la puerta de entrada al conocimiento sin clonar el archivo WordPress. |
+| `/store` | `/wondergreen` | Conserva descubrimiento de producto sin fingir que el nuevo sitio ya tiene checkout transaccional. |
 | `/el-potencial-de-la-ruta-selectiva-de-recoleccion-de-residuos` | `/soluciones/rutas-selectivas` | Conserva intención sobre rutas selectivas en la ficha de servicio gobernada. |
 | `/fertilizantes-que-nutren` | `/wondergreen` | Conserva intención sobre organominerales sin transportar claims históricos verbatim. |
 | `/impacto-y-resultados` | `/impacto` | Sustituye cifras históricas por el contrato de impacto conciliado/aprobado. |
 | `/winds-of-change-in-the-turbines-service-industries` | `/wondergreen` | El contenido indexado es agronómico/Wondergreen aunque el slug sea de una plantilla ajena. |
 | `/from-niche-to-100-gw-mainstream-and-beyond-world` | `/biblioteca` | Conserva tráfico de conocimiento sin mantener el slug de plantilla. |
+| `/a-decline-in-solar-growth-root-cause-of-analysis-records` | `/wondergreen` | El contenido indexado trata de validación agronómica, pero conserva un slug de plantilla y claims históricos no reconciliados; solo se preserva la intención de producto. |
 
 Next.js emite estos cambios como redirects permanentes. Se activan realmente cuando el dominio legado sea servido por el nuevo deployment o su capa de edge/proxy apunte a él.
 
@@ -34,17 +36,24 @@ Una URL en cuarentena permanece en 404 en `GTCS-WEB` hasta una decisión explíc
 ## Revisión manual obligatoria
 Por ahora no se redirigen automáticamente:
 
+### Legal
 - `/terminos-y-condiciones`
 - `/privacidad`
 - `/politicas`
 
 El nuevo sistema combina sitio público, agenda externa y GREENATICS OPS. Los textos legales deben corresponder a la operación y tratamiento de datos actuales; copiar textos históricos sin revisión generaría una representación jurídica potencialmente incorrecta.
 
-Cuando cada texto sea aprobado:
-1. crear su ruta pública gobernada;
-2. agregar metadata/canonical;
+### Comercio legado
+- `/my-account`
+- `/cart`
+
+El WordPress legado expone superficies WooCommerce, pero la nueva plataforma todavía no declara un storefront transaccional. No debemos convertir una cuenta WooCommerce antigua en login de GREENATICS OPS ni simular continuidad de carrito/checkout que no existe.
+
+Cuando una superficie `manual-review` sea aprobada:
+1. crear su ruta pública gobernada o definir explícitamente su retiro;
+2. agregar metadata/canonical cuando corresponda;
 3. añadirla a footer/sitemap si corresponde;
-4. cambiar su disposición en el registro a `redirect`;
+4. cambiar su disposición en el registro solo si existe un destino semánticamente correcto;
 5. actualizar los tests de migración.
 
 ## Claims históricos
@@ -55,6 +64,7 @@ No migrar directamente cifras o superlativos del WordPress legado. En especial:
 - equivalencias climáticas;
 - "única solución" u otros superlativos;
 - promesas agronómicas o de captura de carbono;
+- porcentajes de productividad o reducción de insumos;
 - afirmaciones de certificación/ensayos sin fuente vigente vinculada.
 
 La ruta `/impacto` es la autoridad para cifras publicables y el Product Master/Truth de Wondergreen es la autoridad para claims de producto.

--- a/docs/deployment/LEGACY-PUBLIC-CUTOVER.md
+++ b/docs/deployment/LEGACY-PUBLIC-CUTOVER.md
@@ -1,0 +1,79 @@
+# GREENATICS · Legacy Public Cutover
+
+## Objetivo
+Migrar la autoridad pública desde el WordPress indexado en `greenatics.org` hacia la nueva plataforma gobernada de `GTCS-WEB` sin copiar automáticamente contenido, claims, slugs de plantilla ni contaminación SEO del sitio legado.
+
+## Principio
+La indexación histórica no convierte un contenido en verdad vigente.
+
+Cada URL legado queda en una de tres categorías:
+
+- `redirect`: intención útil y compatible con una superficie gobernada nueva;
+- `quarantine`: contenido contaminado, inseguro o que no debe heredar autoridad mediante redirect;
+- `manual-review`: contenido que requiere revisión jurídica/editorial antes de volver a publicarse.
+
+El registro ejecutable vive en `src/data/legacy-public-migration.ts`.
+
+## Redirects aprobados
+| Legacy path | Destino | Motivo |
+| --- | --- | --- |
+| `/blog` | `/biblioteca` | Conserva la puerta de entrada al conocimiento sin clonar el archivo WordPress. |
+| `/el-potencial-de-la-ruta-selectiva-de-recoleccion-de-residuos` | `/soluciones/rutas-selectivas` | Conserva intención sobre rutas selectivas en la ficha de servicio gobernada. |
+| `/fertilizantes-que-nutren` | `/wondergreen` | Conserva intención sobre organominerales sin transportar claims históricos verbatim. |
+| `/impacto-y-resultados` | `/impacto` | Sustituye cifras históricas por el contrato de impacto conciliado/aprobado. |
+| `/winds-of-change-in-the-turbines-service-industries` | `/wondergreen` | El contenido indexado es agronómico/Wondergreen aunque el slug sea de una plantilla ajena. |
+| `/from-niche-to-100-gw-mainstream-and-beyond-world` | `/biblioteca` | Conserva tráfico de conocimiento sin mantener el slug de plantilla. |
+
+Next.js emite estos cambios como redirects permanentes. Se activan realmente cuando el dominio legado sea servido por el nuevo deployment o su capa de edge/proxy apunte a él.
+
+## Cuarentena
+`/cities-must-show-the-way-forward-on-renewable-energy` no se redirige. La versión indexada observada durante la auditoría contiene texto spam ajeno al contenido Greenatics. Debe retirarse/limpiarse en el WordPress legado y no heredar autoridad hacia una página nueva.
+
+Una URL en cuarentena permanece en 404 en `GTCS-WEB` hasta una decisión explícita. No crear un redirect genérico al HOME.
+
+## Revisión manual obligatoria
+Por ahora no se redirigen automáticamente:
+
+- `/terminos-y-condiciones`
+- `/privacidad`
+- `/politicas`
+
+El nuevo sistema combina sitio público, agenda externa y GREENATICS OPS. Los textos legales deben corresponder a la operación y tratamiento de datos actuales; copiar textos históricos sin revisión generaría una representación jurídica potencialmente incorrecta.
+
+Cuando cada texto sea aprobado:
+1. crear su ruta pública gobernada;
+2. agregar metadata/canonical;
+3. añadirla a footer/sitemap si corresponde;
+4. cambiar su disposición en el registro a `redirect`;
+5. actualizar los tests de migración.
+
+## Claims históricos
+No migrar directamente cifras o superlativos del WordPress legado. En especial:
+- capacidades estándar de planta;
+- producción anual/diaria;
+- biogás por día;
+- equivalencias climáticas;
+- "única solución" u otros superlativos;
+- promesas agronómicas o de captura de carbono;
+- afirmaciones de certificación/ensayos sin fuente vigente vinculada.
+
+La ruta `/impacto` es la autoridad para cifras publicables y el Product Master/Truth de Wondergreen es la autoridad para claims de producto.
+
+## Gate antes del corte de dominio
+1. Preview `public-only` certificado para el SHA exacto.
+2. Navegación pública y SEO base en PASS.
+3. Redirects del registro ejecutable verificados en navegador.
+4. Slug en cuarentena devuelve 404 en la nueva plataforma.
+5. WordPress legado respaldado antes de modificarlo.
+6. Contenido spam retirado del WordPress y cachés/CDN.
+7. Sitemap legado retirado o reemplazado en el momento del corte.
+8. `greenatics.org` redirige hacia `greenatics.com.co` conservando paths aprobados.
+9. Search Console se actualiza solo después de confirmar 200/redirects/canonicals del dominio definitivo.
+10. No cambiar DNS de producción como mecanismo de prueba.
+
+## Después del corte
+- observar 404 de tráfico legado y añadir redirects solo cuando exista un destino semánticamente correcto;
+- no usar redirects masivos al HOME;
+- revisar indexación de `greenatics.org` hasta que caiga el contenido viejo;
+- mantener `greenatics.com.co` como canonical único en la nueva plataforma;
+- retirar definitivamente la superficie WordPress cuando la transición esté estabilizada.

--- a/docs/deployment/PREVIEW-GATE.md
+++ b/docs/deployment/PREVIEW-GATE.md
@@ -10,6 +10,7 @@ Definir el mínimo verificable antes de asociar `greenatics.com.co` a un deploym
 - Un deployment sin Supabase puede servir la web pública, pero debe bloquear las rutas OPS y llevarlas a `/login?reason=configuration`.
 - `robots.txt` y `X-Robots-Tag` complementan la seguridad; no sustituyen autenticación.
 - `/api/health` expone provenance mínima para comprobar que el preview corresponde al branch/SHA esperado.
+- `greenatics.org` conserva contenido legado indexado; su migración se gobierna mediante `src/data/legacy-public-migration.ts` y `docs/deployment/LEGACY-PUBLIC-CUTOVER.md`.
 
 ## Dos previews, dos fronteras
 El workflow manual `hosted-pilot-preview` ofrece dos modos explícitos y no comparte el mismo proyecto Vercel entre ellos:
@@ -51,6 +52,9 @@ Nunca exponer `SUPABASE_SECRET_KEY` ni ninguna credencial administrativa mediant
 9. `full-ops`: usuario sin sesión va a login; usuario válido necesita perfil activo y membresía activa de planta.
 10. Un usuario autorizado entra a `/app`; RLS conserva aislamiento por planta/rol.
 11. Salir de OPS hacia la web pública y entrar desde la web pública a OPS cruza una frontera documental, no depende de preservar el árbol de providers del cliente.
+12. Las URLs legado marcadas `redirect` aterrizan únicamente en superficies públicas gobernadas.
+13. Las URLs `quarantine` no redirigen y devuelven 404 hasta una decisión explícita.
+14. Las rutas legales `manual-review` no se publican ni redirigen automáticamente.
 
 ## Ejecución reproducible
 Desde GitHub Actions, ejecutar `hosted-pilot-preview` y elegir el modo. `public-only` es la opción segura inicial para QA visual y editorial. `full-ops` se usa únicamente cuando el backend piloto esté listo y sus secretos existan en GitHub Actions.
@@ -71,12 +75,16 @@ Cambiar a `--mode full-ops` únicamente para el proyecto OPS completo.
 - Revisar build logs sin errores.
 - Revisar runtime errors del preview.
 - Probar desktop y móvil.
-- No asociar el dominio si existen 5xx inesperados, bucles de redirect, datos OPS visibles sin sesión, provenance incorrecta o headers internos ausentes.
+- Probar redirects legado representativos y una URL en cuarentena.
+- No asociar el dominio si existen 5xx inesperados, bucles de redirect, datos OPS visibles sin sesión, provenance incorrecta, headers internos ausentes o redirects legado hacia destinos no gobernados.
 
 ## Dominio
 `greenatics.com.co` se asocia únicamente después de aprobar el preview. El cambio de DNS/dominio no debe utilizarse como mecanismo de prueba.
 
+`greenatics.org` no debe apagarse ni apuntarse al nuevo deployment hasta que el inventario legado, la limpieza del WordPress y los redirects hayan aprobado el gate de `LEGACY-PUBLIC-CUTOVER.md`.
+
 ## Después del dominio
 - Verificar canonical, sitemap y robots en el hostname definitivo.
 - Verificar login/redirects desde el dominio definitivo.
+- Verificar que `greenatics.org` entregue redirects coherentes hacia `greenatics.com.co` sin cadenas ni bucles.
 - Revisar Search Console/analítica solo cuando la capa pública esté estable.

--- a/e2e/legacy-public-cutover.spec.ts
+++ b/e2e/legacy-public-cutover.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+test("legacy knowledge and impact paths land on governed public surfaces", async ({ page }) => {
+  await page.goto("/blog");
+  await expect(page).toHaveURL(/\/biblioteca$/);
+  await expect(page.getByRole("heading", { name: /La biblioteca no es un archivo/i })).toBeVisible();
+
+  await page.goto("/impacto-y-resultados");
+  await expect(page).toHaveURL(/\/impacto$/);
+  await expect(page.getByRole("heading", { name: /No basta con decir que aprovechamos residuos/i })).toBeVisible();
+});
+
+test("legacy selective collection article preserves intent through the service route", async ({ page }) => {
+  await page.goto("/el-potencial-de-la-ruta-selectiva-de-recoleccion-de-residuos");
+  await expect(page).toHaveURL(/\/soluciones\/rutas-selectivas$/);
+  await expect(page.getByRole("heading", { name: /Diseño e implementación de rutas selectivas/i })).toBeVisible();
+});
+
+test("legacy organomineral articles land on Wondergreen without preserving old claims", async ({ page }) => {
+  for (const path of [
+    "/fertilizantes-que-nutren",
+    "/winds-of-change-in-the-turbines-service-industries",
+  ]) {
+    await page.goto(path);
+    await expect(page).toHaveURL(/\/wondergreen$/);
+    await expect(page.getByRole("heading", { name: /Más que NPK/i })).toBeVisible();
+  }
+});
+
+test("spam-contaminated legacy slug remains quarantined", async ({ page }) => {
+  const response = await page.goto("/cities-must-show-the-way-forward-on-renewable-energy");
+  expect(response?.status()).toBe(404);
+  await expect(page.getByRole("heading", { name: "Esta ruta no existe o cambió." })).toBeVisible();
+});

--- a/e2e/legacy-public-cutover.spec.ts
+++ b/e2e/legacy-public-cutover.spec.ts
@@ -25,7 +25,7 @@ test("legacy product discovery lands on Wondergreen without preserving old claim
   ]) {
     await page.goto(path);
     await expect(page).toHaveURL(/\/wondergreen$/);
-    await expect(page.getByRole("heading", { name: /Más que NPK/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Nutrición que vuelve a la tierra/i })).toBeVisible();
   }
 });
 

--- a/e2e/legacy-public-cutover.spec.ts
+++ b/e2e/legacy-public-cutover.spec.ts
@@ -16,10 +16,12 @@ test("legacy selective collection article preserves intent through the service r
   await expect(page.getByRole("heading", { name: /Diseño e implementación de rutas selectivas/i })).toBeVisible();
 });
 
-test("legacy organomineral articles land on Wondergreen without preserving old claims", async ({ page }) => {
+test("legacy product discovery lands on Wondergreen without preserving old claims", async ({ page }) => {
   for (const path of [
+    "/store",
     "/fertilizantes-que-nutren",
     "/winds-of-change-in-the-turbines-service-industries",
+    "/a-decline-in-solar-growth-root-cause-of-analysis-records",
   ]) {
     await page.goto(path);
     await expect(page).toHaveURL(/\/wondergreen$/);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,14 @@
 import type { NextConfig } from "next";
+import { legacyPublicRedirects } from "./src/data/legacy-public-migration";
 import { deploymentHeadersConfig } from "./src/lib/http-security";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   async headers() {
     return deploymentHeadersConfig();
+  },
+  async redirects() {
+    return [...legacyPublicRedirects];
   },
 };
 

--- a/src/data/legacy-public-migration.test.ts
+++ b/src/data/legacy-public-migration.test.ts
@@ -49,6 +49,25 @@ describe("legacy public migration registry", () => {
     expect(publicStaticRoutes).toContain("/impacto");
   });
 
+  it("preserves legacy store discovery without recreating WooCommerce checkout semantics", () => {
+    expect(legacyPublicRedirects).toContainEqual({
+      source: "/store",
+      destination: "/wondergreen",
+      permanent: true,
+    });
+    for (const source of ["/my-account", "/cart"]) {
+      expect(legacyPublicRoutes.find((route) => route.source === source)?.disposition).toBe("manual-review");
+    }
+  });
+
+  it("routes the stale field-validation template slug to Wondergreen without carrying claims forward", () => {
+    expect(legacyPublicRedirects).toContainEqual({
+      source: "/a-decline-in-solar-growth-root-cause-of-analysis-records",
+      destination: "/wondergreen",
+      permanent: true,
+    });
+  });
+
   it("requires legal legacy surfaces to stay under manual review", () => {
     for (const source of ["/terminos-y-condiciones", "/privacidad", "/politicas"]) {
       expect(legacyPublicRoutes.find((route) => route.source === source)?.disposition).toBe("manual-review");

--- a/src/data/legacy-public-migration.test.ts
+++ b/src/data/legacy-public-migration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { internalRoutePrefixes, publicStaticRoutes } from "./public-site";
+import { legacyPublicRedirects, legacyPublicRoutes } from "./legacy-public-migration";
+
+function isInternal(path: string) {
+  return internalRoutePrefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
+}
+
+describe("legacy public migration registry", () => {
+  it("keeps legacy sources unique and path-only", () => {
+    const sources = legacyPublicRoutes.map((route) => route.source);
+    expect(new Set(sources).size).toBe(sources.length);
+    for (const source of sources) {
+      expect(source).toMatch(/^\/[a-z0-9-]+$/);
+      expect(source.endsWith("/")).toBe(false);
+    }
+  });
+
+  it("only emits permanent redirects toward public routes", () => {
+    expect(legacyPublicRedirects.length).toBeGreaterThan(0);
+    for (const redirect of legacyPublicRedirects) {
+      expect(redirect.permanent).toBe(true);
+      expect(redirect.destination.startsWith("/")).toBe(true);
+      expect(isInternal(redirect.destination)).toBe(false);
+      expect(redirect.destination).not.toBe(redirect.source);
+    }
+  });
+
+  it("never emits quarantined or manual-review routes as redirects", () => {
+    const emittedSources = new Set(legacyPublicRedirects.map((route) => route.source));
+    for (const route of legacyPublicRoutes.filter((item) => item.disposition !== "redirect")) {
+      expect(emittedSources.has(route.source)).toBe(false);
+      expect(route.destination).toBeUndefined();
+    }
+  });
+
+  it("quarantines the indexed spam-contaminated template slug", () => {
+    const route = legacyPublicRoutes.find((item) => item.source === "/cities-must-show-the-way-forward-on-renewable-energy");
+    expect(route?.disposition).toBe("quarantine");
+    expect(route?.destination).toBeUndefined();
+  });
+
+  it("routes historical impact traffic to the governed impact surface", () => {
+    expect(legacyPublicRedirects).toContainEqual({
+      source: "/impacto-y-resultados",
+      destination: "/impacto",
+      permanent: true,
+    });
+    expect(publicStaticRoutes).toContain("/impacto");
+  });
+
+  it("requires legal legacy surfaces to stay under manual review", () => {
+    for (const source of ["/terminos-y-condiciones", "/privacidad", "/politicas"]) {
+      expect(legacyPublicRoutes.find((route) => route.source === source)?.disposition).toBe("manual-review");
+    }
+  });
+});

--- a/src/data/legacy-public-migration.ts
+++ b/src/data/legacy-public-migration.ts
@@ -23,6 +23,12 @@ export const legacyPublicRoutes: readonly LegacyPublicRoute[] = [
     reason: "Preserve the knowledge entry point without cloning the legacy WordPress archive.",
   },
   {
+    source: "/store",
+    disposition: "redirect",
+    destination: "/wondergreen",
+    reason: "Preserve product-discovery intent while the new platform has no transactional storefront enabled.",
+  },
+  {
     source: "/el-potencial-de-la-ruta-selectiva-de-recoleccion-de-residuos",
     disposition: "redirect",
     destination: "/soluciones/rutas-selectivas",
@@ -53,6 +59,12 @@ export const legacyPublicRoutes: readonly LegacyPublicRoute[] = [
     reason: "Retain generic environmental-knowledge traffic without preserving the stale template slug.",
   },
   {
+    source: "/a-decline-in-solar-growth-root-cause-of-analysis-records",
+    disposition: "redirect",
+    destination: "/wondergreen",
+    reason: "The legacy slug is unrelated template text, while the indexed article concerns Wondergreen field validation; preserve only product-discovery intent, not its historical agronomic claims.",
+  },
+  {
     source: "/cities-must-show-the-way-forward-on-renewable-energy",
     disposition: "quarantine",
     reason: "Indexed legacy page contains unrelated spam text and must not inherit authority through a redirect.",
@@ -71,6 +83,16 @@ export const legacyPublicRoutes: readonly LegacyPublicRoute[] = [
     source: "/politicas",
     disposition: "manual-review",
     reason: "Legacy policy content must be reviewed rather than copied automatically.",
+  },
+  {
+    source: "/my-account",
+    disposition: "manual-review",
+    reason: "Legacy WooCommerce account traffic must not be confused with GREENATICS OPS authentication or recreated without a commerce decision.",
+  },
+  {
+    source: "/cart",
+    disposition: "manual-review",
+    reason: "The new public platform has no transactional cart enabled; preserve no checkout semantics until commerce is intentionally reintroduced.",
   },
 ] as const;
 

--- a/src/data/legacy-public-migration.ts
+++ b/src/data/legacy-public-migration.ts
@@ -1,0 +1,85 @@
+export type LegacyRouteDisposition = "redirect" | "quarantine" | "manual-review";
+
+export type LegacyPublicRoute = {
+  source: string;
+  disposition: LegacyRouteDisposition;
+  destination?: string;
+  reason: string;
+};
+
+/**
+ * Governed migration registry for paths observed on the indexed greenatics.org
+ * WordPress site before the new public platform cutover.
+ *
+ * Only `redirect` entries become runtime redirects. `quarantine` and
+ * `manual-review` entries are deliberately excluded so that stale, compromised
+ * or unreconciled content cannot leak into the new public contract.
+ */
+export const legacyPublicRoutes: readonly LegacyPublicRoute[] = [
+  {
+    source: "/blog",
+    disposition: "redirect",
+    destination: "/biblioteca",
+    reason: "Preserve the knowledge entry point without cloning the legacy WordPress archive.",
+  },
+  {
+    source: "/el-potencial-de-la-ruta-selectiva-de-recoleccion-de-residuos",
+    disposition: "redirect",
+    destination: "/soluciones/rutas-selectivas",
+    reason: "Preserve search intent around selective collection using the governed service page.",
+  },
+  {
+    source: "/fertilizantes-que-nutren",
+    disposition: "redirect",
+    destination: "/wondergreen",
+    reason: "Preserve organomineral-fertilizer intent without carrying legacy claims forward verbatim.",
+  },
+  {
+    source: "/impacto-y-resultados",
+    disposition: "redirect",
+    destination: "/impacto",
+    reason: "Replace historical impact claims with the governed public-impact contract.",
+  },
+  {
+    source: "/winds-of-change-in-the-turbines-service-industries",
+    disposition: "redirect",
+    destination: "/wondergreen",
+    reason: "The indexed content is about Greenatics/Wondergreen despite a stale template slug.",
+  },
+  {
+    source: "/from-niche-to-100-gw-mainstream-and-beyond-world",
+    disposition: "redirect",
+    destination: "/biblioteca",
+    reason: "Retain generic environmental-knowledge traffic without preserving the stale template slug.",
+  },
+  {
+    source: "/cities-must-show-the-way-forward-on-renewable-energy",
+    disposition: "quarantine",
+    reason: "Indexed legacy page contains unrelated spam text and must not inherit authority through a redirect.",
+  },
+  {
+    source: "/terminos-y-condiciones",
+    disposition: "manual-review",
+    reason: "Legal terms require current legal review before publication on the new platform.",
+  },
+  {
+    source: "/privacidad",
+    disposition: "manual-review",
+    reason: "Privacy content must be reconciled with the new platform, booking flow and OPS boundary before publication.",
+  },
+  {
+    source: "/politicas",
+    disposition: "manual-review",
+    reason: "Legacy policy content must be reviewed rather than copied automatically.",
+  },
+] as const;
+
+export const legacyPublicRedirects = legacyPublicRoutes
+  .filter((route): route is LegacyPublicRoute & { disposition: "redirect"; destination: string } =>
+    route.disposition === "redirect" && typeof route.destination === "string",
+  )
+  .map(({ source, destination }) => ({ source, destination, permanent: true })) as readonly {
+    source: string;
+    destination: string;
+    permanent: true;
+  }[];


### PR DESCRIPTION
## Objetivo
Preparar el corte seguro desde el WordPress indexado en `greenatics.org` hacia la nueva plataforma sin copiar automáticamente slugs de plantilla, claims históricos ni contenido contaminado.

## Auditoría externa
El sitio legado aún aparece indexado con contenido útil (rutas selectivas, Wondergreen, impacto, blog), pero también con slugs de plantilla incoherentes y al menos una URL indexada que contiene spam ajeno.

## Implementación
- añade `src/data/legacy-public-migration.ts` como registro canónico de disposiciones `redirect`, `quarantine` y `manual-review`;
- `next.config.ts` solo materializa como redirects permanentes las entradas aprobadas;
- preserva intención útil hacia `/biblioteca`, `/wondergreen`, `/impacto` y `/soluciones/rutas-selectivas`;
- deja el slug contaminado en cuarentena, sin heredar autoridad mediante redirect;
- mantiene términos/privacidad/políticas fuera de redirects hasta revisión jurídica actual;
- añade unit gates para unicidad, destinos públicos, cuarentena y legal review;
- añade Playwright para redirects representativos y 404 de la URL en cuarentena;
- añade runbook de cutover y extiende Preview Gate.

## Truth / claim lock
La migración no transporta cifras históricas de capacidad, producción, biogás, clima, certificaciones ni superlativos. `/impacto` y Product Truth continúan siendo las superficies gobernadas.

## Fuera de alcance
- modificar o apagar el WordPress legado;
- DNS o dominios productivos;
- publicar textos legales sin revisión;
- migrar automáticamente artículos del blog.