### PR TITLE
Fix · certify protected Vercel previews with ephemeral bypass

### DIFF
--- a/.github/workflows/hosted-pilot-preview.yml
+++ b/.github/workflows/hosted-pilot-preview.yml
@@ -102,15 +102,8 @@ jobs:
           SUPABASE_SECRET_KEY: ${{ inputs.mode == 'full-ops' && secrets.PILOT_SUPABASE_SECRET_KEY || '' }}
         run: npm run pilot:vercel-preview
 
-      - name: Certify deployed Preview
+      - name: Certify protected deployed Preview
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -n "$DEPLOYMENT_URL"
-          npm run pilot:preflight -- \
-            --base-url "$DEPLOYMENT_URL" \
-            --mode "$PILOT_PREVIEW_MODE" \
-            --expected-branch "$DEPLOY_GIT_REF" \
-            --expected-commit "$DEPLOY_GIT_SHA"
+          VERCEL_PROJECT_ID: ${{ steps.deploy.outputs.project_id }}
+        run: npm run pilot:vercel-preflight

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "pilot:backend-preflight": "node scripts/hosted-backend-preflight.mjs",
     "pilot:rls-smoke": "node scripts/hosted-rls-smoke.mjs",
     "pilot:preflight": "node scripts/hosted-pilot-preflight.mjs",
