### PR TITLE
chore: R1 steady-state pilot readiness + authenticated UAT

### DIFF
--- a/.github/workflows/hosted-pilot-preview.yml
+++ b/.github/workflows/hosted-pilot-preview.yml
@@ -11,6 +11,14 @@ on:
         options:
           - public-only
           - full-ops
+      ops_backend_state:
+        description: Backend state for full-ops certification
+        required: true
+        type: choice
+        default: steady-state
+        options:
+          - steady-state
+          - prebootstrap
 
 permissions:
   contents: read
@@ -25,6 +33,7 @@ jobs:
     timeout-minutes: 20
     env:
       PILOT_PREVIEW_MODE: ${{ inputs.mode }}
+      PILOT_BACKEND_STATE: ${{ inputs.ops_backend_state }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       DEPLOY_GIT_REF: develop
@@ -49,6 +58,9 @@ jobs:
           test "${#sha}" -eq 40
           echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
           echo "Deploying ${PILOT_PREVIEW_MODE} preview from develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$PILOT_PREVIEW_MODE" = "full-ops" ]; then
+            echo "OPS backend state: ${PILOT_BACKEND_STATE}" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Require Vercel preview secrets
         shell: bash
@@ -86,13 +98,21 @@ jobs:
       - name: Install dependencies
         run: npm install --ignore-scripts
 
-      - name: Certify hosted Supabase before full OPS deployment
-        if: ${{ inputs.mode == 'full-ops' }}
+      - name: Certify pristine hosted Supabase before first Director bootstrap
+        if: ${{ inputs.mode == 'full-ops' && inputs.ops_backend_state == 'prebootstrap' }}
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
           SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
         run: npm run pilot:backend-preflight -- --plants TAM,YAR --require-no-director
+
+      - name: Certify steady-state hosted Supabase
+        if: ${{ inputs.mode == 'full-ops' && inputs.ops_backend_state == 'steady-state' }}
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+          SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+        run: npm run pilot:backend-preflight -- --plants TAM,YAR
 
       - name: Create or reuse isolated Vercel project and deploy Preview
         id: deploy

--- a/.github/workflows/hosted-pilot-uat.yml
+++ b/.github/workflows/hosted-pilot-uat.yml
@@ -1,0 +1,119 @@
+# Authenticated, read-only identity/RLS certification plus Preview deployment.
+# Runtime source is always canonical develop. This workflow never deploys Production
+# and does not create, update or delete Auth users, profiles or memberships.
+name: hosted-pilot-uat
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: greenatics-hosted-pilot-uat
+  cancel-in-progress: false
+
+jobs:
+  multiuser-uat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      PILOT_PREVIEW_MODE: full-ops
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      DEPLOY_GIT_REF: develop
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+      SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+      PILOT_DIRECTOR_EMAIL: ${{ secrets.PILOT_DIRECTOR_EMAIL }}
+      PILOT_DIRECTOR_PASSWORD: ${{ secrets.PILOT_DIRECTOR_PASSWORD }}
+      PILOT_OPERATOR_TAM_EMAIL: ${{ secrets.PILOT_OPERATOR_TAM_EMAIL }}
+      PILOT_OPERATOR_TAM_PASSWORD: ${{ secrets.PILOT_OPERATOR_TAM_PASSWORD }}
+      PILOT_OPERATOR_YAR_EMAIL: ${{ secrets.PILOT_OPERATOR_YAR_EMAIL }}
+      PILOT_OPERATOR_YAR_PASSWORD: ${{ secrets.PILOT_OPERATOR_YAR_PASSWORD }}
+      PILOT_DIRECTOR_PLANTS: TAM,YAR
+
+    steps:
+      - name: Checkout canonical develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Resolve exact UAT commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          test "${#sha}" -eq 40
+          echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
+          echo "Authenticated UAT from develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require hosted UAT secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            VERCEL_TOKEN \
+            VERCEL_ORG_ID \
+            NEXT_PUBLIC_SUPABASE_URL \
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
+            SUPABASE_SECRET_KEY \
+            PILOT_DIRECTOR_EMAIL \
+            PILOT_DIRECTOR_PASSWORD \
+            PILOT_OPERATOR_TAM_EMAIL \
+            PILOT_OPERATOR_TAM_PASSWORD \
+            PILOT_OPERATOR_YAR_EMAIL \
+            PILOT_OPERATOR_YAR_PASSWORD
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is not configured for hosted pilot UAT."
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Certify steady-state hosted backend
+        run: npm run pilot:backend-preflight -- --plants TAM,YAR
+
+      - name: Certify Director vs Operario Támesis RLS isolation
+        env:
+          PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_TAM_EMAIL }}
+          PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_TAM_PASSWORD }}
+          PILOT_OPERATOR_PLANTS: TAM
+        run: npm run pilot:rls-smoke
+
+      - name: Certify Director vs Operario Yarumal RLS isolation
+        env:
+          PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_YAR_EMAIL }}
+          PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_YAR_PASSWORD }}
+          PILOT_OPERATOR_PLANTS: YAR
+        run: npm run pilot:rls-smoke
+
+      - name: Deploy exact full OPS Preview
+        id: deploy
+        run: npm run pilot:vercel-preview
+
+      - name: Certify protected deployed Preview
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
+          VERCEL_PROJECT_ID: ${{ steps.deploy.outputs.project_id }}
+        run: npm run pilot:vercel-preflight
+
+      - name: UAT summary
+        shell: bash
+        run: |
+          echo "Hosted multiuser UAT gate: PASS." >> "$GITHUB_STEP_SUMMARY"
+          echo "Director expected scope: TAM + YAR." >> "$GITHUB_STEP_SUMMARY"
+          echo "Operario Támesis expected scope: TAM; YAR read denied by RLS." >> "$GITHUB_STEP_SUMMARY"
+          echo "Operario Yarumal expected scope: YAR; TAM read denied by RLS." >> "$GITHUB_STEP_SUMMARY"
+          echo "No Auth users, profiles or memberships were mutated by this workflow." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/deployment/HOSTED_PILOT_RUNBOOK.md
+++ b/docs/deployment/HOSTED_PILOT_RUNBOOK.md
@@ -3,17 +3,16 @@
 ## Objetivo
 Publicar y certificar la plataforma dual GREENATICS sin exponer secretos: la web pública permanece abierta y GREENATICS OPS solo se habilita cuando existe un backend hospedado certificado.
 
