### PR TITLE
Public v0.27 · Accessible skip-link focus flow

### DIFF
--- a/e2e/public-foundation.spec.ts
+++ b/e2e/public-foundation.spec.ts
@@ -15,6 +15,24 @@ test("public HOME emits governed Organization structured data", async ({ page })
   expect(JSON.stringify(organization)).not.toContain("VERCEL_URL");
 });
 
+test("public skip-link moves keyboard focus into main content", async ({ page }) => {
+  await page.goto("/");
+
+  const skipLink = page.getByRole("link", { name: "Saltar al contenido" });
+  const main = page.locator("#public-main");
+
+  await page.keyboard.press("Tab");
+  await expect(skipLink).toBeFocused();
+  await expect(skipLink).toBeVisible();
+
+  await page.keyboard.press("Enter");
+  await expect(page).toHaveURL(/#public-main$/);
+  await expect(main).toBeFocused();
+
+  await page.keyboard.press("Tab");
+  expect(await main.evaluate((element) => element.contains(document.activeElement))).toBe(true);
+});
+
 test("manifest uses governed site content without inherited color claims", async ({ request }) => {
   const response = await request.get("/manifest.webmanifest");
   expect(response.ok()).toBe(true);

--- a/src/components/public-shell.tsx
+++ b/src/components/public-shell.tsx
@@ -30,7 +30,7 @@ export function PublicShell({ children }: { children: React.ReactNode }) {
         </div>
       </header>
 
-      <div id="public-main" className={styles.main}>{children}</div>
+      <div id="public-main" className={styles.main} tabIndex={-1}>{children}</div>
 
       <footer className={styles.footer}>
         <div className={styles.footerGrid}>


### PR DESCRIPTION
## Objetivo
Cerrar la deuda de accesibilidad del skip-link público sin cambiar diseño, navegación, copy, OPS ni auth.

## Cambio
- `#public-main` pasa a ser programáticamente enfocable mediante `tabIndex={-1}` sin entrar en el orden normal de tabulación;
- se añade una regresión Playwright que reproduce el flujo de teclado completo: primer Tab → `Saltar al contenido` → Enter → foco en `#public-main` → siguiente Tab continúa dentro del contenido.

## Alcance
- no cambia el aspecto visual normal del shell;
- no cambia SEO, canonical, robots ni structured data;
- no toca GREENATICS OPS.

## Certificación requerida
- quality
- database
- desktop Chromium
- mobile Chromium

Closes #121