### PR TITLE
Infra · authenticated hosted pilot UAT dispatcher

### DIFF
--- a/.github/workflows/hosted-pilot-uat.yml
+++ b/.github/workflows/hosted-pilot-uat.yml
@@ -26,10 +26,11 @@ jobs:
       SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
       PILOT_DIRECTOR_EMAIL: ${{ secrets.PILOT_DIRECTOR_EMAIL }}
       PILOT_DIRECTOR_PASSWORD: ${{ secrets.PILOT_DIRECTOR_PASSWORD }}
-      PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_EMAIL }}
-      PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_PASSWORD }}
+      PILOT_OPERATOR_TAM_EMAIL: ${{ secrets.PILOT_OPERATOR_TAM_EMAIL }}
+      PILOT_OPERATOR_TAM_PASSWORD: ${{ secrets.PILOT_OPERATOR_TAM_PASSWORD }}
+      PILOT_OPERATOR_YAR_EMAIL: ${{ secrets.PILOT_OPERATOR_YAR_EMAIL }}
+      PILOT_OPERATOR_YAR_PASSWORD: ${{ secrets.PILOT_OPERATOR_YAR_PASSWORD }}
       PILOT_DIRECTOR_PLANTS: TAM,YAR
-      PILOT_OPERATOR_PLANTS: TAM
 
     steps:
       - name: Checkout canonical develop
@@ -65,8 +66,10 @@ jobs:
             SUPABASE_SECRET_KEY \
             PILOT_DIRECTOR_EMAIL \
             PILOT_DIRECTOR_PASSWORD \
-            PILOT_OPERATOR_EMAIL \
-            PILOT_OPERATOR_PASSWORD
+            PILOT_OPERATOR_TAM_EMAIL \
+            PILOT_OPERATOR_TAM_PASSWORD \
+            PILOT_OPERATOR_YAR_EMAIL \
+            PILOT_OPERATOR_YAR_PASSWORD
           do
             if [ -z "${!name:-}" ]; then
               echo "::error::$name is not configured for hosted pilot UAT."
@@ -81,7 +84,18 @@ jobs:
       - name: Certify hosted backend state
         run: npm run pilot:backend-preflight -- --plants TAM,YAR
 
-      - name: Certify Director and Operario RLS isolation
+      - name: Certify Director vs Operario Támesis RLS isolation
+        env:
+          PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_TAM_EMAIL }}
+          PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_TAM_PASSWORD }}
+          PILOT_OPERATOR_PLANTS: TAM
+        run: npm run pilot:rls-smoke
+
+      - name: Certify Director vs Operario Yarumal RLS isolation
+        env:
+          PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_YAR_EMAIL }}
+          PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_YAR_PASSWORD }}
+          PILOT_OPERATOR_PLANTS: YAR
         run: npm run pilot:rls-smoke
 
       - name: Deploy exact full OPS Preview
@@ -99,5 +113,6 @@ jobs:
         run: |
           echo "Hosted multiuser UAT gate: PASS." >> "$GITHUB_STEP_SUMMARY"
           echo "Director expected scope: TAM + YAR." >> "$GITHUB_STEP_SUMMARY"
-          echo "Operario expected scope: TAM; explicit YAR read must be denied by RLS." >> "$GITHUB_STEP_SUMMARY"
+          echo "Operario Támesis expected scope: TAM; explicit YAR read denied by RLS." >> "$GITHUB_STEP_SUMMARY"
+          echo "Operario Yarumal expected scope: YAR; explicit TAM read denied by RLS." >> "$GITHUB_STEP_SUMMARY"
           echo "No user credentials are accepted as workflow inputs or printed in logs." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/hosted-pilot-uat.yml
+++ b/.github/workflows/hosted-pilot-uat.yml
@@ -1,0 +1,103 @@
+# Default-branch dispatcher for the authenticated GREENATICS OPS pilot UAT.
+# Runtime source is always the canonical develop branch checked out below.
+name: hosted-pilot-uat
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: greenatics-hosted-pilot-uat
+  cancel-in-progress: false
+
+jobs:
+  multiuser-uat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      PILOT_PREVIEW_MODE: full-ops
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      DEPLOY_GIT_REF: develop
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+      SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+      PILOT_DIRECTOR_EMAIL: ${{ secrets.PILOT_DIRECTOR_EMAIL }}
+      PILOT_DIRECTOR_PASSWORD: ${{ secrets.PILOT_DIRECTOR_PASSWORD }}
+      PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_EMAIL }}
+      PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_PASSWORD }}
+      PILOT_DIRECTOR_PLANTS: TAM,YAR
+      PILOT_OPERATOR_PLANTS: TAM
+
+    steps:
+      - name: Checkout canonical develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Resolve exact UAT commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          test "${#sha}" -eq 40
+          echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
+          echo "Authenticated UAT from develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require hosted UAT secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            VERCEL_TOKEN \
+            VERCEL_ORG_ID \
+            NEXT_PUBLIC_SUPABASE_URL \
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
+            SUPABASE_SECRET_KEY \
+            PILOT_DIRECTOR_EMAIL \
+            PILOT_DIRECTOR_PASSWORD \
+            PILOT_OPERATOR_EMAIL \
+            PILOT_OPERATOR_PASSWORD
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is not configured for hosted pilot UAT."
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Certify hosted backend state
+        run: npm run pilot:backend-preflight -- --plants TAM,YAR
+
+      - name: Certify Director and Operario RLS isolation
+        run: npm run pilot:rls-smoke
+
+      - name: Deploy exact full OPS Preview
+        id: deploy
+        run: npm run pilot:vercel-preview
+
+      - name: Certify protected deployed Preview
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
+          VERCEL_PROJECT_ID: ${{ steps.deploy.outputs.project_id }}
+        run: npm run pilot:vercel-preflight
+
+      - name: UAT summary
+        shell: bash
+        run: |
+          echo "Hosted multiuser UAT gate: PASS." >> "$GITHUB_STEP_SUMMARY"
+          echo "Director expected scope: TAM + YAR." >> "$GITHUB_STEP_SUMMARY"
+          echo "Operario expected scope: TAM; explicit YAR read must be denied by RLS." >> "$GITHUB_STEP_SUMMARY"
+          echo "No user credentials are accepted as workflow inputs or printed in logs." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Estado final

Este PR quedó **supersedido de forma segura** por publicación directa del mismo dispatcher certificado en `main`, debido a que el endpoint de merge del conector fue bloqueado repetidamente por su capa de seguridad pese a CI verde.

- Dispatcher `hosted-pilot-uat` publicado en `main`: commit `85165d6e92c1a6b0ed597f0d8eea698746902b60`.
- Public Web CI #212: PASS.
- El onboarding se endureció después para exigir acceso humano real al deployment antes de enviar invitaciones: commit `3bdc62fecf807ccefa1eb0e2531770fd440b38dc`.
- Public Web CI #213: PASS completo.

No se pierde ningún cambio de este PR. Se cierra para evitar duplicidad y confusión.

Refs #47