-## 1. Dos etapas de preview
-La validación hospedada se divide en dos modos explícitos:
+## 1. Dos superficies de preview
 
-### `public-only` · primera etapa y modo predeterminado
+### `public-only` · modo público
 - proyecto Vercel canónico: `greenatics-public-preview`;
 - no requiere Supabase;
 - `NEXT_PUBLIC_DATA_MODE=local`;
 - OPS permanece en `configuration-block`;
 - sirve para QA visual/editorial, SEO, headers, navegación y frontera público/privado.
 
-### `full-ops` · segunda etapa
+### `full-ops` · modo autenticado
 - proyecto Vercel canónico: `greenatics-ops`;
 - requiere Supabase piloto certificado;
 - `NEXT_PUBLIC_DATA_MODE=supabase`;
@@ -21,30 +20,63 @@ La validación hospedada se divide en dos modos explícitos:
 
 Los proyectos son distintos por diseño. No reutilizar `greenatics-ops` como preview público ni `greenatics-public-preview` para pruebas con credenciales.
 
-## 2. Supabase hospedado para `full-ops`
-1. Crear un proyecto dedicado para GREENATICS OPS.
-2. Vincular el repositorio con Supabase CLI.
-3. Aplicar **todas** las migraciones versionadas de `supabase/migrations` sobre una base limpia.
-4. Verificar las plantas canónicas que se usarán en el piloto.
-5. No crear tablas, políticas ni RPC manualmente por fuera de migraciones.
+## 2. Estados del backend `full-ops`
 
-Para el piloto actual, los códigos canónicos son `TAM` (Támesis) y `YAR` (Yarumal). Los scripts aceptan alias humanos, pero el runbook y la base deben usar códigos canónicos.
+El workflow `hosted-pilot-preview.yml` distingue explícitamente dos estados:
 
