### PR TITLE
feat(wondergreen): consulta contextual de producto v4

### DIFF
--- a/e2e/wondergreen-products.spec.ts
+++ b/e2e/wondergreen-products.spec.ts
@@ -39,6 +39,26 @@ test("commercial product page shows reconciled state without inventing a packsho
   await expect(page.getByRole("link", { name: "Manual de uso Wondergreen" })).toHaveAttribute("href", "/biblioteca/manual-uso-wondergreen");
 });
 
+test("product consultation preserves the exact governed reference into contact", async ({ page }) => {
+  await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
+
+  const consult = page.getByRole("link", { name: "Consultar esta referencia" });
+  await expect(consult).toHaveAttribute("href", "/contacto?producto=2grow-solido-15-3-3#wondergreen");
+  await consult.click();
+
+  await expect(page.getByRole("heading", { name: "Estás consultando 2Grow Sólido 15-3-3." })).toBeVisible();
+  await expect(page.getByText("Referencia comercial reconciliada").first()).toBeVisible();
+  await expect(page.getByRole("link", { name: "Volver a la ficha" })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
+  await expect(page.getByRole("link", { name: "Agendar sobre esta referencia" })).toHaveAttribute("href", /^https:\/\/outlook\.office\.com\//);
+});
+
+test("unknown product context is ignored instead of fabricating a reference", async ({ page }) => {
+  await page.goto("/contacto?producto=referencia-inexistente#wondergreen");
+
+  await expect(page.getByRole("heading", { name: "Cuéntanos qué quieres transformar." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Estás consultando/ })).toHaveCount(0);
+});
+
 test("technical bioinput page does not pretend to be commercially available", async ({ page }) => {
   await page.goto("/wondergreen/productos/extracto-neem");
 

--- a/src/app/contacto/page.tsx
+++ b/src/app/contacto/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { publicSite } from "@/data/public-site";
+import { getWondergreenReference } from "@/data/wondergreen-public";
 import styles from "../company-public.module.css";
 
 export const metadata: Metadata = {
@@ -32,11 +33,44 @@ const wondergreenRoutes = [
   { id: "tecnico", title: "Soy agrónomo / técnico", copy: "Quiero revisar Product Master, guías, criterios de uso y soporte técnico del portafolio.", cta: "Revisar portafolio técnico" },
 ] as const;
 
-export default function ContactPage() {
+type ContactSearchParams = {
+  producto?: string | string[];
+};
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function ContactPage({ searchParams }: { searchParams: Promise<ContactSearchParams> }) {
+  const query = await searchParams;
+  const productSlug = firstParam(query.producto);
+  const product = productSlug ? getWondergreenReference(productSlug) : undefined;
+
   return (
     <div className={styles.page}>
       <main>
         <section className={styles.contactHero}><div className={`${styles.container} ${styles.contactGrid}`}><div><span className={styles.eyebrow} style={{color:"#c8f5ad"}}>Contacto Greenatics</span><h1>Cuéntanos qué quieres transformar.</h1><p className={styles.lead}>Podemos hablar de Wondergreen, gestión de residuos, proyectos municipales, plantas, rehabilitación, operación o soluciones para grandes generadores.</p></div><aside className={styles.contactPanel}><span>Reunión técnica</span><h2>Agenda directamente con el equipo.</h2><p>La conversación funciona mejor cuando llegamos con contexto mínimo. Usa la guía inferior y trae lo que ya tengas; no necesitas tener toda la información resuelta.</p><a className={`${styles.button} ${styles.primary}`} href={publicSite.bookingUrl} target="_blank" rel="noreferrer">Agendar reunión</a></aside></div></section>
+
+        {product ? (
+          <section className={`${styles.section} ${styles.soft}`} aria-label="Contexto de la consulta Wondergreen">
+            <div className={`${styles.container} ${styles.officeGrid}`}>
+              <div>
+                <span className={styles.eyebrow}>Consulta Wondergreen · referencia identificada</span>
+                <h2>Estás consultando {product.name}{product.formula ? ` ${product.formula}` : ""}.</h2>
+                <p className={styles.lead}>Conservamos la referencia al pasar desde el Product Master para que la conversación empiece por el producto correcto. La disponibilidad, versión, dosis y recomendación final se confirman con el contexto real del cultivo o del canal comercial.</p>
+                <div className={styles.actions}>
+                  <a className={`${styles.button} ${styles.primary}`} href={publicSite.bookingUrl} target="_blank" rel="noreferrer">Agendar sobre esta referencia</a>
+                  <Link className={`${styles.button} ${styles.ghost}`} href={`/wondergreen/productos/${product.slug}`}>Volver a la ficha</Link>
+                </div>
+              </div>
+              <aside className={styles.officeCard}>
+                <strong>{product.publicStatus}</strong>
+                <span>{product.stage}</span>
+                <span>{product.presentations?.length ? `Presentaciones documentadas: ${product.presentations.join(", ")}` : "Presentaciones por confirmar"}</span>
+              </aside>
+            </div>
+          </section>
+        ) : null}
 
         <section className={`${styles.section} ${styles.soft}`} id="wondergreen"><div className={styles.container}><div className={styles.sectionHead}><span className={styles.eyebrow}>Wondergreen · elige tu ruta</span><h2>La conversación cambia según quién está tomando la decisión.</h2><p>Producto, cultivo y canal comercial comparten el mismo Product Master, pero requieren preguntas y soporte diferentes.</p></div><div className={styles.ecosystem}>{wondergreenRoutes.map((route)=><a id={route.id} href={publicSite.bookingUrl} target="_blank" rel="noreferrer" key={route.id}><strong>{route.title}</strong><span>{route.copy}</span><small>{route.cta} →</small></a>)}</div></div></section>
 

--- a/src/app/wondergreen/productos/[slug]/page.tsx
+++ b/src/app/wondergreen/productos/[slug]/page.tsx
@@ -47,6 +47,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
 
   const crops = relatedCrops(reference.family);
   const isCommercial = reference.truthStatus === "commercial-reconciled";
+  const contactHref = `/contacto?producto=${encodeURIComponent(reference.slug)}#wondergreen`;
 
   return (
     <div className={styles.page}>
@@ -63,7 +64,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
                 <span>{reference.stage}</span>
               </div>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.primary}`} href="/contacto">Consultar esta referencia</Link>
+                <Link className={`${styles.button} ${styles.primary}`} href={contactHref}>Consultar esta referencia</Link>
                 {crops.length > 0 ? <Link className={`${styles.button} ${styles.ghost}`} href={`/wondergreen/cultivos/${crops[0].slug}`}>Ver en cultivo</Link> : null}
               </div>
             </div>
@@ -157,7 +158,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
         <section className={styles.closing}>
           <div className={`${styles.container} ${styles.closingInner}`}>
             <div><span className={styles.eyebrow}>Siguiente paso</span><h2>¿Quieres validar esta referencia para tu cultivo o negocio?</h2></div>
-            <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/contacto">Hablar con Greenatics</Link><Link className={`${styles.button} ${styles.ghost}`} href="/wondergreen">Ver Wondergreen</Link></div>
+            <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href={contactHref}>Hablar con Greenatics</Link><Link className={`${styles.button} ${styles.ghost}`} href="/wondergreen">Ver Wondergreen</Link></div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Scope
- Clean-history replacement for #137 after #139 and #140 were integrated into `develop`.
- Preserves the selected Wondergreen reference from product detail into `/contacto?producto=<slug>#wondergreen`.
- Contacto resolves only valid Product Master slugs and shows governed reference context: name, formula when applicable, public status, stage and documented presentations.
- Unknown or invalid product slugs fail closed into the general contact experience.
- Adds regression coverage for product → contact continuity and invalid-slug behavior.

## Safety / governance
- Exactly three public files applied as one commit on certified `develop`.
- No Product Truth, prices, formulations, presentations or product statuses are modified.
- No external prefill/send behavior is added.
- No OPS, Auth, Supabase, RLS, workflow or infrastructure changes.
- Availability, dose and recommendation remain subject to technical/commercial confirmation.

## History note
This PR supersedes #137, whose branch was stacked on the obsolete #136 history. The final functional blobs were rebuilt directly on the merged #140 base.