### PR TITLE
superseded: Rechazo parcial en dashboard (resuelto en develop)

### DIFF
--- a/src/components/today-dashboard.tsx
+++ b/src/components/today-dashboard.tsx
@@ -14,7 +14,7 @@ function Metric({ label, value, note }: { label: string; value: string; note: st
   return <div className="metric-block"><span>{label}</span><strong>{value}</strong><small>{note}</small></div>;
 }
 
-const statusLabel: Record<AcceptanceStatus, string> = { accepted: "Aceptado", conditioned: "Condicionado", rejected: "Rechazado", unknown: "Sin dato histórico" };
+const statusLabel: Record<AcceptanceStatus, string> = { accepted: "Aceptado", conditioned: "Condicionado", partial_rejection: "Rechazo parcial", rejected: "Rechazado", unknown: "Sin dato histórico" };
 const dayFormatter = new Intl.DateTimeFormat("es-CO", { weekday: "long", day: "numeric", month: "long", year: "numeric", timeZone: "America/Bogota" });
 
 function timeLabel(iso?: string) {
@@ -40,7 +40,7 @@ export function TodayDashboard() {
   const running = activities.filter((activity) => activity.status === "running");
   const workerRows = running.flatMap((activity) => activity.workerIds.map((workerId) => ({ activity, worker: workers.find((item) => item.id === workerId) })));
   const delayed = activities.filter((activity) => (activity.status === "delayed" || activity.status === "missed") && bogotaDateKey(activity.plannedStart) === currentDateKey);
-  const nonConforming = todayReceptions.filter((reception)=>reception.acceptance === "conditioned" || reception.acceptance === "rejected");
+  const nonConforming = todayReceptions.filter((reception)=>reception.acceptance === "conditioned" || reception.acceptance === "partial_rejection" || reception.acceptance === "rejected");
   const openIncidents = incidents.filter((incident) => incident.status === "open");
   const activeMaintenance = tickets.filter((ticket) => ticket.status !== "closed");
   const currentAttentionCount = activeMaintenance.length + openIncidents.length + nonConforming.length + delayed.length;


### PR DESCRIPTION
Superseded by `c316674d6b853728fdd1d490404303cb55ea90bc` already integrated into `develop`. The integrated commit uses the exact same final `today-dashboard.tsx` blob (`e0e534439845f96444a5b3e94189d234805b228d`): it adds `partial_rejection: "Rechazo parcial"` and includes partial rejections among operational exceptions. Do not merge this duplicate PR.