### PR TITLE
Fix · decouple Vercel project provisioning from Git integration

### DIFF
--- a/scripts/vercel-pilot-deploy-lib.mjs
+++ b/scripts/vercel-pilot-deploy-lib.mjs
@@ -163,15 +163,14 @@ export async function ensureVercelPilotProject(config, { fetchImpl = fetch } = {
   });
   if (existing) return Object.freeze({ ...validateProject(existing, config.projectName), created: false });
 
+  // Keep project provisioning independent from Git-provider installation state.
+  // The project API only requires a name; Git provenance is supplied explicitly
+  // on the deployment request below using the exact branch + SHA.
   const created = await vercelRequest(config, fetchImpl, "/v11/projects", {
     method: "POST",
     body: {
       name: config.projectName,
       framework: "nextjs",
-      gitRepository: {
-        type: "github",
-        repo: config.repository.fullName,
-      },
     },
   });
   return Object.freeze({ ...validateProject(created, config.projectName), created: true });

--- a/scripts/vercel-pilot-deploy.test.mjs
+++ b/scripts/vercel-pilot-deploy.test.mjs
@@ -96,7 +96,7 @@ describe("Vercel hosted pilot preview deployment", () => {
     expect(config.supabaseSecretKey).toBe(fullOpsEnv.SUPABASE_SECRET_KEY);
   });
 
-  it("creates an isolated public project, injects only local mode and deploys the exact SHA", async () => {
+  it("creates an isolated public project without coupling provisioning to Git integration", async () => {
     const { calls, fetchImpl } = successfulFetch({
       projectName: "greenatics-public-preview",
       deploymentUrl: "greenatics-public-preview.vercel.app",
@@ -121,11 +121,11 @@ describe("Vercel hosted pilot preview deployment", () => {
     }
 
     const createProject = calls.find((call) => call.method === "POST" && call.parsed.pathname === "/v11/projects");
-    expect(createProject.body).toMatchObject({
+    expect(createProject.body).toEqual({
       name: "greenatics-public-preview",
       framework: "nextjs",
-      gitRepository: { type: "github", repo: "arendon7/GTCS-WEB" },
     });
+    expect(createProject.body).not.toHaveProperty("gitRepository");
 
     const envCall = calls.find((call) => call.parsed.pathname.endsWith("/env"));
     expect(envCall.parsed.searchParams.get("upsert")).toBe("true");


### PR DESCRIPTION
## Causa
El run full-ops #4 certificó Supabase (`0026`, RLS 30/30, TAM/YAR, director vacío) pero Vercel rechazó `POST /v11/projects` con `bad_request` al incluir `gitRepository` durante la creación.

La API actual de Vercel solo requiere `name`; la asociación Git es opcional y puede depender del estado de instalación del proveedor.

## Cambio
- Crea/reutiliza el proyecto Vercel con contrato mínimo: `name + framework`.
- Mantiene la procedencia Git en el deployment posterior (`gitSource` con owner/repo/ref/SHA exactos).
- Añade prueba que prohíbe volver a acoplar `gitRepository` a la provisión.
- No cambia secrets, Supabase, producción ni el dispatcher de `main`.

## Gate
Merge solo con quality + database verdes. Después se reintenta el job full-ops #4.