### PR TITLE
Public v0.20 · Canonical SEO contract · R2

### DIFF
--- a/e2e/public-seo-contract.spec.ts
+++ b/e2e/public-seo-contract.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+const canonicalOrigin = "https://greenatics.com.co";
+
+const publicRoutes = [
+  "/",
+  "/soluciones",
+  "/soluciones/diagnostico-caracterizacion",
+  "/wondergreen",
+  "/wondergreen/cultivos",
+  "/wondergreen/cultivos/cafe",
+  "/proyectos",
+  "/proyectos/yarumal",
+  "/impacto",
+  "/biblioteca",
+  "/biblioteca/guia-deficiencias",
+  "/nosotros",
+  "/contacto",
+] as const;
+
+for (const route of publicRoutes) {
+  test(`public SEO contract: ${route}`, async ({ page }) => {
+    await page.goto(route);
+
+    await expect(page).toHaveTitle(/.+/);
+    expect(await page.title()).not.toContain("GREENATICS OPS");
+
+    const description = page.locator('meta[name="description"]');
+    await expect(description).toHaveCount(1);
+    expect((await description.getAttribute("content"))?.trim().length ?? 0).toBeGreaterThan(20);
+
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    const expectedCanonical = route === "/" ? canonicalOrigin : `${canonicalOrigin}${route}`;
+    await expect(canonical).toHaveAttribute("href", expectedCanonical);
+  });
+}
+
+test("crop canonicals remain specific and do not collapse to the crop index", async ({ page }) => {
+  await page.goto("/wondergreen/cultivos/cafe");
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    `${canonicalOrigin}/wondergreen/cultivos/cafe`,
+  );
+});

--- a/src/app/biblioteca/guia-deficiencias/layout.tsx
+++ b/src/app/biblioteca/guia-deficiencias/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/biblioteca/guia-deficiencias" },
+};
+
+export default function DeficiencyGuideLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/biblioteca/layout.tsx
+++ b/src/app/biblioteca/layout.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/biblioteca" },
+};
 
 export default function KnowledgeLayout({ children }: { children: React.ReactNode }) {
   return <PublicShell>{children}</PublicShell>;

--- a/src/app/contacto/layout.tsx
+++ b/src/app/contacto/layout.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/contacto" },
+};
 
 export default function ContactLayout({ children }: { children: React.ReactNode }) {
   return <PublicShell>{children}</PublicShell>;

--- a/src/app/impacto/layout.tsx
+++ b/src/app/impacto/layout.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/impacto" },
+};
 
 export default function ImpactLayout({ children }: { children: React.ReactNode }) {
   return <PublicShell>{children}</PublicShell>;

--- a/src/app/nosotros/layout.tsx
+++ b/src/app/nosotros/layout.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/nosotros" },
+};
 
 export default function CompanyLayout({ children }: { children: React.ReactNode }) {
   return <PublicShell>{children}</PublicShell>;

--- a/src/app/wondergreen/cultivos/[slug]/layout.tsx
+++ b/src/app/wondergreen/cultivos/[slug]/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { getWondergreenCrop } from "@/data/wondergreen-crops";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Pick<Props, "params">): Promise<Metadata> {
+  const { slug } = await params;
+  const crop = getWondergreenCrop(slug);
+  if (!crop) return {};
+  return {
+    alternates: { canonical: `/wondergreen/cultivos/${crop.slug}` },
+  };
+}
+
+export default function WondergreenCropLayout({ children }: Props) {
+  return children;
+}

--- a/src/app/wondergreen/cultivos/layout.tsx
+++ b/src/app/wondergreen/cultivos/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/wondergreen/cultivos" },
+};
+
+export default function WondergreenCropsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
## Objetivo
Cerrar la brecha de canonical metadata en superficies públicas y evitar que rutas editoriales hereden identidad SEO de GREENATICS OPS.

Esta R2 reconstruye el mismo patch ya certificado de #97 sobre el `develop` actual, que avanzó con #98 mientras corría CI. No fuerza refs ni pierde el fix Vercel: la rama parte directamente de `138d31c...`.

## Cambios
- canonical explícito para Impacto, Contacto, Nosotros y Biblioteca;
- canonical propio para `/biblioteca/guia-deficiencias`;
- canonical propio para `/wondergreen/cultivos`;
- canonical específico por cultivo (`/wondergreen/cultivos/<slug>`);
- Playwright sobre 13 rutas representativas exige:
  - exactamente un canonical absoluto bajo `https://greenatics.com.co`;
  - título público no contaminado por `GREENATICS OPS`;
  - meta description no vacía.

## Normalización root
Next serializa el canonical raíz como `https://greenatics.com.co` (sin slash final). El gate exige esa forma únicamente para `/`; todas las demás rutas mantienen coincidencia absoluta exacta con su path.

## Ya correcto y preservado
- HOME, Soluciones, Wondergreen y Proyectos ya tenían canonical;
- Soluciones y Proyectos dinámicos ya generaban canonical por slug;
- #98 queda incorporado por herencia y no es modificado por este PR.

## Fuera de alcance
- keywords/contenido comercial;
- OPS/auth/Supabase;
- dominio productivo o deploy real.