### PR TITLE
Public v0.29 · One main landmark across public routes

### DIFF
--- a/e2e/public-foundation.spec.ts
+++ b/e2e/public-foundation.spec.ts
@@ -1,5 +1,21 @@
 import { test, expect } from "@playwright/test";
 
+const publicRoutes = [
+  "/",
+  "/soluciones",
+  "/soluciones/diagnostico-caracterizacion",
+  "/wondergreen",
+  "/wondergreen/cultivos",
+  "/wondergreen/cultivos/cafe",
+  "/proyectos",
+  "/proyectos/yarumal",
+  "/impacto",
+  "/biblioteca",
+  "/biblioteca/guia-deficiencias",
+  "/nosotros",
+  "/contacto",
+] as const;
+
 async function jsonLdByType(page: import("@playwright/test").Page, type: string) {
   const payloads = await page.locator('script[type="application/ld+json"]').allTextContents();
   return payloads.map((payload) => JSON.parse(payload) as Record<string, unknown>).find((payload) => payload["@type"] === type);
@@ -15,30 +31,51 @@ test("public HOME emits governed Organization structured data", async ({ page })
   expect(JSON.stringify(organization)).not.toContain("VERCEL_URL");
 });
 
-test("public shell exposes one canonical main landmark", async ({ page }) => {
-  await page.goto("/");
+for (const route of publicRoutes) {
+  test(`public main landmark contract: ${route}`, async ({ page }) => {
+    await page.goto(route);
+    await expect(page.getByRole("main")).toHaveCount(1);
+    await expect(page.locator("#public-main")).toHaveCount(1);
+  });
+}
 
-  const main = page.getByRole("main");
-  await expect(main).toHaveCount(1);
-  await expect(main).toHaveAttribute("id", "public-main");
-});
-
-test("public skip-link moves keyboard focus into main content", async ({ page }) => {
+test("public HOME skip-link moves keyboard focus into the shell-owned main", async ({ page }) => {
   await page.goto("/");
 
   const skipLink = page.getByRole("link", { name: "Saltar al contenido" });
-  const main = page.getByRole("main");
+  const target = page.locator("#public-main");
 
+  await expect(target).toHaveRole("main");
   await page.keyboard.press("Tab");
   await expect(skipLink).toBeFocused();
   await expect(skipLink).toBeVisible();
 
   await page.keyboard.press("Enter");
   await expect(page).toHaveURL(/#public-main$/);
-  await expect(main).toBeFocused();
+  await expect(target).toBeFocused();
 
   await page.keyboard.press("Tab");
-  expect(await main.evaluate((element) => element.contains(document.activeElement))).toBe(true);
+  expect(await target.evaluate((element) => element.contains(document.activeElement))).toBe(true);
+});
+
+test("public nested route skip-link focuses shell target and continues into page main", async ({ page }) => {
+  await page.goto("/soluciones");
+
+  const skipLink = page.getByRole("link", { name: "Saltar al contenido" });
+  const target = page.locator("#public-main");
+  const main = page.getByRole("main");
+
+  await expect(target).not.toHaveRole("main");
+  await expect(main).toHaveCount(1);
+
+  await page.keyboard.press("Tab");
+  await expect(skipLink).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(page).toHaveURL(/#public-main$/);
+  await expect(target).toBeFocused();
+
+  await page.keyboard.press("Tab");
+  expect(await target.evaluate((element) => element.contains(document.activeElement))).toBe(true);
 });
 
 test("manifest uses governed site content without inherited color claims", async ({ request }) => {

--- a/src/app/biblioteca/layout.tsx
+++ b/src/app/biblioteca/layout.tsx
@@ -6,5 +6,5 @@ export const metadata: Metadata = {
 };
 
 export default function KnowledgeLayout({ children }: { children: React.ReactNode }) {
-  return <PublicShell>{children}</PublicShell>;
+  return <PublicShell ownsMain={false}>{children}</PublicShell>;
 }

--- a/src/app/contacto/layout.tsx
+++ b/src/app/contacto/layout.tsx
@@ -6,5 +6,5 @@ export const metadata: Metadata = {
 };
 
 export default function ContactLayout({ children }: { children: React.ReactNode }) {
-  return <PublicShell>{children}</PublicShell>;
+  return <PublicShell ownsMain={false}>{children}</PublicShell>;
 }

--- a/src/app/impacto/layout.tsx
+++ b/src/app/impacto/layout.tsx
@@ -6,5 +6,5 @@ export const metadata: Metadata = {
 };
 
 export default function ImpactLayout({ children }: { children: React.ReactNode }) {
-  return <PublicShell>{children}</PublicShell>;
+  return <PublicShell ownsMain={false}>{children}</PublicShell>;
 }

--- a/src/app/nosotros/layout.tsx
+++ b/src/app/nosotros/layout.tsx
@@ -6,5 +6,5 @@ export const metadata: Metadata = {
 };
 
 export default function CompanyLayout({ children }: { children: React.ReactNode }) {
-  return <PublicShell>{children}</PublicShell>;
+  return <PublicShell ownsMain={false}>{children}</PublicShell>;
 }

--- a/src/app/proyectos/layout.tsx
+++ b/src/app/proyectos/layout.tsx
@@ -1,5 +1,5 @@
 import { PublicShell } from "@/components/public-shell";
 
 export default function ProjectsLayout({ children }: { children: React.ReactNode }) {
-  return <PublicShell>{children}</PublicShell>;
+  return <PublicShell ownsMain={false}>{children}</PublicShell>;
 }

--- a/src/app/soluciones/layout.tsx
+++ b/src/app/soluciones/layout.tsx
@@ -1,5 +1,5 @@
 import { PublicShell } from "@/components/public-shell";
 
 export default function SolutionsLayout({ children }: { children: React.ReactNode }) {
-  return <PublicShell>{children}</PublicShell>;
+  return <PublicShell ownsMain={false}>{children}</PublicShell>;
 }

--- a/src/app/wondergreen/layout.tsx
+++ b/src/app/wondergreen/layout.tsx
@@ -1,5 +1,5 @@
 import { PublicShell } from "@/components/public-shell";
 
 export default function WondergreenLayout({ children }: { children: React.ReactNode }) {
-  return <PublicShell>{children}</PublicShell>;
+  return <PublicShell ownsMain={false}>{children}</PublicShell>;
 }

--- a/src/components/public-shell.tsx
+++ b/src/components/public-shell.tsx
@@ -4,7 +4,18 @@ import { OrganizationJsonLd } from "@/components/organization-json-ld";
 import { publicFooterNav, publicNav, publicSite } from "@/data/public-site";
 import styles from "./public-shell.module.css";
 
-export function PublicShell({ children }: { children: React.ReactNode }) {
+type PublicShellProps = {
+  children: React.ReactNode;
+  ownsMain?: boolean;
+};
+
+export function PublicShell({ children, ownsMain = true }: PublicShellProps) {
+  const content = ownsMain ? (
+    <main id="public-main" className={styles.main} tabIndex={-1}>{children}</main>
+  ) : (
+    <div id="public-main" className={styles.main} tabIndex={-1}>{children}</div>
+  );
+
   return (
     <div className={styles.site}>
       <OrganizationJsonLd />
@@ -30,7 +41,7 @@ export function PublicShell({ children }: { children: React.ReactNode }) {
         </div>
       </header>
 
-      <main id="public-main" className={styles.main} tabIndex={-1}>{children}</main>
+      {content}
 
       <footer className={styles.footer}>
         <div className={styles.footerGrid}>


### PR DESCRIPTION
## Problema detectado
v0.28 convirtió el contenedor del `PublicShell` en `<main>`, pero la auditoría posterior confirmó que varias páginas públicas ya poseían su propio `<main>`. Eso producía landmarks `main` anidados en Soluciones, Wondergreen, Cultivos, Proyectos, Impacto, Biblioteca, Nosotros y Contacto.

## Solución
- `PublicShell` incorpora un contrato explícito `ownsMain`;
- HOME conserva `ownsMain=true` por defecto porque no posee un `<main>` local;
- las siete familias cuyos pages ya poseen `<main>` usan `ownsMain={false}`, por lo que el shell conserva `#public-main` como contenedor neutro y enfocable;
- no se modifica ninguna página grande ni su estructura visual.

## Regresión
`e2e/public-foundation.spec.ts` recorre las mismas 13 rutas del contrato SEO y exige:
- exactamente un landmark `main` por ruta;
- exactamente un `#public-main` por ruta;
- HOME: el skip-link enfoca el `main` propiedad del shell;
- ruta anidada (`/soluciones`): el skip-link enfoca el contenedor del shell y la tabulación continúa hacia el `main` de la página.

## Alcance
- sin cambios visuales o CSS;
- sin cambios de copy;
- sin cambios SEO/canonical/robots/structured data;
- sin cambios OPS/auth/Supabase.

## Certificación requerida
- quality
- database
- desktop Chromium
- mobile Chromium