### PR TITLE
Public v0.19 · Runtime image polish

### DIFF
--- a/e2e/public-runtime-image-warnings.spec.ts
+++ b/e2e/public-runtime-image-warnings.spec.ts
@@ -10,7 +10,7 @@ test("Wondergreen hero logo is served through Next image optimization", async ({
   await expect(logo).toHaveAttribute("srcset", /\/_next\/image\?url=%2Fbrand%2Fwondergreen-nutrients\.webp/);
 });
 
-test("404 brand symbol keeps its intrinsic ratio without Next image warnings", async ({ page }) => {
+test("404 brand symbol keeps its canonical ratio without Next image warnings", async ({ page }) => {
   const imageWarnings: string[] = [];
   page.on("console", (message) => {
     if (message.type() === "warning" && message.text().includes("Image with src")) {
@@ -24,13 +24,13 @@ test("404 brand symbol keeps its intrinsic ratio without Next image warnings", a
   const symbol = page.locator('img[src*="greenatics-symbol.svg"]');
   await expect(symbol).toBeVisible();
   await expect(symbol).toHaveAttribute("width", "80");
-  await expect(symbol).toHaveAttribute("height", "80");
+  await expect(symbol).toHaveAttribute("height", "52");
 
   const rendered = await symbol.evaluate((image) => ({
     width: (image as HTMLImageElement).getBoundingClientRect().width,
     height: (image as HTMLImageElement).getBoundingClientRect().height,
   }));
   expect(Math.round(rendered.width)).toBe(80);
-  expect(Math.round(rendered.height)).toBe(80);
+  expect(Math.round(rendered.height)).toBe(52);
   expect(imageWarnings).toEqual([]);
 });

--- a/e2e/public-runtime-image-warnings.spec.ts
+++ b/e2e/public-runtime-image-warnings.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+test("Wondergreen hero logo is served through Next image optimization", async ({ page }) => {
+  await page.goto("/wondergreen");
+
+  const logo = page.getByRole("img", { name: "Wondergreen Nutrients" });
+  await expect(logo).toBeVisible();
+  await expect(logo).toHaveAttribute("width", "420");
+  await expect(logo).toHaveAttribute("height", "221");
+  await expect(logo).toHaveAttribute("srcset", /\/_next\/image\?url=%2Fbrand%2Fwondergreen-nutrients\.webp/);
+});
+
+test("404 brand symbol keeps its intrinsic ratio without Next image warnings", async ({ page }) => {
+  const imageWarnings: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "warning" && message.text().includes("Image with src")) {
+      imageWarnings.push(message.text());
+    }
+  });
+
+  const response = await page.goto("/ruta-publica-que-no-existe-runtime-gate");
+  expect(response?.status()).toBe(404);
+
+  const symbol = page.locator('img[src*="greenatics-symbol.svg"]');
+  await expect(symbol).toBeVisible();
+  await expect(symbol).toHaveAttribute("width", "80");
+  await expect(symbol).toHaveAttribute("height", "80");
+
+  const rendered = await symbol.evaluate((image) => ({
+    width: (image as HTMLImageElement).getBoundingClientRect().width,
+    height: (image as HTMLImageElement).getBoundingClientRect().height,
+  }));
+  expect(Math.round(rendered.width)).toBe(80);
+  expect(Math.round(rendered.height)).toBe(80);
+  expect(imageWarnings).toEqual([]);
+});

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,7 +5,7 @@ export default function NotFound() {
   return (
     <main className="mx-auto grid min-h-[70vh] w-full max-w-3xl place-items-center px-5 py-20 text-center">
       <section>
-        <Image className="mx-auto mb-6 h-auto w-20" src="/brand/greenatics-symbol.svg" alt="" aria-hidden="true" width={80} height={80} />
+        <Image className="mx-auto mb-6" src="/brand/greenatics-symbol.svg" alt="" aria-hidden="true" width={80} height={80} />
         <p className="eyebrow">404 · Greenatics</p>
         <h1 className="mt-3 text-4xl font-bold tracking-tight text-[var(--ink)] sm:text-5xl">Esta ruta no existe o cambió.</h1>
         <p className="lede mx-auto mt-5 max-w-2xl">Puedes volver al sitio público, explorar Wondergreen o regresar a GREENATICS OPS.</p>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,7 +5,7 @@ export default function NotFound() {
   return (
     <main className="mx-auto grid min-h-[70vh] w-full max-w-3xl place-items-center px-5 py-20 text-center">
       <section>
-        <Image className="mx-auto mb-6" src="/brand/greenatics-symbol.svg" alt="" aria-hidden="true" width={80} height={80} />
+        <Image className="mx-auto mb-6" src="/brand/greenatics-symbol.svg" alt="" aria-hidden="true" width={80} height={52} />
         <p className="eyebrow">404 · Greenatics</p>
         <h1 className="mt-3 text-4xl font-bold tracking-tight text-[var(--ink)] sm:text-5xl">Esta ruta no existe o cambió.</h1>
         <p className="lede mx-auto mt-5 max-w-2xl">Puedes volver al sitio público, explorar Wondergreen o regresar a GREENATICS OPS.</p>

--- a/src/app/wondergreen/page.tsx
+++ b/src/app/wondergreen/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import { bioinputReferences, compostReferences, liquidFertilizers, solidFertilizers } from "@/data/wondergreen-public";
 import { wondergreenCrops } from "@/data/wondergreen-crops";
@@ -74,7 +75,15 @@ export default function WondergreenPage() {
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div className={styles.heroCopy}>
               <span className={styles.eyebrow}>Una marca Greenatics · Producto agrícola</span>
-              <img className={styles.wgLogo} src="/brand/wondergreen-nutrients.webp" alt="Wondergreen Nutrients" width="420" height="221" />
+              <Image
+                className={styles.wgLogo}
+                src="/brand/wondergreen-nutrients.webp"
+                alt="Wondergreen Nutrients"
+                width={420}
+                height={221}
+                sizes="(max-width: 720px) 78vw, 420px"
+                priority
+              />
               <h1>Nutrición que vuelve a la tierra.</h1>
               <p className={styles.lead}>
                 Wondergreen reúne suelo, nutrición, biología y conocimiento para acompañar cada cultivo según su etapa, condición y objetivo. La ruta empieza por entender el caso, no por empujar una referencia.


### PR DESCRIPTION
## Objetivo
Cerrar las dos advertencias públicas reales observadas durante la certificación de v0.18, sin abrir cambios editoriales ni de producto.

## Cambios
- migra el logo hero de Wondergreen a `next/image` con dimensiones, `sizes` y prioridad explícitos;
- corrige el símbolo del 404 al ratio canónico del SVG maestro (`468.2 × 302.624`), representado como `80 × 52` en esta superficie;
- añade Playwright para comprobar que Wondergreen usa el optimizador de Next y que el 404 conserva el ratio real sin warnings de `next/image`.

## Hallazgo de runtime
El gate inicial demostró que `80 × 80` era una declaración incorrecta: el navegador renderizaba aproximadamente `80 × 52`, coherente con el `viewBox` del maestro. Se corrigió el componente y se mantuvo el detector de warnings.

## Alcance excluido
- contenido/claims Wondergreen;
- Product Truth;
- OPS/auth/Supabase;
- redirects v0.18;
- dominio/deploy productivo.