-## 3. Frontera pública / interna
+### `prebootstrap`
+Usar únicamente antes de crear el primer Director.
+
+El gate exige:
+
+```bash
+npm run pilot:backend-preflight -- --plants TAM,YAR --require-no-director
+```
+
+### `steady-state` · predeterminado
+Usar para el piloto normal después del bootstrap.
+
+El gate exige:
+
+```bash
+npm run pilot:backend-preflight -- --plants TAM,YAR
+```
+
+No volver a usar `--require-no-director` para previews rutinarios una vez exista Dirección.
+
+## 3. Supabase hospedado para `full-ops`
+1. Usar el proyecto dedicado GREENATICS OPS.
+2. Mantener el repositorio vinculado con el esquema versionado.
+3. Aplicar cambios de esquema únicamente mediante `supabase/migrations`.
+4. Verificar las plantas canónicas del piloto.
+5. No crear tablas, políticas ni RPC manualmente fuera de migraciones.
+
+Códigos canónicos actuales:
+
+- `TAM` · Támesis
+- `YAR` · Yarumal
+
+Los scripts pueden aceptar alias humanos, pero runbooks, RLS y base usan códigos canónicos.
+
+## 4. Frontera pública / interna
 La misma base de producto contiene dos superficies:
+
 - públicas: `/`, `/wondergreen`, `/soluciones`, `/proyectos`, `/impacto`, `/biblioteca`, `/nosotros`, `/contacto` y descendientes;
 - internas: `/app`, operación, dashboard, importaciones, administración y cuenta.
 
 Una visita anónima a la web pública nunca debe terminar en `/login`.
 
-En `public-only`, `/app` debe redirigir a `/login?reason=configuration&next=/app`. En `full-ops`, `/app` anónimo debe redirigir al login sin `reason=configuration` y una sesión válida debe quedar sujeta a perfil, membresía y RLS.
+En `public-only`, `/app` debe redirigir a `/login?reason=configuration&next=/app`.
 
-## 4. Auth URL y plantilla de invitación para `full-ops`
+En `full-ops`, `/app` anónimo debe redirigir al login sin `reason=configuration`; una sesión válida queda sujeta a perfil, membresía y RLS.
+
+## 5. Auth URL e invitaciones
 Configurar en Supabase Auth:
-- Site URL = origen canónico del deployment Next.js.
-- Allowed Redirect URLs = el mismo origen y previews realmente autorizados.
 
-Personalizar **Invite user** para que el token llegue al endpoint SSR:
+- Site URL = origen canónico del deployment Next.js.
+- Allowed Redirect URLs = origen canónico y previews expresamente autorizados.
+
+Plantilla **Invite user**:
 
 ```html
 <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=invite&next=/account/setup">
@@ -54,17 +86,19 @@ Personalizar **Invite user** para que el token llegue al endpoint SSR:
 
 No usar el fragmento de sesión del flujo cliente como mecanismo principal del piloto.
 
-## 5. GitHub Actions y secretos
-El workflow manual `.github/workflows/hosted-pilot-preview.yml` hace checkout explícito de `develop`, captura su SHA completo, crea o reutiliza el proyecto Vercel canónico del modo seleccionado y despliega **solo Preview**.
+## 6. GitHub Actions y secretos
 
-Secretos requeridos para ambos modos:
+### Preview público / OPS
+`.github/workflows/hosted-pilot-preview.yml` hace checkout explícito de `develop`, captura su SHA completo y despliega solo Preview.
+
+Secretos base:
 
 ```text
 VERCEL_TOKEN
 VERCEL_ORG_ID
 ```
 
-Secretos adicionales requeridos solo por `full-ops`:
+Para `full-ops`:
 
 ```text
 PILOT_SUPABASE_URL
@@ -74,23 +108,24 @@ PILOT_SUPABASE_SECRET_KEY
 
 ### Contrato `public-only`
 El workflow:
-1. selecciona `public-only` por defecto;
-2. no exige secretos Supabase;
-3. no ejecuta `pilot:backend-preflight`;
-4. crea o reutiliza `greenatics-public-preview`;
-5. hace upsert únicamente de `NEXT_PUBLIC_DATA_MODE=local` con target `preview`;
-6. despliega el SHA exacto de `develop` sin `target=production`;
-7. espera `READY` y falla cerrado ante estados terminales;
-8. ejecuta `pilot:preflight -- --mode public-only`.
 
