### PR TITLE
Public v0.26 · Complete structured breadcrumb coverage

### DIFF
--- a/e2e/public-solutions.spec.ts
+++ b/e2e/public-solutions.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from "@playwright/test";
 
+async function jsonLdByType(page: import("@playwright/test").Page, type: string) {
+  const payloads = await page.locator('script[type="application/ld+json"]').allTextContents();
+  return payloads
+    .map((payload) => JSON.parse(payload) as Record<string, unknown>)
+    .filter((payload) => payload["@type"] === type);
+}
+
 test("solutions hub exposes the governed service architecture", async ({ page }) => {
   await page.goto("/soluciones");
 
@@ -10,7 +17,7 @@ test("solutions hub exposes the governed service architecture", async ({ page })
   await expect(page.getByRole("link", { name: /Ver solución en profundidad/i }).first()).toHaveAttribute("href", /\/soluciones\//);
 });
 
-test("solution detail preserves problem, scope and deliverables", async ({ page }) => {
+test("solution detail preserves problem, scope, deliverables and breadcrumb semantics", async ({ page }) => {
   await page.goto("/soluciones/diagnostico-caracterizacion");
 
   await expect(page.getByRole("heading", { name: "Diagnóstico y caracterización de residuos orgánicos" })).toBeVisible();
@@ -18,6 +25,11 @@ test("solution detail preserves problem, scope and deliverables", async ({ page 
   await expect(page.getByRole("heading", { name: "Qué puede incluir" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Entregables típicos" })).toBeVisible();
   await expect(page.getByText("línea base", { exact: true })).toBeVisible();
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(breadcrumbs).toHaveLength(1);
+  expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/diagnostico-caracterizacion");
+  expect(JSON.stringify(breadcrumbs[0])).toContain("Diagnóstico y caracterización de residuos orgánicos");
 });
 
 test("public solutions route keeps the bridge to OPS", async ({ page }) => {

--- a/e2e/wondergreen-crops.spec.ts
+++ b/e2e/wondergreen-crops.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from "@playwright/test";
 
+async function jsonLdByType(page: import("@playwright/test").Page, type: string) {
+  const payloads = await page.locator('script[type="application/ld+json"]').allTextContents();
+  return payloads
+    .map((payload) => JSON.parse(payload) as Record<string, unknown>)
+    .filter((payload) => payload["@type"] === type);
+}
+
 test("Wondergreen exposes exact liquid portfolio and technical statuses", async ({ page }) => {
   await page.goto("/wondergreen");
 
@@ -18,7 +25,7 @@ test("crop library exposes the five initial programs", async ({ page }) => {
   }
 });
 
-test("cacao program connects stage guidance to the product master", async ({ page }) => {
+test("cacao program connects stage guidance to the product master and canonical breadcrumb", async ({ page }) => {
   await page.goto("/wondergreen/cultivos/cacao");
 
   await expect(page.getByText(/01 · Establecimiento/)).toBeVisible();
@@ -26,4 +33,12 @@ test("cacao program connects stage guidance to the product master", async ({ pag
   await expect(page.getByText("2Grow", { exact: true }).first()).toBeVisible();
   await expect(page.getByRole("heading", { name: /Referencias que aparecen en este programa/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: /2Grow Sólido · 15-3-3/i })).toBeVisible();
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(breadcrumbs).toHaveLength(1);
+  const serialized = JSON.stringify(breadcrumbs[0]);
+  expect(serialized).toContain("https://greenatics.com.co/wondergreen/cultivos/cacao");
+  expect(serialized).toContain("Wondergreen");
+  expect(serialized).toContain("Cultivos");
+  expect(serialized).toContain("Cacao");
 });

--- a/src/app/biblioteca/guia-deficiencias/layout.tsx
+++ b/src/app/biblioteca/guia-deficiencias/layout.tsx
@@ -1,9 +1,19 @@
 import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
 
 export const metadata: Metadata = {
   alternates: { canonical: "/biblioteca/guia-deficiencias" },
 };
 
 export default function DeficiencyGuideLayout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Biblioteca", path: "/biblioteca" },
+        { name: "Guía práctica de deficiencias", path: "/biblioteca/guia-deficiencias" },
+      ]} />
+      {children}
+    </>
+  );
 }

--- a/src/app/wondergreen/cultivos/[slug]/layout.tsx
+++ b/src/app/wondergreen/cultivos/[slug]/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
 import { getWondergreenCrop } from "@/data/wondergreen-crops";
 
 type Props = {
@@ -15,6 +16,20 @@ export async function generateMetadata({ params }: Pick<Props, "params">): Promi
   };
 }
 
-export default function WondergreenCropLayout({ children }: Props) {
-  return children;
+export default async function WondergreenCropLayout({ children, params }: Props) {
+  const { slug } = await params;
+  const crop = getWondergreenCrop(slug);
+  if (!crop) return children;
+
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Wondergreen", path: "/wondergreen" },
+        { name: "Cultivos", path: "/wondergreen/cultivos" },
+        { name: crop.name, path: `/wondergreen/cultivos/${crop.slug}` as `/${string}` },
+      ]} />
+      {children}
+    </>
+  );
 }


### PR DESCRIPTION
## Objetivo
Cerrar la cobertura pendiente de `BreadcrumbList` en superficies públicas jerárquicas sin cambiar copy, estilos, canonical, OPS, auth ni datos técnicos.

## Cambios
- `/wondergreen/cultivos/<slug>` emite `Greenatics → Wondergreen → Cultivos → cultivo`;
- `/biblioteca/guia-deficiencias` emite `Greenatics → Biblioteca → Guía práctica de deficiencias`;
- la regresión E2E de Cultivos exige un único `BreadcrumbList` y URL absoluta canónica;
- la regresión E2E de Soluciones ahora valida explícitamente el breadcrumb incorporado en v0.25.

## Alcance y límites
- no se modifica contenido agronómico ni Product Truth;
- no se modifica el shell público ni la navegación;
- el ajuste de foco del skip-link sigue pendiente porque la capa de escritura bloqueó ese archivo;
- la escritura de la aserción específica de breadcrumb de la guía también fue bloqueada; la ruta sigue recorrida por los browser gates existentes.

## Certificación requerida
- quality
- database
- desktop Chromium
- mobile Chromium

Refs #118