### PR TITLE
Public v0.20 · Canonical SEO contract

### DIFF
--- a/e2e/public-seo-contract.spec.ts
+++ b/e2e/public-seo-contract.spec.ts
@@ -31,7 +31,8 @@ for (const route of publicRoutes) {
 
     const canonical = page.locator('link[rel="canonical"]');
     await expect(canonical).toHaveCount(1);
-    await expect(canonical).toHaveAttribute("href", `${canonicalOrigin}${route === "/" ? "/" : route}`);
+    const expectedCanonical = route === "/" ? canonicalOrigin : `${canonicalOrigin}${route}`;
+    await expect(canonical).toHaveAttribute("href", expectedCanonical);
   });
 }
 

--- a/e2e/public-seo-contract.spec.ts
+++ b/e2e/public-seo-contract.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+const canonicalOrigin = "https://greenatics.com.co";
+
+const publicRoutes = [
+  "/",
+  "/soluciones",
+  "/soluciones/diagnostico-caracterizacion",
+  "/wondergreen",
+  "/wondergreen/cultivos",
+  "/wondergreen/cultivos/cafe",
+  "/proyectos",
+  "/proyectos/yarumal",
+  "/impacto",
+  "/biblioteca",
+  "/biblioteca/guia-deficiencias",
+  "/nosotros",
+  "/contacto",
+] as const;
+
+for (const route of publicRoutes) {
+  test(`public SEO contract: ${route}`, async ({ page }) => {
+    await page.goto(route);
+
+    await expect(page).toHaveTitle(/.+/);
+    expect(await page.title()).not.toContain("GREENATICS OPS");
+
+    const description = page.locator('meta[name="description"]');
+    await expect(description).toHaveCount(1);
+    expect((await description.getAttribute("content"))?.trim().length ?? 0).toBeGreaterThan(20);
+
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    await expect(canonical).toHaveAttribute("href", `${canonicalOrigin}${route === "/" ? "/" : route}`);
+  });
+}
+
+test("crop canonicals remain specific and do not collapse to the crop index", async ({ page }) => {
+  await page.goto("/wondergreen/cultivos/cafe");
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    `${canonicalOrigin}/wondergreen/cultivos/cafe`,
+  );
+});

--- a/src/app/biblioteca/guia-deficiencias/layout.tsx
+++ b/src/app/biblioteca/guia-deficiencias/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/biblioteca/guia-deficiencias" },
+};
+
+export default function DeficiencyGuideLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/biblioteca/layout.tsx
+++ b/src/app/biblioteca/layout.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/biblioteca" },
+};
 
 export default function KnowledgeLayout({ children }: { children: React.ReactNode }) {
   return <PublicShell>{children}</PublicShell>;

--- a/src/app/contacto/layout.tsx
+++ b/src/app/contacto/layout.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/contacto" },
+};
 
 export default function ContactLayout({ children }: { children: React.ReactNode }) {
   return <PublicShell>{children}</PublicShell>;

--- a/src/app/impacto/layout.tsx
+++ b/src/app/impacto/layout.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/impacto" },
+};
 
 export default function ImpactLayout({ children }: { children: React.ReactNode }) {
   return <PublicShell>{children}</PublicShell>;

--- a/src/app/nosotros/layout.tsx
+++ b/src/app/nosotros/layout.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/nosotros" },
+};
 
 export default function CompanyLayout({ children }: { children: React.ReactNode }) {
   return <PublicShell>{children}</PublicShell>;

--- a/src/app/wondergreen/cultivos/[slug]/layout.tsx
+++ b/src/app/wondergreen/cultivos/[slug]/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { getWondergreenCrop } from "@/data/wondergreen-crops";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Pick<Props, "params">): Promise<Metadata> {
+  const { slug } = await params;
+  const crop = getWondergreenCrop(slug);
+  if (!crop) return {};
+  return {
+    alternates: { canonical: `/wondergreen/cultivos/${crop.slug}` },
+  };
+}
+
+export default function WondergreenCropLayout({ children }: Props) {
+  return children;
+}

--- a/src/app/wondergreen/cultivos/layout.tsx
+++ b/src/app/wondergreen/cultivos/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/wondergreen/cultivos" },
+};
+
+export default function WondergreenCropsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
## Sustituido por una reconstrucción limpia sobre `develop`

Este PR quedó verde en CI, pero mientras corría `develop` avanzó con PR #98 (provisionamiento Vercel). GitHub recalculó #97 como no mergeable por drift de base.

El mismo contrato SEO fue reconstruido sin cambios funcionales sobre el `develop` nuevo en `feat/public-seo-contract-v020-r2`, incorporando #98 por herencia y evitando forzar refs o historial.

No se perdió ningún cambio de este PR; queda cerrado como superseded.