-El preflight exige que `/api/health` reporte `backend=missing` y `admin=missing`. Si aparecen configurados, el gate falla para detectar contaminación de credenciales.
+1. no exige secretos Supabase;
+2. no ejecuta backend preflight;
+3. usa `greenatics-public-preview`;
+4. configura `NEXT_PUBLIC_DATA_MODE=local` para Preview;
+5. despliega el SHA exacto de `develop` sin Production;
+6. espera `READY` y falla cerrado ante estado terminal;
+7. ejecuta el preflight público.
+
+El preflight exige que `/api/health` reporte backend/admin ausentes y que OPS permanezca bloqueado por configuración.
 
 ### Contrato `full-ops`
 El workflow:
-1. exige los secretos Supabase;
-2. corre `pilot:backend-preflight -- --plants TAM,YAR --require-no-director`;
-3. crea o reutiliza `greenatics-ops`;
-4. configura únicamente en target `preview`:
+
+1. exige secretos Supabase;
+2. ejecuta backend preflight según `ops_backend_state`;
+3. usa `greenatics-ops`;
+4. configura para Preview:
 
 ```text
 NEXT_PUBLIC_DATA_MODE=supabase
@@ -99,17 +134,14 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=<publishable-key>
 SUPABASE_SECRET_KEY=<server-only-secret>
 ```
 
-5. despliega el SHA exacto y espera `READY`;
-6. ejecuta `pilot:preflight -- --mode full-ops`.
+5. despliega el SHA exacto;
+6. espera `READY`;
+7. ejecuta `pilot:preflight -- --mode full-ops`.
 
 `SUPABASE_SECRET_KEY` es exclusivamente server-side. Nunca usar prefijo `NEXT_PUBLIC_`, imprimirla, retornarla por API ni versionarla.
 
-El cliente `scripts/vercel-pilot-deploy.mjs` reduce errores remotos a códigos seguros y no imprime tokens ni claves. Producción no se despliega ni se promueve con este workflow.
-
-## 6. Backend preflight + primer director
-Este bloque aplica únicamente a `full-ops`.
-
-Antes de enviar una invitación real:
+## 7. Primer Director · solo bootstrap
+Antes de enviar la primera invitación real:
 
 ```bash
 npm run pilot:backend-preflight -- \
@@ -117,32 +149,36 @@ npm run pilot:backend-preflight -- \
   --require-no-director
 ```
 
-El gate es de solo lectura: valida contrato de esquema, RLS, Supabase Auth Admin, plantas canónicas y estado de bootstrap sin crear usuarios ni cambiar membresías.
-
-Con el backend certificado y `APP_BASE_URL`/origen confiable resuelto:
+Con backend certificado:
 
 ```bash
 npm run bootstrap:director -- \
-  --email director@greenatics.com.co \
+  --email <correo-director> \
   --name "Director GREENATICS" \
   --plants TAM,YAR
 ```
 
-El bootstrap usa una RPC atómica y se niega a operar si ya existe cualquier membresía activa con rol `director`. Después, invitaciones y cambios de rol se realizan desde `/admin/users`.
+El bootstrap usa una RPC atómica y se niega a operar si ya existe una membresía activa con rol `director`.
 
-## 7. Activación del usuario invitado
+Después del primer Director:
+
+- cambiar el preview a `steady-state`;
+- altas y cambios de rol se realizan desde `/admin/users`;
+- no reejecutar workflows de bootstrap como mecanismo ordinario de administración.
+
+## 8. Activación del usuario invitado
 1. Dirección invita desde `/admin/users`.
 2. Supabase envía el correo.
 3. El usuario abre `/auth/confirm?...`.
-4. El servidor valida `token_hash` y crea la sesión SSR.
-5. `/account/setup` exige una contraseña de al menos 12 caracteres con letra y número.
-6. Al completar la activación se entra a `/app`.
-7. RLS limita lectura y escritura a plantas/membresías autorizadas.
+4. El servidor valida `token_hash` y crea sesión SSR.
+5. `/account/setup` exige contraseña de al menos 12 caracteres con letra y número.
+6. Al completar activación se entra a `/app`.
+7. RLS limita lectura/escritura a membresías autorizadas.
 
-## 8. Readiness ejecutable
+## 9. Readiness ejecutable
 `GET /api/health` es público y no devuelve credenciales.
 
-### Certificar `public-only`
+### `public-only`
 
 ```bash
 npm run pilot:preflight -- \
@@ -153,16 +189,16 @@ npm run pilot:preflight -- \
 ```
 
 Debe reportar:
