### PR TITLE
feat(public): biblioteca Wondergreen v2

### DIFF
--- a/src/app/biblioteca/criterios-nutricionales/page.tsx
+++ b/src/app/biblioteca/criterios-nutricionales/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { wondergreenCrops } from "@/data/wondergreen-crops";
+import styles from "../library.module.css";
+
+export const metadata: Metadata = {
+  title: "Criterios de revisión nutricional | Greenatics",
+  description:
+    "Criterios técnicos para revisar suelo, etapa, densidad, historial de fertilización y objetivo productivo antes de orientar un programa Wondergreen.",
+  alternates: { canonical: "/biblioteca/criterios-nutricionales" },
+};
+
+const criteria = [
+  ["Análisis de suelo", "Fecha, representatividad, pH, materia orgánica, nutrientes, acidez, textura, drenaje y profundidad efectiva.", "Distinguir si el lote necesita corrección, construcción, mantenimiento o recuperación."],
+  ["Etapa del cultivo", "Establecimiento, formación, crecimiento, floración, cuajado, llenado, cosecha, renovación o recuperación.", "Ordenar la prioridad fisiológica antes de elegir una familia de producto."],
+  ["Densidad y arreglo", "Plantas por hectárea, distancias, edad, sombreo, competencia o intensidad de uso.", "Entender demanda por área y cómo distribuir una aplicación."],
+  ["Historial de fertilización", "Fuentes, dosis, frecuencia, vía, épocas, mezclas, enmiendas y respuesta observada.", "Evitar duplicidades y reconocer posibles carencias, excesos o bloqueos."],
+  ["Objetivo productivo", "Rendimiento, calidad, calibre, biomasa, carga animal, sostenimiento, renovación o recuperación.", "Definir qué resultado se pretende mover y cómo se medirá."],
+] as const;
+
+export default function NutritionalReviewCriteriaPage() {
+  return (
+    <div className={styles.page}>
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Greenatics · criterio técnico</span>
+              <h1>Antes de recomendar, hay que entender el lote.</h1>
+              <p className={styles.lead}>
+                Una fórmula por sí sola no describe la necesidad del cultivo. Esta guía organiza la revisión mínima que conviene hacer antes de definir dosis, frecuencia, mezcla o vía de aplicación.
+              </p>
+            </div>
+            <aside className={styles.warning}>
+              <strong>Alcance.</strong>
+              <p>Es una herramienta de revisión técnica. No reemplaza análisis de suelo, análisis foliar, ficha técnica vigente ni criterio agronómico local.</p>
+            </aside>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.white}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Cinco variables</span>
+              <h2>La recomendación empieza con información, no con una bolsa.</h2>
+            </div>
+            <div className={styles.tableWrap} role="region" aria-label="Criterios de revisión nutricional" tabIndex={0}>
+              <table className={styles.table}>
+                <thead><tr><th>Variable</th><th>Qué revisar</th><th>Qué decisión orienta</th></tr></thead>
+                <tbody>
+                  {criteria.map(([variable, review, decision]) => (
+                    <tr key={variable}><td><strong>{variable}</strong></td><td>{review}</td><td>{decision}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Aplicación por cultivo</span>
+              <h2>La misma revisión cambia de énfasis según el sistema productivo.</h2>
+              <p>Los programas Wondergreen desarrollan esas diferencias por etapa, alertas y seguimiento.</p>
+            </div>
+            <div className={styles.libraryGrid}>
+              {wondergreenCrops.map((crop) => (
+                <article className={styles.libraryCard} key={crop.slug}>
+                  <span className={styles.status}>Programa por cultivo</span>
+                  <h3>{crop.name}</h3>
+                  <p>{crop.context}</p>
+                  <Link href={`/wondergreen/cultivos/${crop.slug}`}>Revisar {crop.name} →</Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.dark}`}>
+          <div className={styles.container}>
+            <div className={styles.sourceGrid}>
+              <div><span className={styles.eyebrow}>Principio de decisión</span><h2>Cuando falta una variable, la recomendación debe declararse orientativa.</h2></div>
+              <div><p>La web puede ayudar a ordenar la conversación y proponer referencias potencialmente relevantes, pero no debe fingir precisión cuando faltan suelo, etapa, historial o contexto del lote.</p><Link href="/biblioteca/guia-deficiencias">Complementar con guía de deficiencias →</Link></div>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.closing}>
+          <div className={`${styles.container} ${styles.closingInner}`}>
+            <div><span className={styles.eyebrow}>Wondergreen</span><h2>Pasa del criterio general al programa del cultivo.</h2></div>
+            <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen/cultivos">Explorar cultivos</Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/biblioteca/manual-uso-wondergreen/page.tsx
+++ b/src/app/biblioteca/manual-uso-wondergreen/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { fieldApplicationRules, fieldChecklist } from "@/data/wondergreen-crops";
+import styles from "../library.module.css";
+
+export const metadata: Metadata = {
+  title: "Manual de uso Wondergreen | Greenatics",
+  description:
+    "Ruta práctica para preparar, aplicar, registrar y hacer seguimiento al uso de Wondergreen sin convertir una guía general en una receta universal.",
+  alternates: { canonical: "/biblioteca/manual-uso-wondergreen" },
+};
+
+const route = [
+  ["01", "Leer el contexto", "Cultivo, etapa, objetivo, condición del suelo, agua, manejo previo y análisis disponibles."],
+  ["02", "Confirmar la referencia", "Producto, formato, versión técnica, vía permitida y condición comercial vigente."],
+  ["03", "Preparar la aplicación", "Equipo limpio, agua adecuada, mezcla homogénea y cantidad que realmente se aplicará."],
+  ["04", "Aplicar con criterio", "Evitar estrés severo, lluvia inminente y condiciones que reduzcan la consistencia del evento."],
+  ["05", "Registrar", "Fecha, lote, producto, vía, condición climática, observaciones y responsable."],
+  ["06", "Revisar y ajustar", "Observar respuesta, comparar con el objetivo y decidir el siguiente paso con evidencia."],
+] as const;
+
+const avoid = [
+  "Elegir una referencia únicamente por el número de su fórmula.",
+  "Convertir una guía general en una dosis automática para cualquier lote.",
+  "Mezclar productos sin revisar compatibilidad y sin una prueba previa cuando corresponda.",
+  "Aplicar sobre plantas severamente marchitas, suelo totalmente seco o con lluvia inmediata prevista.",
+  "Confundir un síntoma visual con un diagnóstico definitivo.",
+  "Repetir una aplicación sin registrar qué se hizo y qué ocurrió después.",
+] as const;
+
+export default function WondergreenUseManualPage() {
+  return (
+    <div className={styles.page}>
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Wondergreen · manual web</span>
+              <h1>Aplicar mejor empieza antes de abrir el producto.</h1>
+              <p className={styles.lead}>
+                Esta guía organiza una ruta común de uso y seguimiento. No reemplaza la ficha técnica vigente, el análisis del lote ni la recomendación agronómica específica.
+              </p>
+            </div>
+            <aside className={styles.warning}>
+              <strong>Regla de uso.</strong>
+              <p>Producto correcto + contexto correcto + aplicación consistente + seguimiento. Si falta información crítica, la decisión correcta es detener la receta y completar el diagnóstico.</p>
+            </aside>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.white}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Ruta de aplicación</span>
+              <h2>Seis momentos para convertir una aplicación en un proceso controlado.</h2>
+            </div>
+            <div className={styles.libraryGrid}>
+              {route.map(([number, title, copy]) => (
+                <article className={styles.libraryCard} key={number}>
+                  <span className={styles.status}>{number}</span>
+                  <h3>{title}</h3>
+                  <p>{copy}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Antes de aplicar</span>
+              <h2>Comprobaciones mínimas de campo.</h2>
+              <p>Estas preguntas ya forman parte de los programas Wondergreen por cultivo y ayudan a evitar recomendaciones descontextualizadas.</p>
+            </div>
+            <div className={styles.notes}>
+              {fieldChecklist.map((item) => <div className={styles.note} key={item}>{item}</div>)}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.white}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Ejecución</span>
+              <h2>Reglas comunes para una aplicación más consistente.</h2>
+            </div>
+            <div className={styles.notes}>
+              {fieldApplicationRules.map((item) => <div className={styles.note} key={item}>{item}</div>)}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.dark}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Errores a evitar</span>
+              <h2>Una buena recomendación también define qué no hacer.</h2>
+            </div>
+            <div className={styles.notes}>
+              {avoid.map((item) => <div className={styles.note} key={item}>{item}</div>)}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.closing}>
+          <div className={`${styles.container} ${styles.closingInner}`}>
+            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>Conecta el manual con el cultivo real.</h2></div>
+            <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen/cultivos">Ver programas por cultivo</Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/biblioteca/page.tsx
+++ b/src/app/biblioteca/page.tsx
@@ -4,49 +4,56 @@ import styles from "./library.module.css";
 
 export const metadata: Metadata = {
   title: "Biblioteca | Greenatics",
-  description: "Guías, programas por cultivo y herramientas técnicas de Greenatics y Wondergreen convertidas en conocimiento navegable.",
+  description: "Guías, programas por cultivo, manuales y herramientas técnicas de Greenatics y Wondergreen convertidas en conocimiento navegable.",
 };
 
 const resources = [
   {
     status: "Disponible",
     title: "Programas Wondergreen por cultivo",
-    copy: "Café, cacao, aguacate, limón Tahití y pastos con lectura por etapa, cautelas, alertas y seguimiento.",
+    copy: "Café, cacao, aguacate, limón Tahití y pastos con lectura por etapa, cautelas, alertas, producto relacionado y seguimiento.",
     href: "/wondergreen/cultivos",
     cta: "Explorar cultivos",
   },
   {
     status: "Disponible",
+    title: "Manual de uso Wondergreen",
+    copy: "Ruta común para revisar contexto, confirmar referencia, preparar, aplicar, registrar y hacer seguimiento sin convertir la guía en receta universal.",
+    href: "/biblioteca/manual-uso-wondergreen",
+    cta: "Abrir manual",
+  },
+  {
+    status: "Disponible",
+    title: "Criterios de revisión nutricional",
+    copy: "Suelo, etapa, densidad, historial de fertilización y objetivo productivo como cinco comprobaciones antes de cerrar una recomendación.",
+    href: "/biblioteca/criterios-nutricionales",
+    cta: "Revisar criterios",
+  },
+  {
+    status: "Disponible",
     title: "Guía práctica de deficiencias nutricionales",
-    copy: "Una herramienta de lectura visual inicial que obliga a revisar tejido, patrón del lote y contexto antes de recomendar.",
+    copy: "Lectura visual inicial de síntomas y confundidores que obliga a revisar tejido, patrón del lote y contexto antes de recomendar.",
     href: "/biblioteca/guia-deficiencias",
     cta: "Abrir guía",
   },
   {
-    status: "Integrado en Wondergreen",
-    title: "Más que NPK",
-    copy: "Matriz orgánica, formulación, oclusión y peletizado explicados con un claim gate que separa característica técnica de promesa agronómica.",
-    href: "/wondergreen#tecnologia",
-    cta: "Ver tecnología",
-  },
-  {
-    status: "En consolidación",
-    title: "Manual de uso Wondergreen",
-    copy: "Criterios comunes de aplicación, agua, compatibilidad, registro de eventos y seguimiento. Se publicará por versiones, no como receta universal.",
-    href: "/wondergreen/cultivos",
-    cta: "Ver criterios en cultivo",
-  },
-  {
-    status: "En consolidación",
+    status: "Product Master público",
     title: "Catálogo técnico gobernado",
-    copy: "Productos, formatos, presentaciones, estados comerciales y documentación vinculados al Product Master público.",
+    copy: "Familias, fórmulas, formatos y estado público de cada referencia conectados con el sistema Wondergreen y su versión técnica.",
     href: "/wondergreen#portafolio",
-    cta: "Ver Product Master",
+    cta: "Ver portafolio",
   },
   {
-    status: "Próxima capa",
-    title: "Diagnóstico orientativo",
-    copy: "Cultivo + etapa + necesidad + problema + contexto. El resultado será una ruta potencial, no una prescripción automática.",
+    status: "Tecnología",
+    title: "Más que NPK",
+    copy: "Matriz orgánica, formulación, oclusión y peletizado explicados separando característica técnica de promesa agronómica.",
+    href: "/wondergreen#tecnologia",
+    cta: "Entender la tecnología",
+  },
+  {
+    status: "Ruta orientativa",
+    title: "Wondergreen Finder",
+    copy: "Cultivo + etapa + necesidad + problema + contexto. El resultado orienta una ruta y deriva a asesoría cuando falta información.",
     href: "/wondergreen#finder",
     cta: "Conocer el Finder",
   },
@@ -61,7 +68,7 @@ export default function LibraryPage() {
             <div>
               <span className={styles.eyebrow}>Greenatics · conocimiento aplicado</span>
               <h1>La biblioteca no es un archivo. Es parte de la decisión.</h1>
-              <p className={styles.lead}>Convertimos guías, manuales y conocimiento técnico ya construido en rutas web conectadas con cultivos, productos, síntomas, evidencia y acompañamiento.</p>
+              <p className={styles.lead}>Guías, manuales y conocimiento técnico se convierten en rutas web conectadas con cultivos, productos, síntomas, evidencia y acompañamiento.</p>
             </div>
             <aside className={styles.warning}>
               <strong>Conocimiento antes que recomendación.</strong>
@@ -73,9 +80,9 @@ export default function LibraryPage() {
         <section className={`${styles.section} ${styles.white}`}>
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
-              <span className={styles.eyebrow}>Recursos</span>
-              <h2>De PDF aislado a sistema de conocimiento.</h2>
-              <p>Cada recurso tendrá estado, fuente y relación explícita con el Product Master o con una ruta técnica.</p>
+              <span className={styles.eyebrow}>Recursos disponibles</span>
+              <h2>De documentos aislados a un sistema de conocimiento.</h2>
+              <p>Cada recurso se conecta con el Product Master, una ruta agronómica o una decisión concreta. El estado visible evita presentar como definitivo lo que todavía requiere validación.</p>
             </div>
             <div className={styles.libraryGrid}>
               {resources.map((resource) => (
@@ -86,6 +93,22 @@ export default function LibraryPage() {
                   <Link href={resource.href}>{resource.cta} →</Link>
                 </article>
               ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Cómo usar la biblioteca</span>
+              <h2>Diagnosticar → entender → elegir → aplicar → medir.</h2>
+              <p>La navegación debe acompañar la decisión, no obligar al usuario a conocer de antemano el nombre del producto.</p>
+            </div>
+            <div className={styles.ruleGrid}>
+              <article className={styles.ruleCard}><span>01</span><h3>Diagnosticar</h3><p>Revisa síntomas, lote, suelo y posibles confundidores.</p></article>
+              <article className={styles.ruleCard}><span>02</span><h3>Entender etapa</h3><p>Ubica el momento fisiológico y el objetivo productivo.</p></article>
+              <article className={styles.ruleCard}><span>03</span><h3>Aplicar con criterio</h3><p>Confirma referencia, vía, equipo, condiciones y registro.</p></article>
+              <article className={styles.ruleCard}><span>04</span><h3>Medir y ajustar</h3><p>Observa respuesta y usa evidencia para decidir el siguiente evento.</p></article>
             </div>
           </div>
         </section>

--- a/src/data/public-site.ts
+++ b/src/data/public-site.ts
@@ -39,6 +39,7 @@ export const publicFooterNav = [
     links: [
       { href: "/wondergreen", label: "Wondergreen" },
       { href: "/wondergreen/cultivos", label: "Cultivos" },
+      { href: "/biblioteca/manual-uso-wondergreen", label: "Manual de uso" },
       { href: "/biblioteca", label: "Biblioteca" },
     ],
   },
@@ -61,6 +62,8 @@ export const publicStaticRoutes = [
   "/impacto",
   "/biblioteca",
   "/biblioteca/guia-deficiencias",
+  "/biblioteca/manual-uso-wondergreen",
+  "/biblioteca/criterios-nutricionales",
   "/nosotros",
   "/contacto",
 ] as const;


### PR DESCRIPTION
## Objetivo
Convertir la biblioteca pública en una capa útil y navegable de conocimiento, sin tocar GREENATICS OPS.

## Incluye
- nuevo Manual de uso Wondergreen;
- nuevos Criterios de revisión nutricional;
- Biblioteca reorganizada con recursos realmente disponibles;
- conexión con programas por cultivo, guía de deficiencias, Product Master, tecnología y Finder;
- registro de nuevas rutas públicas en sitemap/indexación;
- acceso al Manual desde el footer Agro.

## Guardrails
- no modifica rutas, datos ni autenticación de OPS;
- no inventa packshots, formulaciones, dosis ni claims;
- mantiene recomendación orientativa y escalamiento a criterio agronómico cuando falta contexto.

## Próxima wave
Fotografía/cultivos + media registry + fichas visuales de producto con activos oficiales verificables.