### PR TITLE
chore: master roadmap + canonical OPS release recovery

### DIFF
--- a/.github/workflows/hosted-pilot-production-refresh.yml
+++ b/.github/workflows/hosted-pilot-production-refresh.yml
@@ -25,6 +25,13 @@ jobs:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
       SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+      PILOT_DIRECTOR_EMAIL: ${{ secrets.PILOT_DIRECTOR_EMAIL }}
+      PILOT_DIRECTOR_PASSWORD: ${{ secrets.PILOT_DIRECTOR_PASSWORD }}
+      PILOT_OPERATOR_TAM_EMAIL: ${{ secrets.PILOT_OPERATOR_TAM_EMAIL }}
+      PILOT_OPERATOR_TAM_PASSWORD: ${{ secrets.PILOT_OPERATOR_TAM_PASSWORD }}
+      PILOT_OPERATOR_YAR_EMAIL: ${{ secrets.PILOT_OPERATOR_YAR_EMAIL }}
+      PILOT_OPERATOR_YAR_PASSWORD: ${{ secrets.PILOT_OPERATOR_YAR_PASSWORD }}
+      PILOT_DIRECTOR_PLANTS: TAM,YAR
 
     steps:
       - name: Checkout canonical develop
@@ -47,15 +54,26 @@ jobs:
           echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
           echo "OPS production refresh from develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Require hosted deployment secrets
+      - name: Require hosted deployment and UAT secrets
         shell: bash
         run: |
           set -euo pipefail
           missing=0
-          for name in VERCEL_TOKEN VERCEL_ORG_ID NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY SUPABASE_SECRET_KEY
+          for name in \
+            VERCEL_TOKEN \
+            VERCEL_ORG_ID \
+            NEXT_PUBLIC_SUPABASE_URL \
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
+            SUPABASE_SECRET_KEY \
+            PILOT_DIRECTOR_EMAIL \
+            PILOT_DIRECTOR_PASSWORD \
+            PILOT_OPERATOR_TAM_EMAIL \
+            PILOT_OPERATOR_TAM_PASSWORD \
+            PILOT_OPERATOR_YAR_EMAIL \
+            PILOT_OPERATOR_YAR_PASSWORD
           do
             if [ -z "${!name:-}" ]; then
-              echo "::error::$name is not configured for hosted OPS deployment."
+              echo "::error::$name is not configured for hosted OPS production certification."
               missing=1
             fi
           done
@@ -74,7 +92,18 @@ jobs:
       - name: Certify hosted backend
         run: npm run pilot:backend-preflight -- --plants TAM,YAR
 
-      - name: Run hosted RLS smoke
+      - name: Certify Director vs Operario Támesis RLS isolation
+        env:
+          PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_TAM_EMAIL }}
+          PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_TAM_PASSWORD }}
+          PILOT_OPERATOR_PLANTS: TAM
+        run: npm run pilot:rls-smoke
+
+      - name: Certify Director vs Operario Yarumal RLS isolation
+        env:
+          PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_YAR_EMAIL }}
+          PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_YAR_PASSWORD }}
+          PILOT_OPERATOR_PLANTS: YAR
         run: npm run pilot:rls-smoke
 
       - name: Deploy full OPS Preview
@@ -109,5 +138,5 @@ jobs:
           OPS_ORIGIN: ${{ steps.production.outputs.deployment_url }}
         run: |
           echo "Stable OPS origin: $OPS_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
-          echo "Quality, backend, RLS, Preview and Production gates passed." >> "$GITHUB_STEP_SUMMARY"
+          echo "Quality, backend, TAM/YAR RLS, Preview and Production gates passed." >> "$GITHUB_STEP_SUMMARY"
           echo "No Auth users, profiles or memberships were mutated by this workflow." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/hosted-pilot-production-refresh.yml
