### PR TITLE
CORE-004N · Director onboarding gate

### DIFF
--- a/scripts/hosted-backend-preflight-lib.mjs
+++ b/scripts/hosted-backend-preflight-lib.mjs
@@ -102,8 +102,13 @@ export async function runHostedBackendPreflight({
   env = process.env,
   plants = DEFAULT_PILOT_PLANT_CODES,
   requireNoDirector = false,
+  requireDirector = false,
   createClientImpl = createSupabaseClient,
 } = {}) {
+  if (requireNoDirector && requireDirector) {
+    throw new BackendPreflightError("El preflight no puede exigir simultáneamente ausencia y presencia de director.");
+  }
+
   const config = parseHostedBackendConfig(env);
   const requestedCodes = normalizePilotPlantCodes(plants);
   const admin = createClientImpl(config.url, config.secret, {
@@ -155,6 +160,9 @@ export async function runHostedBackendPreflight({
   }
   if (requireNoDirector && activeDirectors > 0) {
     throw new BackendPreflightError(`Ya existe ${activeDirectors} director activo; el bootstrap inicial debe permanecer bloqueado.`);
+  }
+  if (requireDirector && activeDirectors === 0) {
+    throw new BackendPreflightError("No existe ningún director activo; el bootstrap inicial todavía no quedó confirmado.");
   }
 
   return Object.freeze({

--- a/scripts/hosted-director-postcheck.mjs
+++ b/scripts/hosted-director-postcheck.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { runHostedBackendPreflight } from "./hosted-backend-preflight-lib.mjs";
+import { DEFAULT_PILOT_PLANT_CODES } from "./pilot-plant-codes.mjs";
+
+async function main() {
+  const result = await runHostedBackendPreflight({
+    plants: DEFAULT_PILOT_PLANT_CODES,
+    requireDirector: true,
+  });
+
+  console.log("GREENATICS hosted director postcheck: PASS");
+  console.log(`plants: ${result.plants.map((plant) => plant.code).join(",")}`);
+  console.log(`director-state: ${result.directorState} (${result.activeDirectors})`);
+}
+
+main().catch((error) => {
+  console.error(`GREENATICS hosted director postcheck: FAIL · ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/hosted-director-postcheck.test.mjs
+++ b/scripts/hosted-director-postcheck.test.mjs
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { BackendPreflightError, runHostedBackendPreflight } from "./hosted-backend-preflight-lib.mjs";
+
+const env = {
+  NEXT_PUBLIC_SUPABASE_URL: "https://sanitized-project.supabase.co",
+  SUPABASE_SECRET_KEY: "sanitized-server-secret",
+};
+
+function fakeClient(activeDirectors) {
+  return {
+    rpc: vi.fn(async () => ({
+      data: [{
+        schema_contract: "0026",
+        public_table_count: 30,
+        rls_enabled_table_count: 30,
+        pilot_plant_codes: ["TAM", "YAR"],
+        active_directors: activeDirectors,
+      }],
+      error: null,
+    })),
+    auth: { admin: { listUsers: vi.fn(async () => ({ data: { users: [] }, error: null })) } },
+    from(table) {
+      if (table === "plants") {
+        return {
+          select() {
+            return {
+              async in() {
+                return {
+                  data: [
+                    { code: "TAM", name: "Támesis", active: true },
+                    { code: "YAR", name: "Yarumal", active: true },
+                  ],
+                  error: null,
+                };
+              },
+            };
+          },
+        };
+      }
+      if (table === "plant_memberships") {
+        return {
+          select() {
+            const response = { data: null, count: activeDirectors, error: null };
+            const chain = {
+              eq() { return chain; },
+              then(resolve, reject) { return Promise.resolve(response).then(resolve, reject); },
+            };
+            return chain;
+          },
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+describe("hosted director post-bootstrap gate", () => {
+  it("fails closed when a director is required but none exists", async () => {
+    await expect(runHostedBackendPreflight({
+      env,
+      requireDirector: true,
+      createClientImpl: () => fakeClient(0),
+    })).rejects.toThrow(/No existe ningún director activo/);
+  });
+
+  it("passes when a director is required and memberships exist", async () => {
+    const result = await runHostedBackendPreflight({
+      env,
+      requireDirector: true,
+      createClientImpl: () => fakeClient(2),
+    });
+    expect(result.directorState).toBe("present");
+    expect(result.activeDirectors).toBe(2);
+  });
+
+  it("rejects contradictory director requirements before touching the backend", async () => {
+    const createClientImpl = vi.fn(() => fakeClient(0));
+    await expect(runHostedBackendPreflight({
+      env,
+      requireDirector: true,
+      requireNoDirector: true,
+      createClientImpl,
+    })).rejects.toBeInstanceOf(BackendPreflightError);
+    expect(createClientImpl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds a fail-closed post-bootstrap Director presence gate for the hosted pilot. Includes a dedicated postcheck script and unit coverage for missing Director, present Director, and contradictory requirements. No schema, auth policy, or user data changes.