+
 - `status=ready`;
 - `mode=local`;
 - `opsAccess=configuration-block`;
-- `checks.backend=missing`;
-- `checks.admin=missing`;
-- Vercel + branch + commit esperados;
+- backend/admin ausentes;
+- branch + commit esperados;
 - `/app` bloqueado con `reason=configuration`;
 - sitemap/robots/headers correctos.
 
-### Certificar `full-ops`
+### `full-ops`
 
 ```bash
 npm run pilot:preflight -- \
@@ -174,48 +210,83 @@ npm run pilot:preflight -- \
 
 Debe reportar `ready`, `supabase`, `supabase-auth`, checks remotos `ok` y `/app` anónimo redirigido al login sin bloqueo de configuración.
 
-## 9. Smoke RLS multiusuario de solo lectura
-Aplica a `full-ops` una vez existan director y operario de prueba.
+## 10. UAT autenticado steady-state
+`.github/workflows/hosted-pilot-uat.yml` es el gate hospedado de preproducción después del bootstrap.
 
-Variables efímeras/secretos de CI:
+No crea ni modifica usuarios, perfiles o memberships y no despliega Production.
+
+Secretos adicionales:
 
 ```text
-PILOT_DIRECTOR_EMAIL=...
-PILOT_DIRECTOR_PASSWORD=...
-PILOT_OPERATOR_EMAIL=...
-PILOT_OPERATOR_PASSWORD=...
+PILOT_DIRECTOR_EMAIL
+PILOT_DIRECTOR_PASSWORD
+PILOT_OPERATOR_TAM_EMAIL
+PILOT_OPERATOR_TAM_PASSWORD
+PILOT_OPERATOR_YAR_EMAIL
+PILOT_OPERATOR_YAR_PASSWORD
 ```
 
-Con URL y publishable key Supabase disponibles:
+Secuencia:
 
-```bash
-npm run pilot:rls-smoke
-```
+1. backend preflight `TAM,YAR` en steady-state;
+2. Director vs Operario Támesis mediante `pilot:rls-smoke`;
+3. Director vs Operario Yarumal mediante `pilot:rls-smoke`;
+4. deployment full-ops Preview del SHA exacto de `develop`;
+5. protected Preview preflight.
 
-El gate usa dos sesiones independientes y únicamente la clave publicable/anon. Falla si recibe una `sb_secret_` o JWT `service_role`. Por defecto exige Dirección `TAM,YAR`, operario `TAM` y cero filas de `YAR` para ese operario.
+Contrato esperado:
 
-## 10. Smoke funcional multiusuario obligatorio
-Con dos perfiles de navegador distintos:
-1. La web pública abre sin sesión.
-2. `/app` redirige a `/login` sin sesión.
-3. Director con Támesis + Yarumal ve ambas plantas.
-4. Operario de Támesis solo ve Támesis.
-5. Operario crea/finaliza actividad y dirección la ve al sincronizar.
-6. Intento de leer/escribir Yarumal como operario de Támesis es bloqueado por RLS.
-7. Compra registrada no crea stock físico.
-8. Recepción física sí crea lote de insumo.
-9. Consumo superior al lote es rechazado.
-10. Cerrar sesión invalida la navegación protegida y redirige a `/login`.
+- Director: `TAM,YAR`;
+- Operario Támesis: `TAM`, lectura `YAR` denegada;
+- Operario Yarumal: `YAR`, lectura `TAM` denegada.
 
-## 11. Gate de promoción
-Antes de asociar dominio o promover a producción:
-- CI de PR verde (`quality` + `database`);
-- `public-only` Preview en PASS para el SHA exacto de `develop`;
-- `full-ops` Preview en PASS cuando se vaya a habilitar OPS remoto;
-- backend preflight, smoke RLS y smoke funcional aprobados para `full-ops`;
+Las credenciales se reciben únicamente como secretos y no se imprimen.
+
+## 11. Smoke funcional multiusuario obligatorio
+Además del smoke RLS de solo lectura, el piloto funcional debe comprobar con sesiones separadas:
+
+1. la web pública abre sin sesión;
+2. `/app` redirige a `/login` sin sesión;
+3. Director ve Támesis + Yarumal;
+4. Operario Támesis solo ve Támesis;
+5. Operario Yarumal solo ve Yarumal;
+6. operario crea/finaliza actividad y Dirección la ve al sincronizar;
+7. lectura/escritura cross-plant es bloqueada por RLS;
+8. compra registrada no crea stock físico;
+9. recepción física sí crea lote de insumo;
+10. consumo superior al lote es rechazado;
+11. cerrar sesión invalida navegación protegida.
+
+## 12. Producción OPS
+`.github/workflows/hosted-pilot-production-refresh.yml` es el único dispatcher recuperado para refresh estable de OPS.
+
+Antes de Production exige:
+
+1. typecheck;
+2. lint;
+3. unit tests;
+4. build;
+5. backend preflight steady-state;
+6. RLS Director/Támesis;
+7. RLS Director/Yarumal;
+8. Preview exacto;
+9. protected Preview preflight;
+10. deployment estable;
+11. preflight humano del origen resultante.
+
+No crea, modifica ni elimina usuarios o memberships.
+
+## 13. Gate de promoción
+Antes de asociar dominio o promover un release:
+
+- CI de PR verde (`quality`, `database`, desktop y mobile);
+- `public-only` Preview PASS para el SHA exacto cuando se modifica superficie pública;
+- `full-ops` Preview PASS para cambios internos;
+- UAT autenticado PASS en steady-state;
+- smoke funcional aprobado;
 - redirects Auth configurados;
-- ningún secreto presente en GitHub, bundle cliente, proyecto público o logs;
-- web pública validada sin autenticación;
-- decisión explícita de convergencia `main` / `develop`, rama productiva y dominio.
+- ningún secreto presente en Git, bundle cliente, proyecto público o logs;
+- web pública validada anónimamente;
+- release candidate explícito desde `develop`.
 
-SharePoint permanece como fuente documental e histórica. GREENATICS OPS es el sistema transaccional; la integración documental debe añadir referencias/lectura sin devolver las transacciones diarias a SharePoint.
+SharePoint permanece como fuente documental e histórica durante la transición. GREENATICS OPS es el sistema transaccional; la integración documental añade referencias/lectura sin devolver las transacciones diarias a SharePoint.

--- a/docs/deployment/PILOT_READINESS_AUDIT_2026-08-17.md
+++ b/docs/deployment/PILOT_READINESS_AUDIT_2026-08-17.md
@@ -1,0 +1,108 @@
+# GREENATICS OPS · PILOT READINESS AUDIT
+
+Fecha de corte: 2026-08-17
+Baseline de código auditado: `develop@7c7225a6e87cb58c6f8866e76e4a77fe5e5f2f3b`
+
+## 1. Propósito
+
+Determinar si el entorno hospedado está listo para iniciar el piloto real Director + Támesis + Yarumal sin volver a ejecutar bootstrap de usuarios innecesariamente ni confundir fallas de infraestructura con fallas de aplicación.
+
+## 2. Estado del código
+
+R0 quedó consolidado con:
+
+- roadmap maestro;
+- estrategia de reconciliación `main`/`develop`;
+- backup histórico de `main`;
+- refresh seguro de OPS production recuperado;
+- gates de quality, backend, RLS TAM/YAR, Preview y Production.
+
+El PR de consolidación pasó quality, database y Playwright desktop/mobile antes de integrarse a `develop`.
+
+## 3. Proyecto Supabase identificado
+
+Proyecto canónico del piloto:
+
+```text
+name: greenatics-ops
+ref: dokxiyyypqbpilfivxse
+region: ca-central-1
+postgres: 17
+```
+
+La API de administración reportó `ACTIVE_HEALTHY`, pero durante la auditoría aparecieron señales incompatibles con una disponibilidad estable:
+
+1. el endpoint de advisors respondió que el proyecto estaba `hibernated`;
+2. un intento de `restore_project` respondió que ya no estaba pausado y que estaba `ACTIVE_HEALTHY` pero podía tardar en restaurarse completamente;
+3. el canal SQL administrativo falló con `28P01 password authentication failed for user postgres`;
+4. logs Postgres registraron un `fast shutdown request` alrededor de `2026-08-17T16:44:21Z`;
+5. logs Auth posteriores registraron varios intentos fallidos de conectar `supabase_auth_admin` contra Postgres local mientras el servicio reiniciaba.
+
+## 4. Interpretación
+
+No se debe concluir todavía que exista pérdida de datos o una regresión de esquema.
+
+La evidencia es consistente con un ciclo de hibernación/restauración o reinicio incompleto del proyecto hospedado, combinado con un canal administrativo SQL que aún no consigue autenticarse.
+
+Hasta que backend preflight responda correctamente, el estado hosted se clasifica:
+
+```text
+R1 / BACKEND HOSTED: BLOCKED-INFRA
+```
+
+## 5. Guardrails
+
+Mientras `BLOCKED-INFRA`:
+
+- NO ejecutar bootstrap de Director;
+- NO recrear usuarios;
+- NO alterar memberships;
+- NO reaplicar migraciones a ciegas;
+- NO cambiar RLS para intentar solucionar conectividad;
+- NO desplegar Production OPS;
+- NO interpretar errores de login como evidencia de credenciales inválidas sin confirmar primero salud del backend.
+
+## 6. Cambios de R1 preparados
+
+### Preview con estado explícito
+
+`hosted-pilot-preview.yml` distingue:
+
+- `prebootstrap`: exige que no exista Director;
+- `steady-state`: valida backend sin esa precondición y es el modo normal del piloto.
+
+### UAT autenticado
+
+`hosted-pilot-uat.yml` certifica sin mutaciones:
+
+1. backend steady-state;
+2. Director con `TAM,YAR`;
+3. Operario Támesis con `TAM` y denegación `YAR`;
+4. Operario Yarumal con `YAR` y denegación `TAM`;
+5. deployment Preview exacto;
+6. preflight protegido.
+
+## 7. Secuencia para desbloquear el piloto
+
+Cuando el backend hospedado vuelva a responder normalmente:
+
+1. ejecutar `pilot:backend-preflight -- --plants TAM,YAR`;
+2. ejecutar UAT autenticado;
+3. confirmar que los tres usuarios de prueba pueden autenticarse;
+4. confirmar memberships y aislamiento RLS;
+5. ejecutar smoke funcional multiusuario;
+6. registrar hallazgos de UX/datos por rol;
+7. corregir únicamente hallazgos reproducibles;
+8. crear release candidate después del piloto mínimo verde.
+
+## 8. Exit criteria de R1
+
+R1 puede marcarse READY cuando:
+
+- backend preflight PASS;
+- Director PASS (`TAM,YAR`);
+- Operario Támesis PASS (`TAM`, no `YAR`);
+- Operario Yarumal PASS (`YAR`, no `TAM`);
+- Preview full-ops PASS;
+- flujo funcional básico de actividad/recepción visible entre operario y Dirección;
+- no existen errores de infraestructura que obliguen a usar Excel o mocks para completar el flujo.


### PR DESCRIPTION
## Objetivo
Preparar GREENATICS OPS para el piloto estable Director + Támesis + Yarumal, separando el bootstrap inicial del estado operativo normal.

## Cambios
- `hosted-pilot-preview.yml`
  - agrega `ops_backend_state`;
  - `steady-state` es el default;
  - `prebootstrap` conserva `--require-no-director` únicamente para el primer Director.
- `hosted-pilot-uat.yml`
  - recupera UAT autenticado sin mutaciones;
  - certifica Director vs Operario Támesis;
  - certifica Director vs Operario Yarumal;
  - despliega solo Preview y ejecuta protected preflight.
- `HOSTED_PILOT_RUNBOOK.md`
  - documenta la transición prebootstrap → steady-state;
  - integra UAT y el refresh seguro de producción.
- `PILOT_READINESS_AUDIT_2026-08-17.md`
  - registra el estado hosted observado y guardrails de recuperación.

## Bloqueante de entorno detectado
Supabase `greenatics-ops` fue reportado simultáneamente como `ACTIVE_HEALTHY` y en proceso de salida de hibernación/restauración. El canal SQL administrativo todavía falla y logs muestran reinicio de Postgres/Auth alrededor de 16:44–16:47 UTC.

Por seguridad, este PR NO ejecuta bootstrap, NO modifica usuarios/memberships, NO reaplica migraciones y NO despliega Production.

## Exit de R1 después del merge
Backend preflight → UAT Director/TAM/YAR → Preview full-ops → smoke funcional multiusuario.