### PR TITLE
Infra · sync protected Vercel preflight on main

### DIFF
--- a/.github/workflows/hosted-pilot-preview.yml
+++ b/.github/workflows/hosted-pilot-preview.yml
@@ -104,15 +104,8 @@ jobs:
           SUPABASE_SECRET_KEY: ${{ inputs.mode == 'full-ops' && secrets.PILOT_SUPABASE_SECRET_KEY || '' }}
         run: npm run pilot:vercel-preview
 
-      - name: Certify deployed Preview
+      - name: Certify protected deployed Preview
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -n "$DEPLOYMENT_URL"
-          npm run pilot:preflight -- \
-            --base-url "$DEPLOYMENT_URL" \
-            --mode "$PILOT_PREVIEW_MODE" \
-            --expected-branch "$DEPLOY_GIT_REF" \
-            --expected-commit "$DEPLOY_GIT_SHA"
+          VERCEL_PROJECT_ID: ${{ steps.deploy.outputs.project_id }}
+        run: npm run pilot:vercel-preflight


### PR DESCRIPTION
Sincroniza únicamente el dispatcher de la rama por defecto con el preflight protegido ya certificado en develop. Mantiene checkout de develop, selector public-only/full-ops y usa el `project_id`/`deployment_url` del paso de Vercel para ejecutar el bypass de automatización efímero. No mezcla código de aplicación en main.