### PR TITLE
Public v0.28 · Canonical main landmark

### DIFF
--- a/e2e/public-foundation.spec.ts
+++ b/e2e/public-foundation.spec.ts
@@ -15,11 +15,19 @@ test("public HOME emits governed Organization structured data", async ({ page })
   expect(JSON.stringify(organization)).not.toContain("VERCEL_URL");
 });
 
+test("public shell exposes one canonical main landmark", async ({ page }) => {
+  await page.goto("/");
+
+  const main = page.getByRole("main");
+  await expect(main).toHaveCount(1);
+  await expect(main).toHaveAttribute("id", "public-main");
+});
+
 test("public skip-link moves keyboard focus into main content", async ({ page }) => {
   await page.goto("/");
 
   const skipLink = page.getByRole("link", { name: "Saltar al contenido" });
-  const main = page.locator("#public-main");
+  const main = page.getByRole("main");
 
   await page.keyboard.press("Tab");
   await expect(skipLink).toBeFocused();

--- a/src/components/public-shell.tsx
+++ b/src/components/public-shell.tsx
@@ -30,7 +30,7 @@ export function PublicShell({ children }: { children: React.ReactNode }) {
         </div>
       </header>
 
-      <div id="public-main" className={styles.main} tabIndex={-1}>{children}</div>
+      <main id="public-main" className={styles.main} tabIndex={-1}>{children}</main>
 
       <footer className={styles.footer}>
         <div className={styles.footerGrid}>


### PR DESCRIPTION
## Objetivo
Completar la semántica del shell público después de v0.27: el destino del skip-link ya es enfocable, pero todavía era un `div` genérico.

## Cambio
- `#public-main` pasa de `<div>` a `<main>` conservando clase, id y `tabIndex={-1}`;
- se añade una regresión que exige exactamente un landmark `main` con `id=public-main`;
- la prueba de teclado existente ahora usa el landmark semántico y conserva el flujo Tab → skip-link → Enter → main → contenido.

## Evidencia previa
La búsqueda de código del repo no encontró otros elementos `<main>`, por lo que el cambio no introduce landmarks `main` anidados.

## Alcance
- sin cambios visuales;
- sin cambios de navegación o copy;
- sin cambios SEO/canonical/robots/structured data;
- sin cambios OPS/auth/Supabase.

## Certificación requerida
- quality
- database
- desktop Chromium
- mobile Chromium