### PR TITLE
CI v0.21 · Faster feedback without reducing coverage

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -86,8 +86,6 @@ jobs:
           node-version: 24
       - name: Install dependencies
         run: npm install --ignore-scripts
-      - name: Build production app
-        run: npm run build
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -70,6 +70,24 @@ jobs:
 
           check_private_headers /login
           check_private_headers /app
+
+  browser:
+    name: browser (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [desktop-chromium, mobile-chromium]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+      - name: Build production app
+        run: npm run build
       - name: Cache Playwright Chromium
         uses: actions/cache@v4
         with:
@@ -79,13 +97,13 @@ jobs:
         timeout-minutes: 8
         run: npx playwright install --with-deps chromium
       - name: Browser gates
-        timeout-minutes: 10
-        run: npm run test:e2e
+        timeout-minutes: 8
+        run: npx playwright test --project=${{ matrix.project }}
       - name: Upload Playwright report on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.project }}
           path: |
             playwright-report/
             test-results/

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [develop]
 
+concurrency:
+  group: quality-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 1 : 0,
-  workers: isCI ? 2 : undefined,
+  workers: isCI ? 1 : undefined,
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: "http://localhost:3000",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const isCI = Boolean(process.env.CI);
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  forbidOnly: isCI,
+  retries: isCI ? 1 : 0,
+  workers: isCI ? 2 : undefined,
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: "http://localhost:3000",
@@ -17,9 +19,9 @@ export default defineConfig({
     { name: "mobile-chromium", use: { ...devices["Pixel 7"] } },
   ],
   webServer: {
-    command: "npm run dev",
+    command: isCI ? "npm run start" : "npm run dev",
     url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
     timeout: 120_000,
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     { name: "mobile-chromium", use: { ...devices["Pixel 7"] } },
   ],
   webServer: {
-    command: isCI ? "npm run start" : "npm run dev",
+    command: "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !isCI,
     timeout: 120_000,


### PR DESCRIPTION
## Objetivo
Reducir la latencia de feedback que estaba alargando iteraciones ya certificadas, sin eliminar ni debilitar gates.

## Implementación final
- añade `concurrency` por PR/ref con `cancel-in-progress: true`: un commit nuevo cancela automáticamente el run obsoleto;
- separa Playwright en dos jobs/runners paralelos: `desktop-chromium` y `mobile-chromium`;
- mantiene 1 worker por job para evitar contención/race conditions dentro del mismo runner;
- conserva el servidor E2E ya probado (`npm run dev`);
- elimina builds redundantes dentro de los jobs browser; el build de producción sigue certificado en `quality`;
- `quality`, `database`, desktop y mobile pueden avanzar en paralelo.

## Preservado
- mismo directorio `e2e` y mismas pruebas;
- mismos proyectos desktop Chromium + mobile Chromium;
- mismos retries, traces, screenshots y artefactos de fallo;
- mismos gates de typecheck, lint, unit, build, headers privados y Supabase;
- ninguna modificación a páginas, OPS, auth, datos o contratos de negocio.

## Validación y aprendizaje
Se probaron dos alternativas y se descartaron antes del merge porque no mejoraban el wall-clock: 2 workers en un mismo runner y E2E contra `next start`. La configuración final usa sharding por runner + 1 worker + `next dev`.

Run final #317 (`2991981...`) completamente verde:
- total workflow: ~3m10s;
- mobile Browser gates: ~1m52s;
- desktop Browser gates: ~1m50s;
- ambos corren en paralelo;
- baseline previo del Browser gate monolítico: ~4m44s serial.

La cancelación de runs obsoletos también quedó demostrada en vivo durante este PR.