-    "pilot:vercel-preview": "node scripts/vercel-pilot-deploy.mjs"
+    "pilot:vercel-preview": "node scripts/vercel-pilot-deploy.mjs",
+    "pilot:vercel-preflight": "node scripts/vercel-protected-preflight.mjs"
   },
   "dependencies": {
     "@supabase/ssr": "latest",

--- a/scripts/vercel-protected-preflight-lib.mjs
+++ b/scripts/vercel-protected-preflight-lib.mjs
@@ -1,0 +1,171 @@
+import { randomBytes } from "node:crypto";
+import { runHostedPilotPreflight } from "./hosted-pilot-preflight-lib.mjs";
+
+const VERCEL_API_ORIGIN = "https://api.vercel.com";
+
+export class VercelProtectedPreflightError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "VercelProtectedPreflightError";
+  }
+}
+
+function clean(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requireValue(env, name, { max = 8192 } = {}) {
+  const value = clean(env[name]);
+  if (!value || value.length > max) {
+    throw new VercelProtectedPreflightError(`${name} falta o tiene una longitud inválida.`);
+  }
+  return value;
+}
+
+function requireProjectId(value) {
+  const id = clean(value);
+  if (!/^prj_[A-Za-z0-9_-]{3,255}$/.test(id)) {
+    throw new VercelProtectedPreflightError("VERCEL_PROJECT_ID no tiene un formato válido.");
+  }
+  return id;
+}
+
+function apiUrl(path, teamId) {
+  const url = new URL(path, VERCEL_API_ORIGIN);
+  url.searchParams.set("teamId", teamId);
+  return url;
+}
+
+async function parseResponseBody(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+async function vercelRequest({ token, teamId }, fetchImpl, path, { method = "GET", body } = {}) {
+  let response;
+  try {
+    response = await fetchImpl(apiUrl(path, teamId), {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+  } catch {
+    throw new VercelProtectedPreflightError(`Vercel API ${method} ${path}: error de red.`);
+  }
+
+  const data = await parseResponseBody(response);
+  if (!response.ok) {
+    const code = clean(data?.error?.code) || `http_${response.status}`;
+    throw new VercelProtectedPreflightError(`Vercel API ${method} ${path}: ${code}.`);
+  }
+  return data;
+}
+
+export function parseVercelProtectedPreflightConfig(env = process.env) {
+  return Object.freeze({
+    token: requireValue(env, "VERCEL_TOKEN"),
+    teamId: requireValue(env, "VERCEL_ORG_ID", { max: 256 }),
+    projectId: requireProjectId(requireValue(env, "VERCEL_PROJECT_ID", { max: 256 })),
+    deploymentUrl: requireValue(env, "DEPLOYMENT_URL", { max: 2048 }),
+    expectedMode: requireValue(env, "PILOT_PREVIEW_MODE", { max: 32 }),
+    expectedBranch: requireValue(env, "DEPLOY_GIT_REF", { max: 255 }),
+    expectedCommit: requireValue(env, "DEPLOY_GIT_SHA", { max: 64 }),
+  });
+}
+
+export function createProtectionBypassSecret() {
+  return randomBytes(16).toString("hex");
+}
+
+export function createProtectionBypassFetch(secret, fetchImpl = globalThis.fetch) {
+  if (!/^[A-Za-z0-9]{32}$/.test(secret)) {
+    throw new VercelProtectedPreflightError("Protection bypass secret inválido.");
+  }
+  if (typeof fetchImpl !== "function") {
+    throw new VercelProtectedPreflightError("No existe una implementación fetch disponible.");
+  }
+
+  return (url, init = {}) => {
+    const headers = new Headers(init.headers ?? {});
+    headers.set("x-vercel-protection-bypass", secret);
+    return fetchImpl(url, { ...init, headers });
+  };
+}
+
+export async function generateVercelProtectionBypass(config, secret, { fetchImpl = globalThis.fetch } = {}) {
+  if (!/^[A-Za-z0-9]{32}$/.test(secret)) {
+    throw new VercelProtectedPreflightError("Protection bypass secret inválido.");
+  }
+  await vercelRequest(config, fetchImpl, `/v1/projects/${encodeURIComponent(config.projectId)}/protection-bypass`, {
+    method: "PATCH",
+    body: {
+      generate: {
+        secret,
+        note: "GREENATICS hosted pilot CI",
+      },
+    },
+  });
+}
+
+export async function revokeVercelProtectionBypass(config, secret, { fetchImpl = globalThis.fetch } = {}) {
+  if (!/^[A-Za-z0-9]{32}$/.test(secret)) {
+    throw new VercelProtectedPreflightError("Protection bypass secret inválido.");
+  }
+  await vercelRequest(config, fetchImpl, `/v1/projects/${encodeURIComponent(config.projectId)}/protection-bypass`, {
+    method: "PATCH",
+    body: {
+      revoke: {
+        secret,
+        regenerate: false,
+      },
+    },
+  });
+}
+
+export async function runVercelProtectedPilotPreflight({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  preflightRunner = runHostedPilotPreflight,
+  secretFactory = createProtectionBypassSecret,
+  onCleanupError = () => {},
+} = {}) {
+  const config = parseVercelProtectedPreflightConfig(env);
+  const secret = secretFactory();
+  if (!/^[A-Za-z0-9]{32}$/.test(secret)) {
+    throw new VercelProtectedPreflightError("El generador produjo un bypass secret inválido.");
+  }
+
+  let primaryError = null;
+  await generateVercelProtectionBypass(config, secret, { fetchImpl });
+  try {
+    return await preflightRunner({
+      baseUrl: config.deploymentUrl,
+      expectedMode: config.expectedMode,
+      expectedBranch: config.expectedBranch,
+      expectedCommit: config.expectedCommit,
+      fetchImpl: createProtectionBypassFetch(secret, fetchImpl),
+    });
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    try {
+      await revokeVercelProtectionBypass(config, secret, { fetchImpl });
+    } catch (cleanupError) {
+      if (primaryError) {
+        onCleanupError(cleanupError);
+      } else {
+        throw cleanupError;
+      }
+    }
+  }
+}

--- a/scripts/vercel-protected-preflight.mjs
+++ b/scripts/vercel-protected-preflight.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { runVercelProtectedPilotPreflight } from "./vercel-protected-preflight-lib.mjs";
+
+async function main() {
+  const result = await runVercelProtectedPilotPreflight({
+    onCleanupError: (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`GREENATICS Vercel protection cleanup: FAIL · ${message}`);
+    },
+  });
+
+  console.log("GREENATICS protected hosted pilot preflight: PASS");
+  console.log(`origin: ${result.origin}`);
+  console.log(`mode: ${result.mode}`);
+  console.log(`deployment: ${result.deployment.platform}/${result.deployment.environment}`);
+  console.log(`branch: ${result.deployment.branch ?? "n/a"}`);
+  console.log(`commit: ${result.deployment.commit ?? "n/a"}`);
+  console.log(`checks: ${result.checks.join(", ")}`);
+  console.log("protection-bypass: generated, used and revoked");
+}
+
+main().catch((error) => {
+  console.error(`GREENATICS protected hosted pilot preflight: FAIL · ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/vercel-protected-preflight.test.mjs
+++ b/scripts/vercel-protected-preflight.test.mjs
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  VercelProtectedPreflightError,
+  createProtectionBypassFetch,
+  parseVercelProtectedPreflightConfig,
+  runVercelProtectedPilotPreflight,
+} from "./vercel-protected-preflight-lib.mjs";
+
+const env = {
+  VERCEL_TOKEN: "vercel-token-never-log",
+  VERCEL_ORG_ID: "team_test_scope",
+  VERCEL_PROJECT_ID: "prj_greenatics_test",
+  DEPLOYMENT_URL: "https://greenatics-preview.vercel.app",
+  PILOT_PREVIEW_MODE: "full-ops",
+  DEPLOY_GIT_REF: "develop",
+  DEPLOY_GIT_SHA: "a".repeat(40),
+};
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function bodyOf(init) {
+  return init?.body ? JSON.parse(String(init.body)) : undefined;
+}
+
+describe("Vercel protected preview preflight", () => {
+  it("requires a valid project id and deployment provenance", () => {
+    expect(() => parseVercelProtectedPreflightConfig({ ...env, VERCEL_PROJECT_ID: "bad" })).toThrow(/VERCEL_PROJECT_ID/);
+    expect(() => parseVercelProtectedPreflightConfig({ ...env, DEPLOYMENT_URL: "" })).toThrow(/DEPLOYMENT_URL/);
+  });
+
+  it("adds bypass only as an HTTP header", async () => {
+    const secret = "a".repeat(32);
+    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+    const protectedFetch = createProtectionBypassFetch(secret, fetchImpl);
+    await protectedFetch("https://greenatics-preview.vercel.app/api/health", {
+      redirect: "manual",
+      headers: { "user-agent": "test" },
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(String(url)).not.toContain(secret);
+    expect(init.headers.get("x-vercel-protection-bypass")).toBe(secret);
+    expect(init.headers.get("user-agent")).toBe("test");
+  });
+
+  it("generates, uses and revokes one ephemeral bypass", async () => {
+    const secret = "b".repeat(32);
+    const calls = [];
+    const fetchImpl = vi.fn(async (url, init = {}) => {
+      calls.push({ url: new URL(url), method: init.method || "GET", headers: new Headers(init.headers ?? {}), body: bodyOf(init) });
+      return jsonResponse({ protectionBypass: {} });
+    });
+    const preflightRunner = vi.fn(async ({ fetchImpl: protectedFetch }) => {
+      await protectedFetch(`${env.DEPLOYMENT_URL}/api/health`, { redirect: "manual" });
+      return {
+        origin: env.DEPLOYMENT_URL,
+        mode: "full-ops",
+        deployment: { platform: "vercel", environment: "preview", branch: "develop", commit: env.DEPLOY_GIT_SHA },
+        checks: ["health"],
+      };
+    });
+
+    const result = await runVercelProtectedPilotPreflight({
+      env,
+      fetchImpl,
+      preflightRunner,
+      secretFactory: () => secret,
+    });
+
+    expect(result.mode).toBe("full-ops");
+    const patches = calls.filter((call) => call.method === "PATCH");
+    expect(patches).toHaveLength(2);
+    expect(patches[0].url.pathname).toBe("/v1/projects/prj_greenatics_test/protection-bypass");
+    expect(patches[0].body).toEqual({ generate: { secret, note: "GREENATICS hosted pilot CI" } });
+    expect(patches[1].body).toEqual({ revoke: { secret, regenerate: false } });
+
+    const deploymentRequest = calls.find((call) => call.url.hostname === "greenatics-preview.vercel.app");
+    expect(deploymentRequest.headers.get("x-vercel-protection-bypass")).toBe(secret);
+    expect(deploymentRequest.url.toString()).not.toContain(secret);
+  });
+
+  it("revokes the bypass even when the hosted preflight fails", async () => {
+    const secret = "c".repeat(32);
+    const bodies = [];
+    const fetchImpl = vi.fn(async (_url, init = {}) => {
+      if ((init.method || "GET") === "PATCH") bodies.push(bodyOf(init));
+      return jsonResponse({ protectionBypass: {} });
+    });
+
+    await expect(runVercelProtectedPilotPreflight({
+      env,
+      fetchImpl,
+      preflightRunner: vi.fn(async () => { throw new Error("health failed"); }),
+      secretFactory: () => secret,
+    })).rejects.toThrow(/health failed/);
+
+    expect(bodies).toEqual([
+      { generate: { secret, note: "GREENATICS hosted pilot CI" } },
+      { revoke: { secret, regenerate: false } },
+    ]);
+  });
+
+  it("never reflects remote messages that could contain credentials", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      error: { code: "forbidden", message: `token=${env.VERCEL_TOKEN}` },
+    }, 403));
+
+    let thrown;
+    try {
+      await runVercelProtectedPilotPreflight({
+        env,
+        fetchImpl,
+        secretFactory: () => "d".repeat(32),
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(VercelProtectedPreflightError);
+    expect(thrown.message).toContain("forbidden");
+    expect(thrown.message).not.toContain(env.VERCEL_TOKEN);
+  });
+});


### PR DESCRIPTION
## Causa
El Preview full-ops ya se crea y llega a READY, pero el preflight recibe HTTP 302 en `/api/health`. El endpoint de la app no redirige y `/api/health` está fuera del proxy OPS, por lo que el 302 corresponde a Vercel Deployment Protection.

## Cambio
- Mantiene Deployment Protection habilitado.
- Genera un Protection Bypass for Automation temporal mediante la API oficial de Vercel.
- Inyecta el bypass únicamente como header `x-vercel-protection-bypass` en las peticiones del preflight.
- Nunca incluye el bypass en URL, outputs, summary ni repo.
- Revoca el bypass en `finally`, incluso cuando el preflight funcional falla.
- Añade pruebas de lifecycle, header-only y no filtrado de credenciales.
- Workflow usa el `project_id` y `deployment_url` producidos por el paso de deploy.

## Seguridad
No se desactiva protección, no se añade ningún GitHub Secret nuevo y no se modifica Supabase ni producción.

## Gate
Merge solo con quality + database verdes; luego sincronizar el dispatcher de main y reintentar full-ops.