### PR TITLE
Public v0.31 · Social metadata for solutions and projects

### DIFF
--- a/e2e/public-social.spec.ts
+++ b/e2e/public-social.spec.ts
@@ -1,9 +1,13 @@
 import { test, expect } from "@playwright/test";
 
 const routes = [
+  "/soluciones",
+  "/soluciones/diagnostico-caracterizacion",
   "/wondergreen",
   "/wondergreen/cultivos",
   "/wondergreen/cultivos/cafe",
+  "/proyectos",
+  "/proyectos/yarumal",
   "/impacto",
   "/biblioteca",
   "/biblioteca/guia-deficiencias",

--- a/src/app/proyectos/[slug]/layout.tsx
+++ b/src/app/proyectos/[slug]/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { getPublicProject } from "@/data/projects-public";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Pick<Props, "params">): Promise<Metadata> {
+  const { slug } = await params;
+  const project = getPublicProject(slug);
+  if (!project) return {};
+
+  const title = `${project.name} | Proyectos Greenatics`;
+  const description = project.summary;
+  const path = `/proyectos/${project.slug}` as `/${string}`;
+
+  return publicSocialMetadata({ title, description, path });
+}
+
+export default function ProjectMetadataLayout({ children }: Props) {
+  return children;
+}

--- a/src/app/proyectos/page.tsx
+++ b/src/app/proyectos/page.tsx
@@ -1,12 +1,17 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { publicProjects } from "@/data/projects-public";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import styles from "./projects.module.css";
 
+const title = "Proyectos | Greenatics";
+const description = "Casos documentados y aprendizajes Greenatics en operación, rehabilitación, tratamiento biológico, rutas selectivas y trazabilidad.";
+
 export const metadata: Metadata = {
-  title: "Proyectos | Greenatics",
-  description: "Casos documentados y aprendizajes Greenatics en operación, rehabilitación, tratamiento biológico, rutas selectivas y trazabilidad.",
+  title,
+  description,
   alternates: { canonical: "/proyectos" },
+  ...publicSocialMetadata({ title, description, path: "/proyectos" }),
 };
 
 const transferable = [

--- a/src/app/soluciones/[slug]/layout.tsx
+++ b/src/app/soluciones/[slug]/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { getService } from "@/data/services";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Pick<Props, "params">): Promise<Metadata> {
+  const { slug } = await params;
+  const service = getService(slug);
+  if (!service) return {};
+
+  const title = `${service.name} | Greenatics`;
+  const description = service.summary;
+  const path = `/soluciones/${service.slug}` as `/${string}`;
+
+  return publicSocialMetadata({ title, description, path });
+}
+
+export default function SolutionMetadataLayout({ children }: Props) {
+  return children;
+}

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -1,12 +1,17 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { companyServices, municipalServices, serviceCategories, services, type ServiceCategory } from "@/data/services";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import styles from "./solutions.module.css";
 
+const title = "Soluciones | Greenatics";
+const description = "Diagnóstico, planeación, rutas selectivas, plantas, operación y trazabilidad para municipios, ESP, empresas y grandes generadores.";
+
 export const metadata: Metadata = {
-  title: "Soluciones | Greenatics",
-  description: "Diagnóstico, planeación, rutas selectivas, plantas, operación y trazabilidad para municipios, ESP, empresas y grandes generadores.",
+  title,
+  description,
   alternates: { canonical: "/soluciones" },
+  ...publicSocialMetadata({ title, description, path: "/soluciones" }),
 };
 
 const categoryIntro: Record<ServiceCategory, string> = {


### PR DESCRIPTION
Completa Open Graph/Twitter para Soluciones y Proyectos sin herencia incorrecta: hubs con metadata propia y overrides dinámicos en `/soluciones/<slug>` y `/proyectos/<slug>`. Amplía la regresión social de 8 a 12 rutas. HOME y la futura imagen social aprobada permanecen separados en #129. Sin cambios visuales, canonical, OPS, auth o Supabase.