### PR TITLE
CORE-004K · Stabilize ephemeral Vercel bypass readiness

### DIFF
--- a/scripts/vercel-protected-preflight-lib.mjs
+++ b/scripts/vercel-protected-preflight-lib.mjs
@@ -2,6 +2,8 @@ import { randomBytes } from "node:crypto";
 import { runHostedPilotPreflight } from "./hosted-pilot-preflight-lib.mjs";
 
 const VERCEL_API_ORIGIN = "https://api.vercel.com";
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const DEFAULT_BYPASS_RETRY_DELAYS_MS = Object.freeze([250, 500, 1000, 2000]);
 
 export class VercelProtectedPreflightError extends Error {
   constructor(message) {
@@ -34,6 +36,29 @@ function apiUrl(path, teamId) {
   const url = new URL(path, VERCEL_API_ORIGIN);
   url.searchParams.set("teamId", teamId);
   return url;
+}
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function safeRedirectTarget(response, baseUrl) {
+  const location = response.headers.get("location");
+  if (!location) return null;
+  try {
+    const target = new URL(location, baseUrl);
+    return `${target.origin}${target.pathname}`;
+  } catch {
+    return "<invalid>";
+  }
+}
+
+function deploymentHealthUrl(value) {
+  try {
+    return new URL("/api/health", value).toString();
+  } catch {
+    throw new VercelProtectedPreflightError("DEPLOYMENT_URL no es una URL válida para readiness.");
+  }
 }
 
 async function parseResponseBody(response) {
@@ -131,11 +156,65 @@ export async function revokeVercelProtectionBypass(config, secret, { fetchImpl =
   });
 }
 
+export async function waitForVercelProtectionBypassReadiness(config, secret, {
+  fetchImpl = globalThis.fetch,
+  sleepImpl = defaultSleep,
+  retryDelays = DEFAULT_BYPASS_RETRY_DELAYS_MS,
+} = {}) {
+  if (typeof sleepImpl !== "function") {
+    throw new VercelProtectedPreflightError("No existe una implementación de espera para readiness.");
+  }
+  if (!Array.isArray(retryDelays) || retryDelays.length > 8) {
+    throw new VercelProtectedPreflightError("La política de retry del bypass es inválida.");
+  }
+
+  const delays = retryDelays.map((value) => Number(value));
+  if (delays.some((value) => !Number.isFinite(value) || value < 0 || value > 10_000)) {
+    throw new VercelProtectedPreflightError("La política de retry del bypass contiene una espera inválida.");
+  }
+
+  const url = deploymentHealthUrl(config.deploymentUrl);
+  const protectedFetch = createProtectionBypassFetch(secret, fetchImpl);
+
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    let response;
+    try {
+      response = await protectedFetch(url, {
+        redirect: "manual",
+        headers: { "user-agent": "GREENATICS-VERCEL-BYPASS-READINESS/1.0" },
+      });
+    } catch {
+      throw new VercelProtectedPreflightError("Bypass readiness: error de red al consultar /api/health.");
+    }
+
+    if (response.status === 200) {
+      return { attempts: attempt + 1, status: response.status };
+    }
+
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return { attempts: attempt + 1, status: response.status };
+    }
+
+    if (attempt === delays.length) {
+      const target = safeRedirectTarget(response, config.deploymentUrl);
+      throw new VercelProtectedPreflightError(
+        `Bypass readiness: /api/health siguió redirigiendo tras ${attempt + 1} intentos (HTTP ${response.status})${target ? `; redirect=${target}` : ""}.`,
+      );
+    }
+
+    await sleepImpl(delays[attempt]);
+  }
+
+  throw new VercelProtectedPreflightError("Bypass readiness terminó en un estado imposible.");
+}
+
 export async function runVercelProtectedPilotPreflight({
   env = process.env,
   fetchImpl = globalThis.fetch,
   preflightRunner = runHostedPilotPreflight,
   secretFactory = createProtectionBypassSecret,
+  sleepImpl = defaultSleep,
+  readinessRetryDelays = DEFAULT_BYPASS_RETRY_DELAYS_MS,
   onCleanupError = () => {},
 } = {}) {
   const config = parseVercelProtectedPreflightConfig(env);
@@ -147,6 +226,12 @@ export async function runVercelProtectedPilotPreflight({
   let primaryError = null;
   await generateVercelProtectionBypass(config, secret, { fetchImpl });
   try {
+    await waitForVercelProtectionBypassReadiness(config, secret, {
+      fetchImpl,
+      sleepImpl,
+      retryDelays: readinessRetryDelays,
+    });
+
     return await preflightRunner({
       baseUrl: config.deploymentUrl,
       expectedMode: config.expectedMode,

--- a/scripts/vercel-protected-preflight.test.mjs
+++ b/scripts/vercel-protected-preflight.test.mjs
@@ -84,6 +84,88 @@ describe("Vercel protected preview preflight", () => {
     expect(deploymentRequest.url.toString()).not.toContain(secret);
   });
 
+  it("retries bounded redirects while a new bypass propagates", async () => {
+    const secret = "e".repeat(32);
+    let readinessReads = 0;
+    const sleepImpl = vi.fn(async () => {});
+    const fetchImpl = vi.fn(async (url, init = {}) => {
+      if ((init.method || "GET") === "PATCH") return jsonResponse({ protectionBypass: {} });
+      if (new URL(url).pathname === "/api/health") {
+        readinessReads += 1;
+        if (readinessReads < 3) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://vercel.com/login?next=protected" },
+          });
+        }
+        return new Response("ok", { status: 200 });
+      }
+      throw new Error(`Unexpected URL ${String(url)}`);
+    });
+    const preflightRunner = vi.fn(async () => ({
+      origin: env.DEPLOYMENT_URL,
+      mode: "full-ops",
+      deployment: { platform: "vercel", environment: "preview", branch: "develop", commit: env.DEPLOY_GIT_SHA },
+      checks: ["health"],
+    }));
+
+    const result = await runVercelProtectedPilotPreflight({
+      env,
+      fetchImpl,
+      preflightRunner,
+      secretFactory: () => secret,
+      sleepImpl,
+      readinessRetryDelays: [10, 20, 40],
+    });
+
+    expect(result.mode).toBe("full-ops");
+    expect(readinessReads).toBe(3);
+    expect(sleepImpl.mock.calls.map(([ms]) => ms)).toEqual([10, 20]);
+    expect(preflightRunner).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds persistent redirects, sanitizes Location and still revokes the bypass", async () => {
+    const secret = "f".repeat(32);
+    const bodies = [];
+    const sleepImpl = vi.fn(async () => {});
+    const fetchImpl = vi.fn(async (url, init = {}) => {
+      if ((init.method || "GET") === "PATCH") {
+        bodies.push(bodyOf(init));
+        return jsonResponse({ protectionBypass: {} });
+      }
+      if (new URL(url).pathname === "/api/health") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: `https://vercel.com/login?token=${env.VERCEL_TOKEN}` },
+        });
+      }
+      throw new Error(`Unexpected URL ${String(url)}`);
+    });
+
+    let thrown;
+    try {
+      await runVercelProtectedPilotPreflight({
+        env,
+        fetchImpl,
+        preflightRunner: vi.fn(async () => ({ ok: true })),
+        secretFactory: () => secret,
+        sleepImpl,
+        readinessRetryDelays: [1, 2],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(VercelProtectedPreflightError);
+    expect(thrown.message).toContain("redirect=https://vercel.com/login");
+    expect(thrown.message).not.toContain(env.VERCEL_TOKEN);
+    expect(sleepImpl.mock.calls.map(([ms]) => ms)).toEqual([1, 2]);
+    expect(bodies).toEqual([
+      { generate: { secret, note: "GREENATICS hosted pilot CI" } },
+      { revoke: { secret, regenerate: false } },
+    ]);
+  });
+
   it("revokes the bypass even when the hosted preflight fails", async () => {
     const secret = "c".repeat(32);
     const bodies = [];


### PR DESCRIPTION
Closes #107.

The hosted pilot generates a fresh Vercel Automation Bypass secret and previously used it immediately. Across consecutive runs, the same corrected routing boundary produced intermittent `/api/health` 200/302 results, which is consistent with a short readiness/propagation window at the deployment-protection boundary.

## Change
- probe `/api/health` with the fresh bypass before running the full hosted preflight;
- retry only HTTP redirect states with bounded backoff (250/500/1000/2000 ms);
- pass deterministic non-redirect statuses directly to the canonical hosted preflight;
- preserve header-only secret transport;
- preserve guaranteed bypass revocation in `finally`;
- sanitize persistent redirect diagnostics to origin+path only, never query strings/secrets;
- add regressions for transient `302 → 302 → 200` and bounded persistent redirects + cleanup.

No application auth policy or Deployment Protection setting is weakened.