### PR TITLE
CORE-004J · Distinguish Vercel Preview noindex from private OPS headers

### DIFF
--- a/scripts/hosted-pilot-preflight-lib.mjs
+++ b/scripts/hosted-pilot-preflight-lib.mjs
@@ -72,6 +72,20 @@ function assertPrivateHeaders(response, label) {
   for (const [name, value] of Object.entries(PRIVATE_HEADERS)) requireHeader(response, name, value, label);
 }
 
+function assertPublicIndexingHeaders(response, deployment, label) {
+  const actual = response.headers.get("x-robots-tag");
+  if (!actual) return;
+
+  const normalized = actual.trim().toLowerCase();
+  const vercelPreviewNoindex =
+    deployment?.platform === "vercel" &&
+    deployment?.environment === "preview" &&
+    normalized === "noindex";
+
+  if (vercelPreviewNoindex) return;
+  fail(`${label}: X-Robots-Tag privado o inesperado en superficie pública.`);
+}
+
 function normalizeCommit(value) {
   if (!value || !/^[0-9a-f]{7,64}$/i.test(value)) return null;
   return value.toLowerCase();
@@ -192,7 +206,7 @@ export async function runHostedPilotPreflight({
   const publicResponse = await get(fetchImpl, `${origin}/`);
   requireStatus(publicResponse, 200, "home pública");
   assertBaselineHeaders(publicResponse, "home pública");
-  if (publicResponse.headers.has("x-robots-tag")) fail("home pública: no debe llevar X-Robots-Tag interno.");
+  assertPublicIndexingHeaders(publicResponse, deployment, "home pública");
 
   const loginResponse = await get(fetchImpl, `${origin}/login`);
   requireStatus(loginResponse, 200, "login");

--- a/scripts/hosted-pilot-preflight.test.mjs
+++ b/scripts/hosted-pilot-preflight.test.mjs
@@ -113,6 +113,62 @@ describe("hosted pilot preflight", () => {
     expect(result.checks).toContain("ops-anonymous");
   });
 
+  it("accepts Vercel's platform noindex on a Preview public home", async () => {
+    const origin = "https://greenatics-pilot.vercel.app";
+    const fixture = hostedFixture({
+      overrides: {
+        [`${origin}/`]: new Response("home", {
+          status: 200,
+          headers: { ...baselineHeaders, "x-robots-tag": "noindex" },
+        }),
+      },
+    });
+
+    await expect(runHostedPilotPreflight({
+      baseUrl: fixture.origin,
+      expectedMode: "full-ops",
+      fetchImpl: fixture.fetchImpl,
+    })).resolves.toMatchObject({ mode: "full-ops" });
+  });
+
+  it("rejects the private OPS robots policy on a Preview public home", async () => {
+    const origin = "https://greenatics-pilot.vercel.app";
+    const fixture = hostedFixture({
+      overrides: {
+        [`${origin}/`]: new Response("home", { status: 200, headers: privateHeaders }),
+      },
+    });
+
+    await expect(runHostedPilotPreflight({
+      baseUrl: fixture.origin,
+      expectedMode: "full-ops",
+      fetchImpl: fixture.fetchImpl,
+    })).rejects.toThrow(/X-Robots-Tag privado o inesperado/);
+  });
+
+  it("keeps a production public home free of X-Robots-Tag", async () => {
+    const origin = "https://greenatics-pilot.vercel.app";
+    const productionHealth = {
+      ...fullOpsHealth,
+      deployment: { ...deployment, environment: "production" },
+    };
+    const fixture = hostedFixture({
+      overrides: {
+        [`${origin}/api/health`]: jsonResponse(productionHealth, { headers: privateHeaders }),
+        [`${origin}/`]: new Response("home", {
+          status: 200,
+          headers: { ...baselineHeaders, "x-robots-tag": "noindex" },
+        }),
+      },
+    });
+
+    await expect(runHostedPilotPreflight({
+      baseUrl: fixture.origin,
+      expectedMode: "full-ops",
+      fetchImpl: fixture.fetchImpl,
+    })).rejects.toThrow(/X-Robots-Tag privado o inesperado/);
+  });
+
   it("accepts a public-only deployment only when OPS is configuration-blocked and Supabase is absent", async () => {
     const fixture = hostedFixture({ mode: "public-only" });
     const result = await runHostedPilotPreflight({


### PR DESCRIPTION
Closes #105.

The hosted pilot now reaches the public boundary after CORE-004I. Vercel Preview deployments automatically add `X-Robots-Tag: noindex`; the prior preflight incorrectly treated any robots header on `/` as an internal leak.

This change keeps the contract strict:
- allow only the Vercel Preview platform value `noindex` on the public home;
- reject GREENATICS private `noindex, nofollow, noarchive` or any other unexpected robots policy on the public home;
- keep production public home free of X-Robots-Tag;
- keep strict private headers unchanged for health/login/OPS;
- add regressions for Preview acceptance, private-header rejection and Production rejection.

Official Vercel documentation confirms `x-robots-tag: noindex` is automatically present on Preview deployments.