+++ b/.github/workflows/hosted-pilot-production-refresh.yml
@@ -1,0 +1,113 @@
+# Safe dispatcher for refreshing the hosted GREENATICS OPS product.
+# Runtime source is always the canonical develop branch checked out below.
+# This workflow does not create, update or delete Auth users, profiles or memberships.
+name: hosted-pilot-production-refresh
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: greenatics-hosted-pilot-production
+  cancel-in-progress: false
+
+jobs:
+  refresh-production:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      PILOT_PREVIEW_MODE: full-ops
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      DEPLOY_GIT_REF: develop
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+      SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+
+    steps:
+      - name: Checkout canonical develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Resolve exact deployment commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          test "${#sha}" -eq 40
+          echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
+          echo "OPS production refresh from develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require hosted deployment secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in VERCEL_TOKEN VERCEL_ORG_ID NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY SUPABASE_SECRET_KEY
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is not configured for hosted OPS deployment."
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Canonical quality gate
+        run: |
+          npm run typecheck
+          npm run lint
+          npm test
+          npm run build
+
+      - name: Certify hosted backend
+        run: npm run pilot:backend-preflight -- --plants TAM,YAR
+
+      - name: Run hosted RLS smoke
+        run: npm run pilot:rls-smoke
+
+      - name: Deploy full OPS Preview
+        id: preview
+        run: npm run pilot:vercel-preview
+
+      - name: Certify protected deployed Preview
+        env:
+          DEPLOYMENT_URL: ${{ steps.preview.outputs.deployment_url }}
+          VERCEL_PROJECT_ID: ${{ steps.preview.outputs.project_id }}
+        run: npm run pilot:vercel-preflight
+
+      - name: Deploy stable full OPS production
+        id: production
+        run: node scripts/vercel-ops-production-deploy.mjs
+
+      - name: Certify stable human-accessible OPS origin
+        env:
+          APP_BASE_URL: ${{ steps.production.outputs.deployment_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run pilot:preflight -- \
+            --base-url "$APP_BASE_URL" \
+            --mode full-ops \
+            --expected-branch "$DEPLOY_GIT_REF" \
+            --expected-commit "$DEPLOY_GIT_SHA"
+
+      - name: Production refresh summary
+        shell: bash
+        env:
+          OPS_ORIGIN: ${{ steps.production.outputs.deployment_url }}
+        run: |
+          echo "Stable OPS origin: $OPS_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
+          echo "Quality, backend, RLS, Preview and Production gates passed." >> "$GITHUB_STEP_SUMMARY"
+          echo "No Auth users, profiles or memberships were mutated by this workflow." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/MASTER_ROADMAP_2026-08-17.md
+++ b/docs/MASTER_ROADMAP_2026-08-17.md
@@ -1,0 +1,366 @@
+# GREENATICS WEB PLATFORM · MASTER ROADMAP
+
+Fecha de corte: 2026-08-17
+Repositorio canónico: `arendon7/GTCS-WEB`
+Rama de integración: `develop`
+Rama de producción: `main`
+
+## 1. Objetivo de esta etapa
+
+Pasar de una plataforma con muchos módulos ya construidos a una plataforma operable, pilotable y publicable con un release train claro.
+
+La prioridad inmediata no es abrir más dominios. Es consolidar:
+
+1. gobernanza de ramas y releases;
+2. estabilidad de GREENATICS OPS;
+3. piloto real Támesis + Yarumal;
+4. cierre de Web Pública V1;
+5. publicación controlada a producción.
+
+## 2. Arquitectura vigente
+
+Una sola plataforma técnica con dos superficies separadas:
+
+- Web pública: `/` y rutas públicas aprobadas.
+- GREENATICS OPS: `/app` y rutas operacionales autenticadas.
+
+Regla: compartir repositorio e infraestructura no implica compartir UX, navegación, permisos ni acceso a datos internos.
+
+## 3. Estado maestro por frente
+
+| Frente | Estado | Nivel | Próximo cierre |
+|---|---|---:|---|
+| Arquitectura dual Public + OPS | VALIDADO | 100% | mantener contrato |
+| Supabase + RLS + Auth | AVANZADO | 85% | smoke real por roles |
+| Usuarios / administración | AVANZADO | 80% | piloto usuarios reales |
+| Maestros operacionales | AVANZADO | 85% | validar datos de planta |
+| Planeación / calendario | AVANZADO | 80% | plan vs real real |
+| Actividades V2 | AVANZADO | 85% | prueba operario end-to-end |
+| Recepción V2 | AVANZADO | 80% | prueba diaria de planta |
+| Compostaje V2 | AVANZADO | 80% | trazabilidad lote real |
+| Mantenimiento V2 | AVANZADO | 80% | incidencia → cierre real |
+| Producción | FUNCIONAL | 70% | integración con inventario |
+| Inventario producto | FUNCIONAL | 70% | conciliación de movimientos |
+| Insumos | FUNCIONAL | 70% | mínimos + consumos |
+| Ventas / comercial | FUNCIONAL | 65% | flujo real y métricas |
+| Gastos / finanzas / caja | FUNCIONAL | 65% | conciliación y permisos |
+| Compras | FUNCIONAL | 65% | aprobación y recepción |
+| Dashboard Dirección | AVANZADO | 75% | datos reales y alertas |
+| Documentos / SharePoint | PARCIAL | 55% | lectura gobernada + fuentes |
+| Importación histórica | AVANZADO | 70% | reconciliación auditada |
+| Web pública corporativa | AVANZADO | 85% | QA editorial y visual |
+| Wondergreen | AVANZADO | 85% | assets canónicos + conversión |
+| Biblioteca / conocimiento | AVANZADO | 85% | recursos finales descargables |
+| SEO / metadata / sitemap | AVANZADO | 90% | auditoría pre-release |
+| Pipeline de producción | REQUIERE CONSOLIDACIÓN | 60% | reconciliar `main` / `develop` |
+
+Los porcentajes son indicadores de madurez operativa, no cobertura de líneas de código.
+
+## 4. Secuencia ejecutable
+
+### FASE R0 · Consolidación de release
+
+Objetivo: recuperar un camino seguro `feature -> develop -> release -> main`.
+
+Bloqueantes:
+
+- `main` y `develop` están divergidos.
+- `main` conserva dispatchers de infraestructura del piloto que no deben fusionarse junto con la web legacy.
+- `develop` contiene la arquitectura y producto actuales.
+
+Acciones:
+
+- [x] identificar divergencia;
+- [x] clasificar la mayor parte de `main` legacy como no fusionable en bloque;
+- [x] identificar `hosted-pilot-production-refresh.yml` como infraestructura recuperable;
+- [ ] recuperar únicamente infraestructura vigente y compatible;
+- [ ] crear release candidate desde `develop`;
+- [ ] ejecutar quality + E2E crítico + backend preflight + RLS smoke;
+- [ ] promover release candidate a `main` sin reintroducir web legacy;
+- [ ] establecer desde ese punto `main` como descendiente de la línea canónica.
+
+Exit criteria:
+
+- `main` deja de contener una historia paralela funcionalmente relevante.
+- Todo release nuevo proviene de `develop`.
+- No se requieren merges ciegos entre historias antiguas.
+
+### FASE R1 · Pilot Readiness OPS
+
+Objetivo: demostrar un ciclo operacional completo con datos reales.
+
+Orden obligatorio:
+
+1. autenticación y rol;
+2. planta y maestros;
+3. programación;
+4. actividad de Hoy;
+5. recepción;
+6. actividad técnica;
+7. compost / mantenimiento según caso;
+8. producción e inventario;
+9. dashboard;
+10. reconstrucción histórica del día.
+
+Pruebas mínimas por rol:
+
+#### Director
+
+- acceso a TAM + YAR;
+- calendario y programación;
+- maestros autorizados;
+- dashboards;
+- administración según RBAC.
+
+#### Responsable de planta
+
+- acceso únicamente a planta autorizada;
+- registro diario;
+- ejecución de actividades;
+- recepción;
+- incidencias;
+- consulta de inventario y mantenimiento pertinente.
+
+#### Administrador
+
+- usuarios;
+- catálogos autorizados;
+- auditoría y soporte de operación.
+
+Exit criteria:
+
+- un día operacional puede registrarse de principio a fin sin Excel paralelo;
+- plan vs real se reconstruye desde datos canónicos;
+- ninguna vista depende de mock data en modo piloto;
+- RLS impide lectura/escritura fuera de permisos.
+
+### FASE R2 · Núcleo operacional V1
+
+Objetivo: estabilizar los seis dominios que alimentan la operación diaria.
+
+#### 2.1 Planeación + actividades
+
+- plantillas canónicas;
+- asignación trabajador/equipo;
+- reprogramación trazable;
+- ejecución no programada gobernada;
+- motivo de desviación;
+- horas-hombre derivables.
+
+#### 2.2 Recepción
+
+- fuente;
+- ruta;
+- material;
+- cantidades y rechazo;
+- evidencia/incidencia;
+- trazabilidad a planta y fecha.
+
+#### 2.3 Compostaje
+
+- lote;
+- estado;
+- controles;
+- movimientos;
+- entradas/salidas;
+- vínculo con actividades.
+
+#### 2.4 Mantenimiento
+
+- equipo;
+- falla/incidencia;
+- prioridad;
+- intervención;
+- tiempo fuera de servicio;
+- cierre verificable.
+
+#### 2.5 Producción + inventario
+
+- producción por referencia;
+- movimientos de inventario;
+- despacho;
+- conciliación de stock;
+- trazabilidad de origen.
+
+#### 2.6 Dashboard
+
+- recibido;
+- rechazo;
+- procesado;
+- producción;
+- cumplimiento de plan;
+- horas-hombre;
+- mantenimiento abierto;
+- inventario crítico;
+- alertas de calidad del dato.
+
+Exit criteria:
+
+- datos de los dominios se relacionan y concilian;
+- dashboards no requieren reconstrucción manual;
+- pruebas E2E cubren happy path y permisos críticos.
+
+### FASE R3 · Backoffice y control
+
+Después de estabilizar R2:
+
+- ventas;
+- compras;
+- gastos;
+- caja;
+- finanzas;
+- insumos;
+- documentos;
+- flujos de aprobación.
+
+Regla: no aumentar complejidad financiera antes de asegurar que los movimientos operativos base son confiables.
+
+### FASE R4 · Web Pública V1 definitiva
+
+Objetivo: convertir la web actual en la superficie pública oficial de GREENATICS.
+
+Checklist:
+
+- Home;
+- Soluciones;
+- Proyectos;
+- Impacto;
+- Nosotros;
+- Contacto;
+- Wondergreen;
+- productos;
+- cultivos;
+- Biblioteca;
+- guías y manuales;
+- CTA y rutas de conversión;
+- assets canónicos;
+- Product Truth / Brand Lock;
+- responsive;
+- accesibilidad;
+- SEO técnico;
+- performance;
+- evidencia y fuentes.
+
+Principio: no publicar claims, cifras o impacto que no tengan fuente, fecha, estado y aprobación.
+
+### FASE R5 · Datos históricos e integraciones
+
+- importación Excel gobernada;
+- reconciliación de históricos;
+- SharePoint read-only donde sea necesario;
+- migración de fuente de verdad a OPS;
+- documentos con procedencia;
+- contrato de publicación interna → pública.
+
+Exit criteria:
+
+SharePoint y Excel dejan de ser fuentes paralelas de la operación nueva.
+
+### FASE R6 · Evolución V2
+
+Solo después del piloto estable:
+
+- alertas automáticas;
+- notificaciones;
+- aprobaciones avanzadas;
+- calidad de dato;
+- KPIs predictivos;
+- publicación gobernada de indicadores;
+- PWA / experiencia móvil;
+- automatización de reportes;
+- capacidades asistidas por IA donde exista dato confiable.
+
+## 5. Dependencias críticas
+
+```text
+R0 Release governance
+  -> R1 Pilot readiness
+      -> R2 Operational core
+          -> R3 Backoffice
+
+R0
+  -> R4 Public Web release
+
+R2
+  -> R5 Historical + integrations
+      -> R6 Automation / intelligence
+```
+
+Web pública puede continuar editorialmente en paralelo con R1-R2, pero su promoción a producción depende de R0.
+
+## 6. Política de ramas desde este punto
+
+- `feature/*`, `fix/*`, `chore/*`: cambios aislados.
+- PR obligatorio hacia `develop`.
+- `develop`: única rama de integración.
+- `release/*`: congelación de candidato cuando se prepara producción.
+- `main`: producción; no desarrollo directo.
+
+No volver a mantener dos implementaciones completas de la web en `main` y `develop`.
+
+## 7. Quality gates
+
+Antes de integrar a `develop`:
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+npm run build
+```
+
+Para cambios funcionales críticos:
+
+```bash
+npm run test:e2e
+```
+
+Para piloto hosted:
+
+```bash
+npm run pilot:backend-preflight -- --plants TAM,YAR
+npm run pilot:rls-smoke
+```
+
+Y preflight del deployment cuando aplique.
+
+## 8. Orden de ejecución inmediato
+
+### Sprint de consolidación actual
+
+1. preservar `develop@bad111b` como baseline verde;
+2. recuperar workflow seguro de producción compatible;
+3. documentar reconciliación `main`/`develop`;
+4. revisar PRs abiertos obsoletos;
+5. crear release candidate canónico;
+6. probar auth + RLS + usuarios reales;
+7. ejecutar flujo Director;
+8. ejecutar flujo Támesis;
+9. ejecutar flujo Yarumal;
+10. corregir hallazgos del piloto antes de abrir nuevas Waves.
+
+## 9. Regla para futuras decisiones
+
+Cuando aparezca una nueva idea se clasifica primero como:
+
+- BLOQUEANTE DEL PILOTO;
+- MEJORA V1;
+- BACKOFFICE;
+- WEB PÚBLICA;
+- INTEGRACIÓN;
+- V2.
+
+Solo los bloqueantes del piloto interrumpen R0-R2.
+
+## 10. Definición de éxito V1
+
+GREENATICS V1 está lista cuando:
+
+- la web pública explica y convierte correctamente;
+- OPS permite ejecutar y reconstruir la operación real;
+- Támesis y Yarumal operan con roles separados;
+- Supabase es la fuente canónica de operación nueva;
+- plan vs real es confiable;
+- dashboards salen del dato registrado;
+- los releases son repetibles y auditables;
+- `main` representa producción y no una implementación paralela antigua.

--- a/docs/deployment/MAIN_DEVELOP_RECONCILIATION_2026-08-17.md
+++ b/docs/deployment/MAIN_DEVELOP_RECONCILIATION_2026-08-17.md
@@ -1,0 +1,166 @@
+# MAIN / DEVELOP RECONCILIATION · 2026-08-17
+
+## Diagnóstico
+
+Estado observado:
+
+- `develop`: `bad111b729063ba8853b97eb679b05f898eed2f2`
+- `main`: `22a0005806a9cbc11523439e37f6bc91d5aa1c57`
+- relación: diverged
+- `develop` ahead de `main`: 649 commits
+- `main` ahead de `develop`: 22 commits
+- merge base: `314da8d80c3730d08f372918e41fb01203ce2f5f`
+
+No se recomienda merge directo entre ambas ramas.
+
+## Por qué existe la divergencia
+
+Las ramas evolucionaron como líneas funcionales paralelas desde una base muy temprana:
+
+### Historia de `main`
+
+Incluye principalmente:
+
+1. Web pública V0.1 / V0.2 inicial.
+2. soporte GitHub Pages / static export.
+3. dispatchers manuales de infraestructura para piloto hosted.
+4. workflows de onboarding/bootstrap inicial.
+5. workflow de refresh de OPS production.
+
+### Historia de `develop`
+
+Contiene la plataforma actual:
+
+- web pública reestructurada;
+- GREENATICS OPS;
+- Auth/RLS;
+- Supabase y migraciones hasta 0037;
+- planeación y maestros;
+- Activity Log V2;
+- Recepción V2;
+- Compost V2;
+- Mantenimiento V2;
+- producción, inventario, comercial y finanzas;
+- pruebas E2E y DB;
+- infraestructura hosted actualizada;
+- nueva Biblioteca y Wondergreen.
+
+## Clasificación de cambios exclusivos de `main`
+
+### A. NO FUSIONAR COMO CÓDIGO ACTUAL
+
+La antigua Web Pública V0.1/V0.2 y sus componentes.
+
+Razón: `develop` ya contiene una arquitectura pública posterior, integrada con la plataforma actual y con una batería de pruebas nueva.
+
+Acción: conservar únicamente como historia Git; no cherry-pick.
+
+### B. LEGADO DE GITHUB PAGES
+
+- `.github/workflows/pages.yml`
+- scripts/static export asociados
+- ajustes históricos específicos de base path
+
+Razón: no deben condicionar la arquitectura hosted de la plataforma actual.
+
+Acción: no recuperar salvo decisión explícita de mantener GitHub Pages como mirror estático independiente.
+
+### C. BOOTSTRAP / ONBOARDING DE UNA SOLA VEZ
+
+- `hosted-pilot-onboarding.yml`
+- `hosted-pilot-admin-resume.yml`
+
+Estos workflows resuelven alta inicial de Director/Administrador y recuperación del proceso de bootstrap.
+
+Acción: NO reintroducir automáticamente. Antes se debe verificar el estado actual de Auth, perfiles y memberships. Si los propietarios iniciales ya existen, estos flujos pasan a archivo histórico y el alta futura debe usar administración ordinaria.
+
+### D. UAT DISPATCHER
+
+- `hosted-pilot-uat.yml`
+
+Acción: revisar durante Pilot Readiness. Recuperar solo si agrega valor sobre el `hosted-pilot-preview.yml` actual y no duplica mecanismos.
+
+### E. PRODUCCIÓN OPS · RECUPERABLE
+
+- `hosted-pilot-production-refresh.yml`
+
+Este workflow:
+
+- hace checkout de `develop`;
+- ejecuta quality gates;
+- valida backend;
+- genera Preview;
+- valida Preview protegido;
+- despliega origen OPS estable;
+- valida el deployment humano;
+- no modifica usuarios ni memberships.
+
+Los scripts requeridos continúan presentes en `develop`:
+
+- `pilot:backend-preflight`
+- `pilot:vercel-preview`
+- `pilot:vercel-preflight`
+- `pilot:preflight`
+- `scripts/vercel-ops-production-deploy.mjs`
+
+Acción: recuperar el workflow sobre la línea actual usando gates canónicos:
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+npm run build
+```
+
+## Estrategia de reconciliación
+
+### Paso 1
+
+Mantener `develop` como fuente funcional canónica.
+
+### Paso 2
+
+Recuperar de `main` únicamente infraestructura todavía necesaria, revalidada contra `develop`.
+
+### Paso 3
+
+No transportar la historia pública legacy hacia `develop`.
+
+### Paso 4
+
+Crear un release candidate desde `develop` una vez superado Pilot Readiness mínimo.
+
+Ejemplo:
+
+```text
+release/ops-public-v1
+```
+
+### Paso 5
+
+Hacer que `main` adopte el release candidate canónico mediante PR de release controlado.
+
+Si GitHub no permite un merge limpio debido a historias incompatibles, la reconciliación debe realizarse mediante una estrategia explícita de sustitución canónica, preservando previamente un tag/branch histórico de `main`.
+
+No se debe force-push `main` sin backup verificable y decisión documentada.
+
+## Backup requerido antes del cutover
+
+Antes de normalizar `main`, crear referencia inmutable o rama archivada:
+
+```text
+archive/main-pre-canonical-2026-08-17
+```
+
+Debe apuntar al SHA de `main` vigente antes del cutover.
+
+## Exit criteria
+
+La reconciliación termina cuando:
+
+1. existe backup de la línea histórica de `main`;
+2. la infraestructura vigente necesaria está recuperada en la línea canónica;
+3. `develop` pasa quality y pilot gates;
+4. existe un release candidate validado;
+5. `main` representa ese release y no una implementación antigua paralela;
+6. el siguiente ciclo puede operar normalmente `feature -> develop -> release -> main`.


### PR DESCRIPTION
## Objetivo
Consolidar la siguiente etapa de GREENATICS WEB PLATFORM sin mezclar la historia legacy de `main` con la línea funcional actual de `develop`.

## Incluye
- `docs/MASTER_ROADMAP_2026-08-17.md`: mapa maestro con fases R0-R6, estados, dependencias, exit criteria y orden inmediato.
- `docs/deployment/MAIN_DEVELOP_RECONCILIATION_2026-08-17.md`: clasificación de la divergencia `main`/`develop` y estrategia de reconciliación selectiva.
- `.github/workflows/hosted-pilot-production-refresh.yml`: recuperación del dispatcher seguro de OPS production sobre la línea canónica actual.

## Release gate recuperado
Antes de promover OPS:
- typecheck
- lint
- unit tests
- build
- hosted backend preflight
- RLS smoke
- protected Preview preflight
- stable Production deploy
- human-accessible origin preflight

El workflow no muta Auth users, profiles ni memberships.

## No incluye
- merge de la antigua Web Pública V0.1/V0.2 desde `main`;
- GitHub Pages legacy;
- reactivación automática de workflows de bootstrap/onboarding de una sola vez;
- cambios de esquema Supabase o Product Truth.

## Siguiente paso después de este PR
Pilot Readiness: Auth/RLS/roles reales → Director → Támesis → Yarumal → flujo operacional end-to-end.