### PR TITLE
CORE-004L · Canonical public sitemap origin

### DIFF
--- a/e2e/deployment-readiness.spec.ts
+++ b/e2e/deployment-readiness.spec.ts
@@ -36,19 +36,21 @@ test("login is private and excluded from indexing in the development E2E server"
   expectDevelopmentNonCacheable(headers["cache-control"]);
 });
 
-test("health exposes only safe deployment provenance", async ({ request }) => {
+test("health exposes only safe deployment provenance and the canonical public origin", async ({ request }) => {
   const response = await request.get("/api/health");
   expect(response.ok()).toBe(true);
   const body = await response.json() as {
     status: string;
     mode: string;
     opsAccess: string;
+    publicOrigin: string;
     deployment: { platform: string; environment: string; branch: string | null; commit: string | null };
   };
 
   expect(body.status).toBe("ready");
   expect(body.mode).toBe("local");
   expect(body.opsAccess).toBe("local-bypass");
+  expect(body.publicOrigin).toBe("https://greenatics.com.co");
   expect(body.deployment.platform).toBe("generic");
   expect(Object.keys(body.deployment).sort()).toEqual(["branch", "commit", "environment", "platform"]);
   expect(body.deployment.branch).toBeNull();

--- a/scripts/hosted-pilot-preflight-lib.mjs
+++ b/scripts/hosted-pilot-preflight-lib.mjs
@@ -22,21 +22,31 @@ function fail(message) {
   throw new PreflightError(message);
 }
 
-export function normalizeHostedBaseUrl(value) {
-  if (!value) fail("Falta --base-url o APP_BASE_URL.");
+function normalizeHttpsOrigin(value, label) {
+  if (!value || typeof value !== "string") fail(`${label}: falta el origen HTTPS.`);
 
   let url;
   try {
     url = new URL(value);
   } catch {
-    fail("El origen del piloto no es una URL válida.");
+    fail(`${label}: origen inválido.`);
   }
 
-  if (url.protocol !== "https:") fail("El piloto hospedado debe usar HTTPS.");
-  if (url.username || url.password) fail("El origen del piloto no puede incluir credenciales.");
-  if (url.pathname !== "/" || url.search || url.hash) fail("Usa únicamente el origen del deployment, sin ruta, query ni fragmento.");
-
+  if (url.protocol !== "https:") fail(`${label}: el origen debe usar HTTPS.`);
+  if (url.username || url.password) fail(`${label}: el origen no puede incluir credenciales.`);
+  if (url.pathname !== "/" || url.search || url.hash) {
+    fail(`${label}: se esperaba únicamente un origen, sin ruta, query ni fragmento.`);
+  }
   return url.origin;
+}
+
+export function normalizeHostedBaseUrl(value) {
+  if (!value) fail("Falta --base-url o APP_BASE_URL.");
+  return normalizeHttpsOrigin(value, "origen del piloto");
+}
+
+export function normalizePublicOrigin(value) {
+  return normalizeHttpsOrigin(value, "health publicOrigin");
 }
 
 export function normalizePilotMode(value) {
@@ -62,7 +72,7 @@ function requireHeaderIncludes(response, name, expected, label) {
 function assertBaselineHeaders(response, label) {
   for (const [name, value] of Object.entries(BASELINE_HEADERS)) requireHeader(response, name, value, label);
   const permissions = response.headers.get("permissions-policy") ?? "";
-  for (const token of ["camera=()", "microphone=()", "geolocation=()"] ) {
+  for (const token of ["camera=()", "microphone=()", "geolocation=()"]) {
     if (!permissions.includes(token)) fail(`${label}: Permissions-Policy no contiene ${token}.`);
   }
 }
@@ -99,6 +109,8 @@ export function assertHostedHealth(payload, {
   const pilotMode = normalizePilotMode(expectedMode);
   if (!payload || typeof payload !== "object") fail("health: respuesta JSON inválida.");
   if (payload.status !== "ready") fail(`health: status=${String(payload.status)}; se esperaba ready.`);
+
+  normalizePublicOrigin(payload.publicOrigin);
 
   const checks = payload.checks ?? {};
   if (pilotMode === "public-only") {
@@ -148,7 +160,7 @@ function sitemapLocations(xml) {
   return [...xml.matchAll(/<loc>([^<]+)<\/loc>/gi)].map((match) => match[1].trim());
 }
 
-function assertPublicSitemap(xml, origin) {
+function assertPublicSitemap(xml, publicOrigin) {
   const locations = sitemapLocations(xml);
   if (locations.length === 0) fail("sitemap: no contiene URLs públicas.");
 
@@ -160,7 +172,7 @@ function assertPublicSitemap(xml, origin) {
     } catch {
       fail(`sitemap: URL inválida: ${location}`);
     }
-    if (url.origin !== origin) fail(`sitemap: URL fuera del origen del piloto: ${location}`);
+    if (url.origin !== publicOrigin) fail(`sitemap: URL fuera del origen público canónico: ${location}`);
     if (forbiddenPrefixes.some((prefix) => url.pathname === prefix || url.pathname.startsWith(`${prefix}/`))) {
       fail(`sitemap: expone una ruta interna: ${url.pathname}`);
     }
@@ -202,6 +214,7 @@ export async function runHostedPilotPreflight({
     fail("health: el endpoint no devolvió JSON válido.");
   }
   const deployment = assertHostedHealth(health, { expectedBranch, expectedCommit, expectedMode: pilotMode });
+  const publicOrigin = normalizePublicOrigin(health.publicOrigin);
 
   const publicResponse = await get(fetchImpl, `${origin}/`);
   requireStatus(publicResponse, 200, "home pública");
@@ -234,7 +247,7 @@ export async function runHostedPilotPreflight({
 
   const sitemapResponse = await get(fetchImpl, `${origin}/sitemap.xml`);
   requireStatus(sitemapResponse, 200, "sitemap");
-  assertPublicSitemap(await sitemapResponse.text(), origin);
+  assertPublicSitemap(await sitemapResponse.text(), publicOrigin);
 
   const robotsResponse = await get(fetchImpl, `${origin}/robots.txt`);
   requireStatus(robotsResponse, 200, "robots");
@@ -242,6 +255,7 @@ export async function runHostedPilotPreflight({
 
   return {
     origin,
+    publicOrigin,
     mode: pilotMode,
     deployment,
     checks: [

--- a/scripts/hosted-pilot-preflight.test.mjs
+++ b/scripts/hosted-pilot-preflight.test.mjs
@@ -4,8 +4,11 @@ import {
   assertHostedHealth,
   normalizeHostedBaseUrl,
   normalizePilotMode,
+  normalizePublicOrigin,
   runHostedPilotPreflight,
 } from "./hosted-pilot-preflight-lib.mjs";
+
+const canonicalPublicOrigin = "https://greenatics.com.co";
 
 const baselineHeaders = {
   "x-content-type-options": "nosniff",
@@ -33,6 +36,7 @@ const fullOpsHealth = {
   mode: "supabase",
   opsAccess: "supabase-auth",
   checks: { backend: "ok", admin: "ok", appOrigin: "ok" },
+  publicOrigin: canonicalPublicOrigin,
   deployment,
 };
 
@@ -41,6 +45,7 @@ const publicHealth = {
   mode: "local",
   opsAccess: "configuration-block",
   checks: { backend: "missing", admin: "missing", appOrigin: "ok" },
+  publicOrigin: canonicalPublicOrigin,
   deployment,
 };
 
@@ -69,7 +74,7 @@ function hostedFixture({ mode = "full-ops", overrides = {} } = {}) {
       },
     }),
     [`${origin}/sitemap.xml`]: new Response(
-      `<?xml version="1.0"?><urlset><url><loc>${origin}/</loc></url><url><loc>${origin}/wondergreen</loc></url></urlset>`,
+      `<?xml version="1.0"?><urlset><url><loc>${canonicalPublicOrigin}/</loc></url><url><loc>${canonicalPublicOrigin}/wondergreen</loc></url></urlset>`,
       { status: 200 },
     ),
     [`${origin}/robots.txt`]: new Response("User-agent: *\nDisallow: /app\nDisallow: /login\nDisallow: /api/\n", { status: 200 }),
@@ -87,17 +92,20 @@ function hostedFixture({ mode = "full-ops", overrides = {} } = {}) {
 }
 
 describe("hosted pilot preflight", () => {
-  it("normalizes only HTTPS origins and accepted pilot modes", () => {
+  it("normalizes only clean HTTPS deployment and public origins plus accepted pilot modes", () => {
     expect(normalizeHostedBaseUrl("https://pilot.example.com")).toBe("https://pilot.example.com");
+    expect(normalizePublicOrigin(canonicalPublicOrigin)).toBe(canonicalPublicOrigin);
     expect(() => normalizeHostedBaseUrl("http://pilot.example.com")).toThrow(PreflightError);
     expect(() => normalizeHostedBaseUrl("https://user:pass@pilot.example.com")).toThrow(PreflightError);
     expect(() => normalizeHostedBaseUrl("https://pilot.example.com/app")).toThrow(PreflightError);
+    expect(() => normalizePublicOrigin("http://greenatics.com.co")).toThrow(/HTTPS/);
+    expect(() => normalizePublicOrigin("https://greenatics.com.co/path")).toThrow(/únicamente un origen/);
     expect(normalizePilotMode(undefined)).toBe("full-ops");
     expect(normalizePilotMode("public-only")).toBe("public-only");
     expect(() => normalizePilotMode("unknown")).toThrow(/public-only o full-ops/);
   });
 
-  it("accepts a ready full-ops deployment with matching branch and commit", async () => {
+  it("accepts a ready full-ops deployment with matching branch, commit and canonical public origin", async () => {
     const fixture = hostedFixture();
     const result = await runHostedPilotPreflight({
       baseUrl: fixture.origin,
@@ -108,9 +116,15 @@ describe("hosted pilot preflight", () => {
     });
 
     expect(result.origin).toBe(fixture.origin);
+    expect(result.publicOrigin).toBe(canonicalPublicOrigin);
     expect(result.mode).toBe("full-ops");
     expect(result.deployment.environment).toBe("preview");
     expect(result.checks).toContain("ops-anonymous");
+  });
+
+  it("rejects hosted health without a valid canonical public origin", () => {
+    expect(() => assertHostedHealth({ ...fullOpsHealth, publicOrigin: undefined }, { expectedMode: "full-ops" })).toThrow(/publicOrigin/);
+    expect(() => assertHostedHealth({ ...fullOpsHealth, publicOrigin: "https://greenatics.com.co/path" }, { expectedMode: "full-ops" })).toThrow(/publicOrigin/);
   });
 
   it("accepts Vercel's platform noindex on a Preview public home", async () => {
@@ -128,7 +142,7 @@ describe("hosted pilot preflight", () => {
       baseUrl: fixture.origin,
       expectedMode: "full-ops",
       fetchImpl: fixture.fetchImpl,
-    })).resolves.toMatchObject({ mode: "full-ops" });
+    })).resolves.toMatchObject({ mode: "full-ops", publicOrigin: canonicalPublicOrigin });
   });
 
   it("rejects the private OPS robots policy on a Preview public home", async () => {
@@ -213,7 +227,7 @@ describe("hosted pilot preflight", () => {
     })).rejects.toThrow(/reason=configuration/);
   });
 
-  it("rejects anonymous OPS redirects that leave the canonical origin", async () => {
+  it("rejects anonymous OPS redirects that leave the deployment origin", async () => {
     const origin = "https://greenatics-pilot.vercel.app";
     const fixture = hostedFixture({
       overrides: {
@@ -227,17 +241,31 @@ describe("hosted pilot preflight", () => {
     await expect(runHostedPilotPreflight({ baseUrl: fixture.origin, fetchImpl: fixture.fetchImpl })).rejects.toThrow(/login canónico/);
   });
 
-  it("rejects internal routes leaked into the public sitemap", async () => {
+  it("rejects internal routes leaked into the canonical public sitemap", async () => {
     const origin = "https://greenatics-pilot.vercel.app";
     const fixture = hostedFixture({
       overrides: {
         [`${origin}/sitemap.xml`]: new Response(
-          `<?xml version="1.0"?><urlset><url><loc>${origin}/app</loc></url></urlset>`,
+          `<?xml version="1.0"?><urlset><url><loc>${canonicalPublicOrigin}/app</loc></url></urlset>`,
           { status: 200 },
         ),
       },
     });
 
     await expect(runHostedPilotPreflight({ baseUrl: fixture.origin, fetchImpl: fixture.fetchImpl })).rejects.toThrow(/ruta interna/);
+  });
+
+  it("rejects sitemap URLs outside health's canonical public origin", async () => {
+    const origin = "https://greenatics-pilot.vercel.app";
+    const fixture = hostedFixture({
+      overrides: {
+        [`${origin}/sitemap.xml`]: new Response(
+          `<?xml version="1.0"?><urlset><url><loc>https://evil.example/wondergreen</loc></url></urlset>`,
+          { status: 200 },
+        ),
+      },
+    });
+
+    await expect(runHostedPilotPreflight({ baseUrl: fixture.origin, fetchImpl: fixture.fetchImpl })).rejects.toThrow(/origen público canónico/);
   });
 });

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { publicSite } from "@/data/public-site";
 import { getDataMode, isSupabaseConfigured } from "@/lib/data-mode";
 import { getDeploymentProvenance } from "@/lib/deployment-provenance";
 import { getOpsAccessMode } from "@/lib/ops-access-policy";
@@ -36,6 +37,7 @@ export async function GET() {
       mode,
       opsAccess: getOpsAccessMode(),
       checks,
+      publicOrigin: publicSite.publicDomainTarget.replace(/\/$/, ""),
       deployment: getDeploymentProvenance(),
     },
     { status: ready ? 200 : 503 },


### PR DESCRIPTION
Closes #109.

Updates hosted pilot certification so sitemap URLs are checked against the canonical public origin exposed by `/api/health`, while the Preview deployment URL remains the runtime origin for health/login/OPS. Adds validation and regression coverage. No auth, Supabase, Vercel protection or production SEO configuration is changed.