### PR TITLE
Public v0.25 · Solution breadcrumb structured data

### DIFF
--- a/src/app/soluciones/[slug]/page.tsx
+++ b/src/app/soluciones/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
 import { getService, services } from "@/data/services";
 import styles from "../solutions.module.css";
 
@@ -28,6 +29,11 @@ export default async function SolutionDetailPage({ params }: Props) {
 
   return (
     <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Soluciones", path: "/soluciones" },
+        { name: service.name, path: `/soluciones/${service.slug}` as `/${string}` },
+      ]} />
       <main>
         <section className={styles.detailHero}>
           <div className={styles.heroAccent} aria-hidden="true" />


### PR DESCRIPTION
## Objetivo
Extender el contrato de datos estructurados a las páginas dinámicas de Soluciones reutilizando el componente `BreadcrumbJsonLd` ya usado por Proyectos.

## Cambio
- cada `/soluciones/<slug>` emite una única jerarquía `Greenatics → Soluciones → solución`;
- las URLs se generan de forma absoluta por el componente canónico existente;
- no cambian HTML visible, estilos, copy, canonical, sitemap, robots, OPS, auth ni Supabase.

## Alcance
Esta iteración queda deliberadamente limitada a Soluciones. La auditoría detectó también oportunidades en Cultivos y la guía técnica, pero las escrituras de esos archivos y del test JSON-LD adicional fueron bloqueadas por la capa del conector; no se declaran resueltas en este PR.

## Certificación
Se conservan sin cambios los cuatro gates existentes: quality, database, desktop Chromium y mobile Chromium.