### PR TITLE
Public v0.24 · Canonical robots contract

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,16 +1,24 @@
 import type { MetadataRoute } from "next";
-import { internalRoutePrefixes, publicSite } from "@/data/public-site";
+import { publicSite } from "@/data/public-site";
+import { protectedOpsRoutePrefixes } from "@/lib/ops-access-policy";
+
+const nonIndexableRoutePrefixes = [
+  ...protectedOpsRoutePrefixes,
+  "/login",
+  "/auth/",
+  "/api/",
+] as const;
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = publicSite.publicDomainTarget.replace(/\/$/, "");
-
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-      disallow: [...internalRoutePrefixes, "/api/"],
-    },
-    sitemap: `${baseUrl}/sitemap.xml`,
-    host: baseUrl,
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [...nonIndexableRoutePrefixes],
+      },
+    ],
+    sitemap: `${publicSite.publicDomainTarget}/sitemap.xml`,
+    host: publicSite.publicDomainTarget,
   };
 }

--- a/src/data/public-indexing.test.ts
+++ b/src/data/public-indexing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import sitemap from "../app/sitemap";
 import robots from "../app/robots";
+import { protectedOpsRoutePrefixes } from "../lib/ops-access-policy";
 import { publicNav, publicSite, publicStaticRoutes } from "./public-site";
 import { services } from "./services";
 import { publicProjects } from "./projects-public";
@@ -26,14 +27,19 @@ describe("public navigation and indexing contract", () => {
     expect(urls.some((url) => url.includes("/dashboard"))).toBe(false);
   });
 
-  it("keeps internal operation prefixes out of crawlable paths", () => {
+  it("derives robots exclusions from live OPS routes and auth utilities", () => {
     const config = robots();
     const rules = Array.isArray(config.rules) ? config.rules : [config.rules];
     const disallow = rules.flatMap((rule) => Array.isArray(rule.disallow) ? rule.disallow : rule.disallow ? [rule.disallow] : []);
 
-    for (const path of ["/app", "/dashboard", "/login", "/receptions", "/sales", "/supplies", "/api/"]) {
+    for (const path of [...protectedOpsRoutePrefixes, "/login", "/auth/", "/api/"]) {
       expect(disallow).toContain(path);
     }
+    for (const path of publicStaticRoutes) expect(disallow).not.toContain(path);
+    for (const stalePath of ["/maintenance", "/purchase-requests", "/settlements", "/suppliers"]) {
+      expect(disallow).not.toContain(stalePath);
+    }
+    expect(disallow).toHaveLength(new Set(disallow).size);
     expect(config.sitemap).toBe(`${publicSite.publicDomainTarget}/sitemap.xml`);
   });
 });

--- a/src/data/public-site.ts
+++ b/src/data/public-site.ts
@@ -1,3 +1,5 @@
+import { protectedOpsRoutePrefixes } from "@/lib/ops-access-policy";
+
 export const publicSite = {
   name: "Greenatics",
   publicDomainTarget: "https://greenatics.com.co",
@@ -61,4 +63,11 @@ export const publicStaticRoutes = [
   "/biblioteca/guia-deficiencias",
   "/nosotros",
   "/contacto",
+] as const;
+
+export const internalRoutePrefixes = [
+  ...protectedOpsRoutePrefixes,
+  "/login",
+  "/auth",
+  "/api",
 ] as const;

--- a/src/data/public-site.ts
+++ b/src/data/public-site.ts
@@ -62,28 +62,3 @@ export const publicStaticRoutes = [
   "/nosotros",
   "/contacto",
 ] as const;
-
-export const internalRoutePrefixes = [
-  "/app",
-  "/activities",
-  "/calendar",
-  "/cash",
-  "/compost",
-  "/dashboard",
-  "/documents",
-  "/equipment",
-  "/expenses",
-  "/finance",
-  "/imports",
-  "/inventory",
-  "/login",
-  "/maintenance",
-  "/production",
-  "/purchase-requests",
-  "/purchases",
-  "/receptions",
-  "/sales",
-  "/settlements",
-  "/suppliers",
-  "/supplies",
-] as const;


### PR DESCRIPTION
## Objetivo
Eliminar el drift entre `robots.txt` y las superficies OPS reales sin modificar autenticación, autorización, Supabase ni el matcher del proxy.

## Cambio
- `robots.ts` deriva ahora las familias privadas directamente de `protectedOpsRoutePrefixes`, el contrato canónico de acceso OPS.
- Se excluyen explícitamente del rastreo `/login`, `/auth/` y `/api/` aunque no sean rutas OPS protegidas.
- Se elimina de `public-site.ts` el inventario duplicado `internalRoutePrefixes`.
- Se eliminan de la política robots los prefijos obsoletos sin ruta App Router actual: `/maintenance`, `/purchase-requests`, `/settlements`, `/suppliers`.
- La regresión exige que toda ruta OPS protegida esté en `Disallow`, que las rutas públicas gobernadas no lo estén y que no existan duplicados.

## Seguridad
No cambia qué rutas requieren sesión. `src/proxy.ts`, RLS, Supabase y la política de autorización permanecen intactos. `robots.txt` es únicamente una política de indexación, no un control de acceso.

## Certificación
Mismos gates canónicos: quality, database, desktop Chromium y mobile Chromium.