### PR TITLE
feat(public): HOME visual + programas de cultivo v5

### DIFF
--- a/e2e/public-editorial-home.spec.ts
+++ b/e2e/public-editorial-home.spec.ts
@@ -5,9 +5,24 @@ test("public HOME presents the editorial hierarchy and governed Yarumal evidence
 
   await expect(page.getByRole("heading", { name: /Transformar residuos en vida/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Más que NPK." })).toBeVisible();
-  await expect(page.getByRole("img", { name: "Vista aérea documentada del caso Greenatics en Yarumal" })).toBeVisible();
+  await expect(page.getByRole("img", { name: "Vista aérea documentada del caso Greenatics en Yarumal", exact: true })).toBeVisible();
+  await expect(page.getByRole("img", { name: "Segunda vista aérea documentada del caso Greenatics en Yarumal", exact: true })).toBeVisible();
+  await expect(page.getByText("2 activos conciliados", { exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: "Ver caso Yarumal →" })).toHaveAttribute("href", "/proyectos/yarumal");
   await expect(page.getByText(/Product Truth vigente/i)).toBeVisible();
+});
+
+test("public HOME exposes all five governed crop programs", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Cinco cultivos. Decisiones distintas según la etapa." })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Cacao/ })).toHaveAttribute("href", "/wondergreen/cultivos/cacao");
+  await expect(page.getByRole("link", { name: /Café/ })).toHaveAttribute("href", "/wondergreen/cultivos/cafe");
+  await expect(page.getByRole("link", { name: /Aguacate/ })).toHaveAttribute("href", "/wondergreen/cultivos/aguacate");
+  await expect(page.getByRole("link", { name: /Limón Tahití/ })).toHaveAttribute("href", "/wondergreen/cultivos/limon-tahiti");
+  await expect(page.getByRole("link", { name: /Pastos y gramíneas/ })).toHaveAttribute("href", "/wondergreen/cultivos/pastos-gramineas");
+  await expect(page.getByRole("link", { name: "Revisar criterios" })).toHaveAttribute("href", "/biblioteca/criterios-nutricionales");
+  await expect(page.getByRole("link", { name: "Ver Product Master" })).toHaveAttribute("href", "/wondergreen/productos");
 });
 
 test("public HOME keeps its primary routes explicit and separate from OPS", async ({ page }) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { HomeCropPrograms, HomeProjectEvidence } from "@/components/public-home-evidence-crops";
 import { PublicShell } from "@/components/public-shell";
-import { getPrimaryProjectMedia } from "@/data/public-media";
 import styles from "./public-home.module.css";
 
 export const metadata: Metadata = {
@@ -87,8 +87,6 @@ const knowledge = [
 ];
 
 export default function Home() {
-  const yarumalMedia = getPrimaryProjectMedia("yarumal");
-
   return (
     <PublicShell>
       <div className={styles.publicSite}>
@@ -195,6 +193,8 @@ export default function Home() {
           </div>
         </section>
 
+        <HomeCropPrograms />
+
         <section className={styles.paths} id="soluciones">
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
@@ -225,34 +225,7 @@ export default function Home() {
           </div>
         </section>
 
-        <section className={styles.evidence}>
-          <div className={`${styles.container} ${styles.evidenceGrid}`}>
-            {yarumalMedia ? (
-              <figure className={styles.evidenceMedia}>
-                <Image
-                  src={yarumalMedia.src}
-                  alt={yarumalMedia.alt}
-                  width={1200}
-                  height={900}
-                  sizes="(max-width: 900px) 100vw, 56vw"
-                />
-                <figcaption>{yarumalMedia.caption}</figcaption>
-              </figure>
-            ) : null}
-            <div className={styles.evidenceCopy}>
-              <span className={styles.eyebrow}>Experiencia que deja evidencia</span>
-              <h2>Proyecto, operación y aprendizaje en territorio.</h2>
-              <p>
-                La web incorpora material real de los proyectos para explicar lo que Greenatics ha construido y aprendido. Las fotografías históricas documentan experiencia; no se usan para afirmar capacidad, producción o estado actual sin una fuente vigente y aprobada.
-              </p>
-              <div className={styles.evidenceFacts}>
-                <div><span>Caso</span><strong>Yarumal</strong></div>
-                <div><span>Estado de publicación</span><strong>Evidencia visual conciliada</strong></div>
-              </div>
-              <Link className={styles.inlineLink} href="/proyectos/yarumal">Ver caso Yarumal →</Link>
-            </div>
-          </div>
-        </section>
+        <HomeProjectEvidence />
 
         <section className={styles.chain}>
           <div className={styles.container}>

--- a/src/components/public-home-evidence-crops.module.css
+++ b/src/components/public-home-evidence-crops.module.css
@@ -1,0 +1,460 @@
+.container {
+  width: min(1240px, calc(100% - 48px));
+  margin: 0 auto;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 16px;
+  color: var(--green);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.crops {
+  padding: 112px 0 104px;
+  background: #e9eee4;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.cropHeading {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  gap: 70px;
+  align-items: end;
+  margin-bottom: 48px;
+}
+
+.cropHeading h2,
+.evidenceCopy h2 {
+  margin: 0;
+  font-family: var(--display);
+  font-weight: 600;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  font-size: clamp(3rem, 5vw, 5.3rem);
+}
+
+.cropIntro p,
+.evidenceCopy > p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.72;
+}
+
+.cropIntro a {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  margin-top: 16px;
+  color: var(--green);
+  font-weight: 800;
+  border-bottom: 1px solid currentColor;
+}
+
+.cropGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.cropCard {
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 28px 24px;
+  border-right: 1px solid var(--line);
+  text-decoration: none;
+  transition: background-color 160ms ease, transform 160ms ease;
+}
+
+.cropCard:first-child {
+  padding-left: 0;
+}
+
+.cropCard:last-child {
+  padding-right: 0;
+  border-right: 0;
+}
+
+.cropCard:hover {
+  background: rgba(255, 255, 255, 0.5);
+  transform: translateY(-3px);
+}
+
+.cropCard:focus-visible,
+.cropRouter a:focus-visible,
+.evidenceActions a:focus-visible {
+  outline: 3px solid var(--sun);
+  outline-offset: 4px;
+}
+
+.cropTopline {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 42px;
+}
+
+.cropTopline span {
+  color: var(--green);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.cropTopline small {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-align: right;
+}
+
+.cropCard h3 {
+  margin: 0;
+  font-family: var(--display);
+  font-size: clamp(2rem, 2.5vw, 2.65rem);
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.cropCard p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.cropCard strong {
+  margin-top: auto;
+  color: var(--green);
+  font-size: 0.82rem;
+}
+
+.cropRouter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 30px;
+  padding-top: 26px;
+}
+
+.cropRouter > div:first-child {
+  display: grid;
+  gap: 4px;
+}
+
+.cropRouter span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.cropActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 22px;
+}
+
+.cropActions a {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--green);
+  font-weight: 800;
+  border-bottom: 1px solid currentColor;
+}
+
+.evidence {
+  padding: 116px 0;
+  background: var(--cream);
+}
+
+.evidenceGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(330px, 0.8fr);
+  gap: 78px;
+  align-items: center;
+}
+
+.visualStack {
+  position: relative;
+  min-height: 650px;
+  padding: 0 84px 72px 0;
+}
+
+.figure {
+  margin: 0;
+  background: var(--forest-deep);
+  color: var(--white);
+  box-shadow: 0 22px 55px rgba(11, 36, 28, 0.12);
+}
+
+.figure img {
+  width: 100%;
+  height: auto;
+  display: block;
+  object-fit: cover;
+}
+
+.figure figcaption {
+  padding: 12px 16px;
+  color: rgba(255, 255, 255, 0.74);
+  font-size: 0.68rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.primaryFigure {
+  border-left: 8px solid var(--sun);
+}
+
+.primaryFigure img {
+  aspect-ratio: 4 / 3;
+}
+
+.secondaryFigure {
+  position: absolute;
+  width: min(48%, 360px);
+  right: 0;
+  bottom: 0;
+  border-left: 6px solid var(--lime);
+}
+
+.secondaryFigure img {
+  aspect-ratio: 4 / 3;
+}
+
+.mediaSeal {
+  position: absolute;
+  left: 22px;
+  bottom: 18px;
+  width: 118px;
+  height: 118px;
+  display: grid;
+  align-content: center;
+  gap: 0;
+  padding: 16px;
+  background: var(--forest);
+  color: var(--white);
+  border-top: 5px solid var(--lime);
+}
+
+.mediaSeal span {
+  font-family: var(--display);
+  font-size: 2.5rem;
+  line-height: 0.9;
+}
+
+.mediaSeal strong,
+.mediaSeal small {
+  font-size: 0.67rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mediaSeal small {
+  color: #b8c9bf;
+}
+
+.evidenceCopy > p {
+  margin-top: 24px;
+}
+
+.evidenceFacts {
+  margin: 30px 0 22px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.evidenceFacts > div {
+  min-height: 62px;
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  align-items: center;
+  gap: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.evidenceFacts > div:last-child {
+  border-bottom: 0;
+}
+
+.evidenceFacts dt {
+  color: var(--muted);
+  font-size: 0.69rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.evidenceFacts dd {
+  margin: 0;
+  font-weight: 800;
+}
+
+.evidenceActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 24px;
+}
+
+.evidenceActions a {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--green);
+  font-weight: 800;
+  border-bottom: 1px solid currentColor;
+}
+
+.truthNote {
+  margin-top: 28px !important;
+  padding-top: 18px;
+  border-top: 1px dashed var(--line);
+  font-size: 0.78rem !important;
+  line-height: 1.6 !important;
+}
+
+@media (max-width: 1060px) {
+  .cropHeading,
+  .evidenceGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .cropGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .cropCard,
+  .cropCard:first-child,
+  .cropCard:last-child {
+    min-height: 280px;
+    padding: 26px;
+    border-right: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+  }
+
+  .cropCard:nth-child(even) {
+    border-right: 0;
+  }
+
+  .cropCard:last-child {
+    grid-column: 1 / -1;
+    border-right: 0;
+  }
+
+  .visualStack {
+    max-width: 840px;
+  }
+}
+
+@media (max-width: 760px) {
+  .container {
+    width: min(100% - 28px, 1240px);
+  }
+
+  .crops,
+  .evidence {
+    padding: 84px 0;
+  }
+
+  .cropHeading {
+    gap: 28px;
+  }
+
+  .cropGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .cropCard,
+  .cropCard:first-child,
+  .cropCard:last-child {
+    grid-column: auto;
+    min-height: 0;
+    padding: 24px 0;
+    border-right: 0;
+  }
+
+  .cropTopline {
+    margin-bottom: 22px;
+  }
+
+  .cropCard strong {
+    margin-top: 18px;
+  }
+
+  .cropRouter {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .visualStack {
+    min-height: 0;
+    padding: 0;
+    display: grid;
+    gap: 14px;
+  }
+
+  .secondaryFigure {
+    position: static;
+    width: 78%;
+    justify-self: end;
+  }
+
+  .mediaSeal {
+    left: 12px;
+    bottom: 46px;
+    width: 96px;
+    height: 96px;
+  }
+
+  .evidenceGrid {
+    gap: 44px;
+  }
+
+  .evidenceFacts > div {
+    grid-template-columns: 1fr;
+    gap: 3px;
+    padding: 12px 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .cropActions,
+  .evidenceActions {
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .secondaryFigure {
+    width: 88%;
+  }
+
+  .mediaSeal {
+    position: static;
+    width: 100%;
+    height: auto;
+    grid-template-columns: auto auto auto;
+    align-items: baseline;
+    gap: 8px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cropCard {
+    transition: none;
+  }
+
+  .cropCard:hover {
+    transform: none;
+  }
+}

--- a/src/components/public-home-evidence-crops.tsx
+++ b/src/components/public-home-evidence-crops.tsx
@@ -1,0 +1,97 @@
+import Image from "next/image";
+import Link from "next/link";
+import { getProjectMedia } from "@/data/public-media";
+import { wondergreenCrops } from "@/data/wondergreen-crops";
+import styles from "./public-home-evidence-crops.module.css";
+
+export function HomeCropPrograms() {
+  return (
+    <section className={styles.crops} id="cultivos" aria-labelledby="home-crops-title">
+      <div className={styles.container}>
+        <div className={styles.cropHeading}>
+          <div>
+            <span className={styles.eyebrow}>Wondergreen · Programas por cultivo</span>
+            <h2 id="home-crops-title">Cinco cultivos. Decisiones distintas según la etapa.</h2>
+          </div>
+          <div className={styles.cropIntro}>
+            <p>Las guías ya están navegables y conectan momento fisiológico, objetivo, familia de producto, cautelas, alertas y seguimiento. Son una ruta de decisión técnica; no una dosis universal.</p>
+            <Link href="/wondergreen/cultivos">Explorar biblioteca de cultivos →</Link>
+          </div>
+        </div>
+
+        <div className={styles.cropGrid}>
+          {wondergreenCrops.map((crop, index) => (
+            <Link className={styles.cropCard} href={`/wondergreen/cultivos/${crop.slug}`} key={crop.slug}>
+              <div className={styles.cropTopline}>
+                <span>{String(index + 1).padStart(2, "0")}</span>
+                <small>{crop.stages.length} momentos técnicos</small>
+              </div>
+              <h3>{crop.name}</h3>
+              <p>{crop.headline}</p>
+              <strong>Abrir programa →</strong>
+            </Link>
+          ))}
+        </div>
+
+        <div className={styles.cropRouter}>
+          <div>
+            <strong>¿Todavía no sabes qué referencia mirar?</strong>
+            <span>Empieza por cultivo y etapa; luego cruza el contexto con el Product Master y los criterios de uso.</span>
+          </div>
+          <div className={styles.cropActions}>
+            <Link href="/biblioteca/criterios-nutricionales">Revisar criterios</Link>
+            <Link href="/wondergreen/productos">Ver Product Master</Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function HomeProjectEvidence() {
+  const evidence = getProjectMedia("yarumal");
+  if (evidence.length === 0) return null;
+
+  const primary = evidence[0];
+  const secondary = evidence[1];
+
+  return (
+    <section className={styles.evidence} aria-labelledby="home-evidence-title">
+      <div className={`${styles.container} ${styles.evidenceGrid}`}>
+        <div className={styles.visualStack} aria-label="Evidencia visual conciliada del caso Yarumal">
+          <figure className={`${styles.figure} ${styles.primaryFigure}`}>
+            <Image src={primary.src} alt={primary.alt} width={1200} height={900} sizes="(max-width: 900px) 100vw, 54vw" />
+            <figcaption>{primary.caption}</figcaption>
+          </figure>
+          {secondary ? (
+            <figure className={`${styles.figure} ${styles.secondaryFigure}`}>
+              <Image src={secondary.src} alt={secondary.alt} width={1200} height={900} sizes="(max-width: 900px) 88vw, 26vw" />
+              <figcaption>{secondary.caption}</figcaption>
+            </figure>
+          ) : null}
+          <div className={styles.mediaSeal} aria-hidden="true">
+            <span>02</span>
+            <strong>registros</strong>
+            <small>conciliados</small>
+          </div>
+        </div>
+
+        <div className={styles.evidenceCopy}>
+          <span className={styles.eyebrow}>Experiencia que deja evidencia</span>
+          <h2 id="home-evidence-title">Proyecto, operación y aprendizaje en territorio.</h2>
+          <p>La web incorpora material real de los proyectos para explicar lo que Greenatics ha construido y aprendido. Las fotografías históricas documentan experiencia; no se usan para afirmar capacidad, producción o estado actual sin una fuente vigente y aprobada.</p>
+          <dl className={styles.evidenceFacts}>
+            <div><dt>Caso</dt><dd>Yarumal</dd></div>
+            <div><dt>Medios publicados</dt><dd>{evidence.length} activos conciliados</dd></div>
+            <div><dt>Alcance</dt><dd>Evidencia histórica del proyecto</dd></div>
+          </dl>
+          <div className={styles.evidenceActions}>
+            <Link href="/proyectos/yarumal">Ver caso Yarumal →</Link>
+            <Link href="/proyectos">Explorar proyectos →</Link>
+          </div>
+          <p className={styles.truthNote}><strong>Media truth:</strong> si una planta o cultivo todavía no tiene fotografía validada, la web conserva el espacio editorial sin sustituirla por una imagen genérica.</p>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Scope
- Enriches public HOME with a governed 2-image Yarumal evidence composition sourced exclusively from `public-media.ts`.
- Surfaces all five existing Wondergreen crop programs directly on HOME with stage-count context and links to each governed guide.
- Adds routes from HOME to nutritional review criteria and the public Product Master.
- Keeps media truth explicit: no generic substitute is used when a project/crop lacks reconciled photography.

## Safety / governance
- Public-only change: HOME, one reusable public component + CSS module, and one E2E spec.
- No Product Truth, formulas, prices, doses, claims, packshots or availability are changed.
- No OPS/Auth/Supabase/RLS/workflow changes.
- Uses only existing `approved-public` Yarumal media assets from the canonical registry.

## QA
- Adds regression coverage for both Yarumal images and all five crop routes on HOME.