### PR TITLE
feat(r2): link maintenance repairs to canonical activity

### DIFF
--- a/e2e/core-flows.spec.ts
+++ b/e2e/core-flows.spec.ts
@@ -45,6 +45,7 @@ test("maintenance ticket follows stopped to repairing to available", async ({ pa
   await expect(page.getByText("En reparación", { exact: true }).first()).toBeVisible();
   await page.getByLabel("Causa encontrada").fill("QA causa verificada");
   await page.getByLabel("Acción realizada").fill("QA ajuste ejecutado");
+  await page.getByRole("group", { name: "Trabajadores de reparación" }).getByRole("checkbox").first().check();
   await page.getByRole("button", { name: "Cerrar reparación" }).click();
   await expect(page.getByText("Disponible", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("Reparación cerrada y equipo disponible.")).toBeVisible();

--- a/src/components/equipment-detail.tsx
+++ b/src/components/equipment-detail.tsx
@@ -3,8 +3,10 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { useMaintenanceStore } from "@/components/maintenance-store";
+import { useOpsStore } from "@/components/ops-store";
+import { useSupplyStore } from "@/components/supply-store";
 import { EquipmentStatusPill, MaintenanceStatusPill } from "@/components/equipment-status-pill";
-import { getDowntimeMinutes, maintenanceFailureTypeLabels } from "@/lib/maintenance-domain";
+import { getDowntimeMinutes, maintenanceFailureTypeLabels, type MaintenanceSpareUse } from "@/lib/maintenance-domain";
 import { bogotaTime } from "@/lib/time";
 
 function parseEvidenceRefs(value: string) {
@@ -18,16 +20,27 @@ function EvidenceList({ refs }: { refs: string[] }) {
 
 export function EquipmentDetail({ equipmentId }: { equipmentId: string }) {
   const { equipment, tickets, startRepair, closeTicket } = useMaintenanceStore();
+  const { workers, activities, refresh: refreshOps } = useOpsStore();
+  const { lots, movements, refreshSupplies } = useSupplyStore();
   const asset = equipment.find((item) => item.id === equipmentId);
   const assetTickets = useMemo(() => tickets.filter((ticket) => ticket.equipmentId === equipmentId).sort((a,b)=>new Date(b.openedAt).getTime()-new Date(a.openedAt).getTime()), [tickets, equipmentId]);
   const active = assetTickets.find((ticket) => ticket.status !== "closed");
   const [cause, setCause] = useState("");
   const [resolution, setResolution] = useState("");
   const [repairEvidence, setRepairEvidence] = useState("");
+  const [repairWorkerIds, setRepairWorkerIds] = useState<string[]>([]);
+  const [selectedSpareKey, setSelectedSpareKey] = useState("");
+  const [spareQuantity, setSpareQuantity] = useState("");
+  const [spares, setSpares] = useState<MaintenanceSpareUse[]>([]);
   const [feedback, setFeedback] = useState("");
   const [busy, setBusy] = useState(false);
 
   if (!asset) return <section className="panel mx-auto max-w-3xl"><h1 className="text-2xl">Equipo no encontrado</h1><Link className="button secondary mt-5" href="/equipment">Volver</Link></section>;
+
+  const plantWorkers = workers.filter((worker) => worker.plantId === asset.plantId && !worker.historical);
+  const workerNames = new Map(workers.map((worker) => [worker.id, worker.name]));
+  const spareLots = lots.filter((lot) => lot.plantId === asset.plantId && lot.category === "spare_part" && lot.quantity > 0);
+  const spareLotByKey = new Map(spareLots.map((lot) => [`${lot.supplyId}|${lot.lotCode}`, lot]));
 
   const beginRepair = async () => {
     if (!active || busy) return;
@@ -40,25 +53,59 @@ export function EquipmentDetail({ equipmentId }: { equipmentId: string }) {
       setBusy(false);
     }
   };
+
+  const toggleWorker = (id: string, checked: boolean) => setRepairWorkerIds((current) => checked ? [...current, id] : current.filter((value) => value !== id));
+
+  const addSpare = () => {
+    const lot = spareLotByKey.get(selectedSpareKey);
+    const quantity = Number(spareQuantity);
+    if (!lot) return setFeedback("Selecciona un repuesto y lote disponible.");
+    if (!Number.isFinite(quantity) || quantity <= 0) return setFeedback("La cantidad de repuesto debe ser mayor que cero.");
+    if (quantity > lot.quantity + 1e-9) return setFeedback(`Stock insuficiente en ${lot.lotCode}. Disponible: ${lot.quantity.toLocaleString("es-CO")} ${lot.unit}.`);
+    if (spares.some((item) => item.supplyId === lot.supplyId && item.lotCode === lot.lotCode)) return setFeedback("Ese repuesto y lote ya fue agregado.");
+    setSpares((current) => [...current, { supplyId: lot.supplyId, lotCode: lot.lotCode, quantity }]);
+    setSelectedSpareKey("");
+    setSpareQuantity("");
+    setFeedback("");
+  };
+
   const close = async () => {
     if (!active || busy) return;
     setBusy(true);
     setFeedback("");
     try {
-      const result = await closeTicket(active.id, { cause, resolution, evidenceRefs: parseEvidenceRefs(repairEvidence) });
+      const result = await closeTicket(active.id, {
+        cause,
+        resolution,
+        evidenceRefs: parseEvidenceRefs(repairEvidence),
+        workerIds: repairWorkerIds,
+        spares,
+      });
       if (!result.ok) return setFeedback(result.error);
+      await Promise.all([refreshOps(), refreshSupplies()]);
       setCause("");
       setResolution("");
       setRepairEvidence("");
-      setFeedback("Reparación cerrada y equipo disponible.");
+      setRepairWorkerIds([]);
+      setSpares([]);
+      setSelectedSpareKey("");
+      setSpareQuantity("");
+      setFeedback("Reparación cerrada, equipo disponible y actividad registrada en Bitácora.");
     } finally {
       setBusy(false);
     }
   };
 
   return <>
-    <header className="page-header"><div><p className="eyebrow">{asset.plant} · {asset.area}</p><h1>{asset.code} · {asset.name}</h1><p className="lede">Ficha operacional, cronología real e historial de mantenimiento.</p></div><div className="header-actions"><Link className="button secondary" href="/equipment">Volver</Link>{!active && <Link className="button primary" href={`/equipment/${asset.id}/report`}>Reportar falla</Link>}</div></header>
-    <section className="panel mx-auto max-w-4xl"><div className="section-head"><div><p className="eyebrow">Estado</p><h2>Situación actual</h2></div><EquipmentStatusPill status={asset.status}/></div>{active ? <div className="rounded-xl border border-[var(--line)] bg-[var(--surface-soft)] p-4"><div className="flex flex-wrap items-start justify-between gap-3"><div><strong className="block text-sm">{active.title}</strong><span className="mt-1 block text-xs text-[var(--muted)]">{active.description}</span></div><MaintenanceStatusPill status={active.status}/></div><div className="mt-4 grid gap-3 border-t border-[var(--line)] pt-3 sm:grid-cols-2 lg:grid-cols-4"><div><span className="quiet">Ocurrió</span><strong className="mt-1 block text-xs">{bogotaTime.format(new Date(active.failedAt || active.openedAt))}</strong></div><div><span className="quiet">Reportada</span><strong className="mt-1 block text-xs">{bogotaTime.format(new Date(active.openedAt))}</strong></div><div><span className="quiet">Fuera de servicio</span><strong className="mt-1 block text-xs">{Math.round(getDowntimeMinutes(active, new Date().toISOString()))} min</strong></div><div><span className="quiet">Tipo · severidad</span><strong className="mt-1 block text-xs">{maintenanceFailureTypeLabels[active.failureType ?? "other"]} · <span className="capitalize">{active.severity}</span></strong></div></div><div className="mt-3 border-t border-[var(--line)] pt-3 text-xs"><span className="quiet">Evidencia de falla</span><EvidenceList refs={active.failureEvidenceRefs ?? []}/></div>{active.status === "open" && <div className="mt-4 flex justify-end"><button className="button primary" type="button" disabled={busy} onClick={beginRepair}>{busy ? "Iniciando…" : "Iniciar reparación"}</button></div>}{active.status === "repairing" && <div className="mt-5 grid gap-4"><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Causa encontrada<textarea className="min-h-20 rounded-lg border border-[var(--line)] bg-white p-3 text-sm text-[var(--ink)]" value={cause} onChange={(e)=>setCause(e.target.value)} placeholder="Qué originó la falla"/></label><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Acción realizada<textarea className="min-h-20 rounded-lg border border-[var(--line)] bg-white p-3 text-sm text-[var(--ink)]" value={resolution} onChange={(e)=>setResolution(e.target.value)} placeholder="Qué se reparó o ajustó"/></label><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Evidencia de reparación <span className="font-normal">(opcional, una referencia por línea)</span><textarea className="min-h-20 rounded-lg border border-[var(--line)] bg-white p-3 text-sm text-[var(--ink)]" value={repairEvidence} onChange={(e)=>setRepairEvidence(e.target.value)} placeholder="URL, código documental o referencia verificable"/></label><div className="flex justify-end"><button className="button primary" type="button" disabled={busy} onClick={close}>{busy ? "Cerrando…" : "Cerrar reparación"}</button></div></div>}</div> : <div className="rounded-xl bg-[var(--green-soft)] p-4 text-sm text-[var(--green-dark)]">No hay fallas o reparaciones abiertas para este equipo.</div>}{feedback && <p className="mt-4 rounded-lg bg-[var(--blue-soft)] p-3 text-sm font-semibold text-[var(--blue)]" role="status">{feedback}</p>}</section>
-    <section className="panel mx-auto mt-4 max-w-4xl"><div className="section-head"><div><p className="eyebrow">Historial</p><h2>Tickets registrados</h2></div><span className="quiet">{assetTickets.length} eventos</span></div><div className="grid gap-3">{assetTickets.map((ticket)=><article className="rounded-xl border border-[var(--line)] p-4" key={ticket.id}><div className="flex flex-wrap items-start justify-between gap-3"><div><strong className="text-sm">{ticket.title}</strong><span className="mt-1 block text-xs text-[var(--muted)]">Falla: {bogotaTime.format(new Date(ticket.failedAt || ticket.openedAt))} · Reporte: {bogotaTime.format(new Date(ticket.openedAt))} · {maintenanceFailureTypeLabels[ticket.failureType ?? "other"]}</span><span className="mt-1 block text-xs text-[var(--muted)]">{ticket.description}</span></div><MaintenanceStatusPill status={ticket.status}/></div>{ticket.status === "closed" && <div className="mt-3 grid gap-3 border-t border-[var(--line)] pt-3 text-xs sm:grid-cols-2 lg:grid-cols-4"><div><span className="quiet">Parada total</span><strong className="mt-1 block">{Math.round(getDowntimeMinutes(ticket))} min</strong></div><div><span className="quiet">Causa</span><strong className="mt-1 block">{ticket.cause}</strong></div><div><span className="quiet">Acción</span><strong className="mt-1 block">{ticket.resolution}</strong></div><div><span className="quiet">Evidencia reparación</span><EvidenceList refs={ticket.repairEvidenceRefs ?? []}/></div></div>}</article>)}</div></section>
+    <header className="page-header"><div><p className="eyebrow">{asset.plant} · {asset.area}</p><h1>{asset.code} · {asset.name}</h1><p className="lede">Ficha operacional, cronología real, repuestos físicos y Bitácora canónica de mantenimiento.</p></div><div className="header-actions"><Link className="button secondary" href="/equipment">Volver</Link>{!active && <Link className="button primary" href={`/equipment/${asset.id}/report`}>Reportar falla</Link>}</div></header>
+    <section className="panel mx-auto max-w-5xl"><div className="section-head"><div><p className="eyebrow">Estado</p><h2>Situación actual</h2></div><EquipmentStatusPill status={asset.status}/></div>{active ? <div className="rounded-xl border border-[var(--line)] bg-[var(--surface-soft)] p-4"><div className="flex flex-wrap items-start justify-between gap-3"><div><strong className="block text-sm">{active.title}</strong><span className="mt-1 block text-xs text-[var(--muted)]">{active.description}</span></div><MaintenanceStatusPill status={active.status}/></div><div className="mt-4 grid gap-3 border-t border-[var(--line)] pt-3 sm:grid-cols-2 lg:grid-cols-4"><div><span className="quiet">Ocurrió</span><strong className="mt-1 block text-xs">{bogotaTime.format(new Date(active.failedAt || active.openedAt))}</strong></div><div><span className="quiet">Reportada</span><strong className="mt-1 block text-xs">{bogotaTime.format(new Date(active.openedAt))}</strong></div><div><span className="quiet">Fuera de servicio</span><strong className="mt-1 block text-xs">{Math.round(getDowntimeMinutes(active, new Date().toISOString()))} min</strong></div><div><span className="quiet">Tipo · severidad</span><strong className="mt-1 block text-xs">{maintenanceFailureTypeLabels[active.failureType ?? "other"]} · <span className="capitalize">{active.severity}</span></strong></div></div><div className="mt-3 border-t border-[var(--line)] pt-3 text-xs"><span className="quiet">Evidencia de falla</span><EvidenceList refs={active.failureEvidenceRefs ?? []}/></div>{active.status === "open" && <div className="mt-4 flex justify-end"><button className="button primary" type="button" disabled={busy} onClick={beginRepair}>{busy ? "Iniciando…" : "Iniciar reparación"}</button></div>}{active.status === "repairing" && <div className="mt-5 grid gap-5">
+        <div className="grid gap-4 md:grid-cols-2"><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Causa encontrada<textarea className="min-h-20 rounded-lg border border-[var(--line)] bg-white p-3 text-sm text-[var(--ink)]" value={cause} onChange={(e)=>setCause(e.target.value)} placeholder="Qué originó la falla"/></label><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Acción realizada<textarea className="min-h-20 rounded-lg border border-[var(--line)] bg-white p-3 text-sm text-[var(--ink)]" value={resolution} onChange={(e)=>setResolution(e.target.value)} placeholder="Qué se reparó o ajustó"/></label></div>
+        <fieldset className="grid gap-2"><legend className="mb-1 text-xs font-bold text-[var(--muted)]">Trabajadores de reparación</legend><div className="grid gap-2 sm:grid-cols-2 md:grid-cols-3">{plantWorkers.map((worker) => <label className="flex min-h-10 items-center gap-2 rounded-lg border border-[var(--line)] bg-white px-3 text-xs" key={worker.id}><input type="checkbox" checked={repairWorkerIds.includes(worker.id)} onChange={(event) => toggleWorker(worker.id,event.target.checked)}/>{worker.name}</label>)}</div>{plantWorkers.length===0&&<span className="text-xs text-[var(--red)]">No hay trabajadores operacionales activos para esta planta.</span>}</fieldset>
+        <div className="rounded-xl border border-[var(--line)] bg-white p-4"><div className="section-head"><div><p className="eyebrow">Repuestos</p><h3>Consumo físico por lote</h3></div><span className="quiet">Opcional</span></div>{spareLots.length>0?<><div className="grid gap-3 md:grid-cols-[1fr_160px_auto]"><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Repuesto y lote<select aria-label="Repuesto por lote" className="min-h-11 rounded-lg border border-[var(--line)] bg-white px-3 text-sm text-[var(--ink)]" value={selectedSpareKey} onChange={(event)=>setSelectedSpareKey(event.target.value)}><option value="">Seleccionar…</option>{spareLots.map((lot)=><option value={`${lot.supplyId}|${lot.lotCode}`} key={`${lot.supplyId}|${lot.lotCode}`}>{lot.supplyName} · {lot.lotCode} · {lot.quantity.toLocaleString("es-CO")} {lot.unit}</option>)}</select></label><label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Cantidad<input aria-label="Cantidad de repuesto" className="min-h-11 rounded-lg border border-[var(--line)] px-3 text-sm text-[var(--ink)]" inputMode="decimal" value={spareQuantity} onChange={(event)=>setSpareQuantity(event.target.value)}/></label><button className="button secondary self-end" type="button" onClick={addSpare}>Agregar repuesto</button></div>{spares.length>0&&<div className="mt-3 grid gap-2">{spares.map((spare)=>{const lot=spareLotByKey.get(`${spare.supplyId}|${spare.lotCode}`);return <div className="flex items-center justify-between gap-3 rounded-lg bg-[var(--surface-soft)] px-3 py-2 text-xs" key={`${spare.supplyId}|${spare.lotCode}`}><span><strong>{lot?.supplyName ?? spare.supplyId}</strong> · {spare.lotCode} · {spare.quantity.toLocaleString("es-CO")} {lot?.unit ?? ""}</span><button className="font-bold text-[var(--red)]" type="button" onClick={()=>setSpares((current)=>current.filter((item)=>!(item.supplyId===spare.supplyId&&item.lotCode===spare.lotCode)))}>Quitar</button></div>})}</div>}</>:<p className="text-xs text-[var(--muted)]">No hay lotes de repuestos con stock disponible. El cierre puede continuar sin repuestos.</p>}</div>
+        <label className="grid gap-2 text-xs font-bold text-[var(--muted)]">Evidencia de reparación <span className="font-normal">(opcional, una referencia por línea)</span><textarea className="min-h-20 rounded-lg border border-[var(--line)] bg-white p-3 text-sm text-[var(--ink)]" value={repairEvidence} onChange={(e)=>setRepairEvidence(e.target.value)} placeholder="URL, código documental o referencia verificable"/></label>
+        <p className="rounded-lg bg-[var(--green-soft)] p-3 text-xs text-[var(--green-dark)]">Al cerrar, causa, acción, trabajadores, horario y equipo se registran una sola vez como actividad canónica de Mantenimiento. Los repuestos seleccionados se descuentan por lote en la misma transacción.</p>
+        <div className="flex justify-end"><button className="button primary" type="button" disabled={busy} onClick={close}>{busy ? "Cerrando…" : "Cerrar reparación"}</button></div>
+      </div>}</div> : <div className="rounded-xl bg-[var(--green-soft)] p-4 text-sm text-[var(--green-dark)]">No hay fallas o reparaciones abiertas para este equipo.</div>}{feedback && <p className="mt-4 rounded-lg bg-[var(--blue-soft)] p-3 text-sm font-semibold text-[var(--blue)]" role="status">{feedback}</p>}</section>
+    <section className="panel mx-auto mt-4 max-w-5xl"><div className="section-head"><div><p className="eyebrow">Historial</p><h2>Tickets registrados</h2></div><span className="quiet">{assetTickets.length} eventos</span></div><div className="grid gap-3">{assetTickets.map((ticket)=>{const repairActivity=ticket.repairActivityId?activities.find((activity)=>activity.id===ticket.repairActivityId):undefined;const repairWorkers=repairActivity?.workerIds.map((id)=>workerNames.get(id)??id)??[];const spareMovements=movements.filter((movement)=>movement.referenceId===ticket.id&&movement.kind==="consumption");return <article className="rounded-xl border border-[var(--line)] p-4" key={ticket.id}><div className="flex flex-wrap items-start justify-between gap-3"><div><strong className="text-sm">{ticket.title}</strong><span className="mt-1 block text-xs text-[var(--muted)]">Falla: {bogotaTime.format(new Date(ticket.failedAt || ticket.openedAt))} · Reporte: {bogotaTime.format(new Date(ticket.openedAt))} · {maintenanceFailureTypeLabels[ticket.failureType ?? "other"]}</span><span className="mt-1 block text-xs text-[var(--muted)]">{ticket.description}</span></div><MaintenanceStatusPill status={ticket.status}/></div>{ticket.status === "closed" && <div className="mt-3 grid gap-3 border-t border-[var(--line)] pt-3 text-xs sm:grid-cols-2 lg:grid-cols-3"><div><span className="quiet">Parada total</span><strong className="mt-1 block">{Math.round(getDowntimeMinutes(ticket))} min</strong></div><div><span className="quiet">Causa</span><strong className="mt-1 block">{ticket.cause}</strong></div><div><span className="quiet">Acción</span><strong className="mt-1 block">{ticket.resolution}</strong></div><div><span className="quiet">Bitácora</span><strong className="mt-1 block">{ticket.repairActivityId?"Bitácora enlazada":"Cierre previo sin vínculo canónico"}</strong>{repairWorkers.length>0&&<span className="mt-1 block text-[var(--muted)]">{repairWorkers.join(", ")}</span>}</div><div><span className="quiet">Repuestos consumidos</span>{spareMovements.length>0?<ul className="mt-1 grid gap-1">{spareMovements.map((movement)=><li key={movement.id}><strong>{movement.supplyName}</strong> · {movement.lotCode} · {movement.quantity.toLocaleString("es-CO")} {movement.unit}</li>)}</ul>:<span className="mt-1 block text-[var(--muted)]">Sin consumo registrado</span>}</div><div><span className="quiet">Evidencia reparación</span><EvidenceList refs={ticket.repairEvidenceRefs ?? []}/></div></div>}</article>})}</div></section>
   </>;
 }

--- a/src/components/equipment-detail.tsx
+++ b/src/components/equipment-detail.tsx
@@ -20,7 +20,7 @@ function EvidenceList({ refs }: { refs: string[] }) {
 
 export function EquipmentDetail({ equipmentId }: { equipmentId: string }) {
   const { equipment, tickets, startRepair, closeTicket } = useMaintenanceStore();
-  const { workers, activities, refresh: refreshOps } = useOpsStore();
+  const { workers, activities, backend, refresh: refreshOps } = useOpsStore();
   const { lots, movements, refreshSupplies } = useSupplyStore();
   const asset = equipment.find((item) => item.id === equipmentId);
   const assetTickets = useMemo(() => tickets.filter((ticket) => ticket.equipmentId === equipmentId).sort((a,b)=>new Date(b.openedAt).getTime()-new Date(a.openedAt).getTime()), [tickets, equipmentId]);
@@ -90,7 +90,9 @@ export function EquipmentDetail({ equipmentId }: { equipmentId: string }) {
       setSpares([]);
       setSelectedSpareKey("");
       setSpareQuantity("");
-      setFeedback("Reparación cerrada, equipo disponible y actividad registrada en Bitácora.");
+      setFeedback(backend.mode === "supabase"
+        ? "Reparación cerrada, equipo disponible y actividad registrada en Bitácora."
+        : "Reparación cerrada y equipo disponible.");
     } finally {
       setBusy(false);
     }

--- a/src/components/maintenance-store.tsx
+++ b/src/components/maintenance-store.tsx
@@ -3,7 +3,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useOpsStore } from "@/components/ops-store";
 import type { AlertSeverity } from "@/lib/domain";
-import type { EquipmentRecord, MaintenanceFailureType, MaintenanceTicket } from "@/lib/maintenance-domain";
+import type { EquipmentRecord, MaintenanceFailureType, MaintenanceSpareUse, MaintenanceTicket } from "@/lib/maintenance-domain";
 import { seedEquipment, seedMaintenanceTickets } from "@/lib/maintenance-data";
 import {
   closeRemoteMaintenanceTicket,
@@ -12,7 +12,7 @@ import {
   startRemoteRepair,
 } from "@/lib/supabase/maintenance-repository";
 
-const STORAGE_KEY = "greenatics-ops-maintenance-mvp-004";
+const STORAGE_KEY = "greenatics-ops-maintenance-mvp-005";
 
 type Result = { ok: true } | { ok: false; error: string };
 type CreateResult = { ok: true; id: string } | { ok: false; error: string };
@@ -25,7 +25,13 @@ type FailurePayload = {
   description: string;
   evidenceRefs: string[];
 };
-type ClosePayload = { cause: string; resolution: string; evidenceRefs: string[] };
+type ClosePayload = {
+  cause: string;
+  resolution: string;
+  evidenceRefs: string[];
+  workerIds: string[];
+  spares: MaintenanceSpareUse[];
+};
 type LegacyStoredTicket = Omit<MaintenanceTicket, "failedAt" | "failureType" | "failureEvidenceRefs" | "repairEvidenceRefs"> & {
   failedAt?: string;
   failureType?: MaintenanceFailureType;
@@ -62,7 +68,7 @@ function normalizeStoredTicket(ticket: LegacyStoredTicket): MaintenanceTicket {
 }
 
 export function MaintenanceStoreProvider({ children }: { children: ReactNode }) {
-  const { backend, access } = useOpsStore();
+  const { backend, access, workers } = useOpsStore();
   const remoteMode = backend.mode === "supabase";
   const [equipment, setEquipment] = useState<EquipmentRecord[]>(() => remoteMode ? [] : seedEquipment);
   const [tickets, setTickets] = useState<MaintenanceTicket[]>(() => remoteMode ? [] : seedMaintenanceTickets);
@@ -210,6 +216,11 @@ export function MaintenanceStoreProvider({ children }: { children: ReactNode }) 
       if (ticket.status !== "repairing" || !ticket.repairStartedAt) return { ok: false, error: "Debes iniciar la reparación antes de cerrarla." };
       if (!payload.cause.trim()) return { ok: false, error: "Registra la causa encontrada." };
       if (!payload.resolution.trim()) return { ok: false, error: "Registra la acción realizada." };
+      if (payload.workerIds.length === 0) return { ok: false, error: "Selecciona al menos un trabajador para cerrar la reparación." };
+      if (new Set(payload.workerIds).size !== payload.workerIds.length) return { ok: false, error: "La lista de trabajadores contiene duplicados." };
+      const activeWorkers = new Set(workers.filter((worker) => worker.plantId === ticket.plantId && !worker.historical).map((worker) => worker.id));
+      if (payload.workerIds.some((id) => !activeWorkers.has(id))) return { ok: false, error: "Uno o más trabajadores no pertenecen a la planta o están inactivos." };
+      if (payload.spares.some((spare) => !spare.supplyId || !spare.lotCode.trim() || !Number.isFinite(spare.quantity) || spare.quantity <= 0)) return { ok: false, error: "Cada repuesto debe incluir insumo, lote y una cantidad mayor que cero." };
 
       if (remoteMode) {
         try {
@@ -244,7 +255,7 @@ export function MaintenanceStoreProvider({ children }: { children: ReactNode }) 
       setError(undefined);
       window.localStorage.removeItem(STORAGE_KEY);
     },
-  }), [equipment, error, ready, refreshMaintenance, reloadRemote, remoteMode, tickets]);
+  }), [equipment, error, ready, refreshMaintenance, reloadRemote, remoteMode, tickets, workers]);
 
   return <MaintenanceContext.Provider value={value}>{children}</MaintenanceContext.Provider>;
 }

--- a/src/lib/maintenance-domain.ts
+++ b/src/lib/maintenance-domain.ts
@@ -12,6 +12,12 @@ export type MaintenanceFailureType =
   | "structural"
   | "other";
 
+export type MaintenanceSpareUse = {
+  supplyId: string;
+  lotCode: string;
+  quantity: number;
+};
+
 export type EquipmentRecord = {
   id: string;
   plantId: string;
@@ -41,6 +47,7 @@ export type MaintenanceTicket = {
   resolution?: string;
   failureEvidenceRefs?: string[];
   repairEvidenceRefs?: string[];
+  repairActivityId?: string;
   status: MaintenanceStatus;
 };
 

--- a/src/lib/supabase/maintenance-repository.ts
+++ b/src/lib/supabase/maintenance-repository.ts
@@ -3,6 +3,7 @@ import type { AlertSeverity } from "@/lib/domain";
 import type {
   EquipmentRecord,
   MaintenanceFailureType,
+  MaintenanceSpareUse,
   MaintenanceTicket,
 } from "@/lib/maintenance-domain";
 import type { PlantAccess } from "@/lib/ops-data-contract";
@@ -32,6 +33,7 @@ type TicketRow = {
   closed_at?: string | null;
   cause?: string | null;
   resolution?: string | null;
+  repair_activity_id?: string | null;
 };
 
 type EvidenceRow = {
@@ -56,6 +58,8 @@ export type RemoteMaintenanceClosePayload = {
   cause: string;
   resolution: string;
   evidenceRefs: string[];
+  workerIds: string[];
+  spares: MaintenanceSpareUse[];
 };
 
 function errorMessage(scope: string, error: { message?: string; code?: string } | null) {
@@ -76,7 +80,7 @@ export async function loadRemoteMaintenance(
   const [equipmentResult, ticketResult, evidenceResult] = await Promise.all([
     client.from("equipment").select("id,plant_id,code,name,area,status").in("plant_id", plantIds).order("code"),
     client.from("maintenance_tickets")
-      .select("id,equipment_id,plant_id,severity,failure_type,title,description,status,failed_at,opened_at,repair_started_at,closed_at,cause,resolution")
+      .select("id,equipment_id,plant_id,severity,failure_type,title,description,status,failed_at,opened_at,repair_started_at,closed_at,cause,resolution,repair_activity_id")
       .in("plant_id", plantIds)
       .order("opened_at", { ascending: false }),
     client.from("maintenance_ticket_evidence")
@@ -132,6 +136,7 @@ export async function loadRemoteMaintenance(
       resolution: row.resolution || undefined,
       failureEvidenceRefs: evidence.failure,
       repairEvidenceRefs: evidence.repair,
+      repairActivityId: row.repair_activity_id || undefined,
       status: row.status,
     };
   });
@@ -174,10 +179,11 @@ export async function closeRemoteMaintenanceTicket(
     repair_ended: new Date().toISOString(),
     root_cause: payload.cause.trim(),
     repair_action: payload.resolution.trim(),
-    spare_supply_ids: [],
-    spare_lot_codes: [],
-    spare_quantities: [],
+    spare_supply_ids: payload.spares.map((item) => item.supplyId),
+    spare_lot_codes: payload.spares.map((item) => item.lotCode),
+    spare_quantities: payload.spares.map((item) => item.quantity),
     repair_evidence_refs: payload.evidenceRefs,
+    employee_ids: payload.workerIds,
   });
   if (error) throw new Error(errorMessage("No fue posible cerrar la reparación", error));
 }

--- a/supabase/migrations/0041_maintenance_repair_activity_link.sql
+++ b/supabase/migrations/0041_maintenance_repair_activity_link.sql
@@ -1,0 +1,179 @@
+-- R2.4B · Maintenance repair -> canonical activity.
+-- New repair closes create exactly one canonical maintenance activity in the same transaction.
+-- Existing/historical tickets remain nullable to avoid inventing labor records.
+
+alter table public.maintenance_tickets
+  add column if not exists repair_activity_id uuid;
+
+alter table public.maintenance_tickets
+  drop constraint if exists maintenance_tickets_repair_activity_plant_fk;
+alter table public.maintenance_tickets
+  add constraint maintenance_tickets_repair_activity_plant_fk
+  foreign key (repair_activity_id,plant_id)
+  references public.activities(id,plant_id)
+  on delete restrict;
+
+create unique index if not exists maintenance_tickets_repair_activity_uidx
+  on public.maintenance_tickets(repair_activity_id)
+  where repair_activity_id is not null;
+
+create or replace function private.insert_maintenance_repair_activity(
+  target_ticket uuid,
+  employee_ids uuid[],
+  repair_ended timestamptz,
+  root_cause text,
+  repair_action text
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path=''
+as $$
+declare
+  ticket public.maintenance_tickets%rowtype;
+  asset public.equipment%rowtype;
+  canonical_process uuid;
+  process_name text;
+  template_id uuid;
+  template_name text;
+  activity_id uuid;
+begin
+  select * into ticket from public.maintenance_tickets t where t.id=target_ticket for update;
+  if not found then raise exception 'Ticket de mantenimiento no encontrado.'; end if;
+  if ticket.status<>'repairing' or ticket.repair_started_at is null then raise exception 'La reparación debe estar iniciada antes de registrar su actividad.'; end if;
+  if ticket.repair_activity_id is not null then raise exception 'La reparación ya tiene una actividad canónica.'; end if;
+
+  select * into asset from public.equipment e where e.id=ticket.equipment_id and e.plant_id=ticket.plant_id;
+  if not found then raise exception 'Equipo de mantenimiento no encontrado en la planta.'; end if;
+
+  perform private.assert_activity_log_workers(ticket.plant_id,employee_ids,ticket.repair_started_at,repair_ended);
+
+  select p.id,p.name into canonical_process,process_name
+  from public.operational_processes p
+  where p.plant_id=ticket.plant_id and p.code='MANTENIMIENTO' and p.active;
+  if not found then raise exception 'La planta no tiene un proceso activo de mantenimiento.'; end if;
+
+  select t.id,t.name into template_id,template_name
+  from public.activity_templates t
+  where t.plant_id=ticket.plant_id
+    and t.process_id=canonical_process
+    and t.code='MANTENIMIENTO_HERRAMIENTAS_EQUIPOS'
+    and t.active;
+
+  insert into public.activities(
+    plant_id,title,process,started_at,ended_at,equipment_id,equipment_ref,
+    process_id,activity_template_id,activity_comment,source_kind,created_by
+  ) values (
+    ticket.plant_id,
+    coalesce(template_name,'Mantenimiento de equipo'),
+    process_name,
+    ticket.repair_started_at,
+    repair_ended,
+    asset.id,
+    asset.code,
+    canonical_process,
+    template_id,
+    'Ticket '||ticket.id::text||' · Causa: '||btrim(root_cause)||' · Acción: '||btrim(repair_action),
+    'app',
+    auth.uid()
+  ) returning id into activity_id;
+
+  insert into public.activity_workers(activity_id,employee_id)
+  select activity_id,value from unnest(employee_ids) value;
+
+  return activity_id;
+end;
+$$;
+
+revoke all on function private.insert_maintenance_repair_activity(uuid,uuid[],timestamptz,text,text)
+from public,anon,authenticated;
+
+-- Extend the guarded close RPC with actual repair workers. Spare-part and evidence semantics stay unchanged.
+create or replace function public.ops_close_equipment_repair_v2(
+  target_ticket uuid,
+  repair_ended timestamptz,
+  root_cause text,
+  repair_action text,
+  spare_supply_ids uuid[] default '{}'::uuid[],
+  spare_lot_codes text[] default '{}'::text[],
+  spare_quantities numeric[] default '{}'::numeric[],
+  repair_evidence_refs text[] default '{}'::text[],
+  employee_ids uuid[] default '{}'::uuid[]
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  ticket public.maintenance_tickets%rowtype;
+  supplied_count integer;
+  worker_count integer;
+  idx integer;
+  movement_id uuid;
+  evidence_ref text;
+  repair_activity uuid;
+begin
+  select * into ticket from public.maintenance_tickets t where t.id=target_ticket for update;
+  if not found then raise exception 'Ticket de mantenimiento no encontrado.'; end if;
+  if not private.has_plant_role(ticket.plant_id,array['maintenance','supervisor','technical','admin','director']) then raise exception 'No tienes permiso para cerrar reparaciones en esta planta.'; end if;
+  if ticket.status<>'repairing' or ticket.repair_started_at is null then raise exception 'La reparación debe estar iniciada antes de cerrarse.'; end if;
+  if repair_ended is null or repair_ended<ticket.repair_started_at then raise exception 'El fin de reparación no puede ser anterior al inicio.'; end if;
+  if repair_ended>now()+interval '5 minutes' then raise exception 'El fin de reparación no puede estar en el futuro.'; end if;
+  if nullif(btrim(root_cause),'') is null then raise exception 'Registra la causa encontrada.'; end if;
+  if nullif(btrim(repair_action),'') is null then raise exception 'Registra la acción realizada.'; end if;
+
+  worker_count:=coalesce(cardinality(employee_ids),0);
+  if worker_count=0 then raise exception 'Selecciona al menos un trabajador para cerrar la reparación.'; end if;
+  if worker_count<>(select count(distinct value) from unnest(employee_ids) value) then raise exception 'Los trabajadores de reparación contienen duplicados.'; end if;
+
+  -- Assert and lock workers before any stock/evidence mutation.
+  perform private.assert_activity_log_workers(ticket.plant_id,employee_ids,ticket.repair_started_at,repair_ended);
+
+  supplied_count:=coalesce(cardinality(spare_supply_ids),0);
+  if supplied_count<>coalesce(cardinality(spare_lot_codes),0) or supplied_count<>coalesce(cardinality(spare_quantities),0) then raise exception 'Cada repuesto debe incluir insumo, lote y cantidad.'; end if;
+  if exists(select 1 from unnest(coalesce(spare_quantities,'{}'::numeric[])) value where value is null or value<=0) then raise exception 'Las cantidades de repuestos deben ser mayores que cero.'; end if;
+
+  if supplied_count>0 then
+    for idx in 1..supplied_count loop
+      if nullif(btrim(spare_lot_codes[idx]),'') is null then raise exception 'Indica el lote de cada repuesto.'; end if;
+      movement_id:=private.consume_maintenance_spare(
+        ticket.plant_id,
+        spare_supply_ids[idx],
+        btrim(spare_lot_codes[idx]),
+        spare_quantities[idx],
+        (repair_ended at time zone 'America/Bogota')::date,
+        ticket.equipment_id,
+        ticket.id
+      );
+      update public.supply_movements set reference_id=ticket.id where id=movement_id;
+    end loop;
+  end if;
+
+  foreach evidence_ref in array coalesce(repair_evidence_refs,'{}'::text[]) loop
+    if nullif(btrim(evidence_ref),'') is null then raise exception 'Las referencias de evidencia no pueden estar vacías.'; end if;
+    if length(btrim(evidence_ref))>1000 then raise exception 'Una referencia de evidencia es demasiado larga.'; end if;
+    insert into public.maintenance_ticket_evidence(ticket_id,plant_id,stage,evidence_ref,created_by)
+    values(ticket.id,ticket.plant_id,'repair',btrim(evidence_ref),auth.uid());
+  end loop;
+
+  repair_activity:=private.insert_maintenance_repair_activity(
+    ticket.id,employee_ids,repair_ended,root_cause,repair_action
+  );
+
+  update public.maintenance_tickets
+  set status='closed',closed_at=repair_ended,cause=btrim(root_cause),resolution=btrim(repair_action),repair_activity_id=repair_activity
+  where id=ticket.id;
+  update public.equipment set status='available' where id=ticket.equipment_id;
+end;
+$$;
+
+-- Remove execute on the previous 8-argument overload so clients cannot close without workers.
+revoke all on function public.ops_close_equipment_repair_v2(uuid,timestamptz,text,text,uuid[],text[],numeric[],text[]) from public,anon,authenticated;
+grant execute on function public.ops_close_equipment_repair_v2(uuid,timestamptz,text,text,uuid[],text[],numeric[],text[],uuid[]) to authenticated;
+revoke all on function public.ops_close_equipment_repair_v2(uuid,timestamptz,text,text,uuid[],text[],numeric[],text[],uuid[]) from public,anon;
+
+comment on column public.maintenance_tickets.repair_activity_id is
+'Canonical activity created atomically when a new Maintenance V2 repair closes; null is reserved for historical/pre-link tickets.';
+comment on function private.insert_maintenance_repair_activity(uuid,uuid[],timestamptz,text,text) is
+'Internal bridge from one validated repair interval to one canonical maintenance activity and its actual workers.';

--- a/supabase/migrations/0041_maintenance_repair_activity_link.sql
+++ b/supabase/migrations/0041_maintenance_repair_activity_link.sql
@@ -168,10 +168,10 @@ begin
 end;
 $$;
 
--- Remove execute on the previous 8-argument overload so clients cannot close without workers.
-revoke all on function public.ops_close_equipment_repair_v2(uuid,timestamptz,text,text,uuid[],text[],numeric[],text[]) from public,anon,authenticated;
-grant execute on function public.ops_close_equipment_repair_v2(uuid,timestamptz,text,text,uuid[],text[],numeric[],text[],uuid[]) to authenticated;
+-- Remove the previous overload entirely: there is no supported close path without actual workers.
+drop function if exists public.ops_close_equipment_repair_v2(uuid,timestamptz,text,text,uuid[],text[],numeric[],text[]);
 revoke all on function public.ops_close_equipment_repair_v2(uuid,timestamptz,text,text,uuid[],text[],numeric[],text[],uuid[]) from public,anon;
+grant execute on function public.ops_close_equipment_repair_v2(uuid,timestamptz,text,text,uuid[],text[],numeric[],text[],uuid[]) to authenticated;
 
 comment on column public.maintenance_tickets.repair_activity_id is
 'Canonical activity created atomically when a new Maintenance V2 repair closes; null is reserved for historical/pre-link tickets.';

--- a/supabase/tests/database/maintenance_activity_link.test.sql
+++ b/supabase/tests/database/maintenance_activity_link.test.sql
@@ -1,0 +1,86 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+select plan(17);
+
+select has_column('public','maintenance_tickets','repair_activity_id','maintenance ticket exposes canonical repair activity link');
+select ok(exists(
+  select 1 from pg_constraint c
+  where c.conrelid='public.maintenance_tickets'::regclass
+    and c.conname='maintenance_tickets_repair_activity_plant_fk'
+),'repair activity link has same-plant FK');
+select ok(exists(
+  select 1 from pg_indexes
+  where schemaname='public' and tablename='maintenance_tickets'
+    and indexname='maintenance_tickets_repair_activity_uidx'
+),'repair activity link is unique when present');
+select ok(to_regprocedure('private.insert_maintenance_repair_activity(uuid,uuid[],timestamp with time zone,text,text)') is not null,'private maintenance activity bridge exists');
+select ok(not has_function_privilege('authenticated','private.insert_maintenance_repair_activity(uuid,uuid[],timestamp with time zone,text,text)','EXECUTE'),'authenticated cannot execute private maintenance bridge');
+select ok(has_function_privilege('authenticated','public.ops_close_equipment_repair_v2(uuid,timestamp with time zone,text,text,uuid[],text[],numeric[],text[],uuid[])','EXECUTE'),'authenticated can execute worker-aware repair close');
+select ok(not has_function_privilege('authenticated','public.ops_close_equipment_repair_v2(uuid,timestamp with time zone,text,text,uuid[],text[],numeric[],text[])','EXECUTE'),'legacy repair close overload cannot bypass workers');
+
+insert into auth.users(id,email,created_at,updated_at) values
+ ('c1000000-0000-4000-8000-000000000001','mnt-link-tech@greenatics.test',now(),now());
+insert into public.plants(id,code,name,active) values
+ ('c2000000-0000-4000-8000-000000000001','MNT-LNK','Maintenance Link QA',true);
+insert into public.profiles(id,display_name) values
+ ('c1000000-0000-4000-8000-000000000001','Maintenance Link Technician');
+insert into public.plant_memberships(user_id,plant_id,role) values
+ ('c1000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','maintenance');
+insert into public.operational_processes(id,plant_id,code,name,active) values
+ ('c3000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','MANTENIMIENTO','Mantenimiento',true);
+insert into public.activity_templates(id,plant_id,process_id,code,name,allows_unplanned,active) values
+ ('c4000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','c3000000-0000-4000-8000-000000000001','MANTENIMIENTO_HERRAMIENTAS_EQUIPOS','Mantenimiento de herramientas o equipos',true,true);
+insert into public.employees(id,plant_id,code,full_name,active) values
+ ('c5000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','MNT-01','Técnico QA',true),
+ ('c5000000-0000-4000-8000-000000000002','c2000000-0000-4000-8000-000000000001','MNT-02','Auxiliar QA',true);
+insert into public.equipment(id,plant_id,code,name,status,area) values
+ ('c6000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','MNT-EQ-01','Equipo mantenimiento QA','available','QA');
+
+set local role authenticated;
+set local request.jwt.claim.sub='c1000000-0000-4000-8000-000000000001';
+
+select lives_ok($$select public.ops_report_equipment_failure_v2(
+ 'c6000000-0000-4000-8000-000000000001','mechanical',now()-interval '60 minutes','high',
+ 'Falla enlace','Equipo detenido',array['evidencia://falla'])
+$$,'failure can be reported');
+select lives_ok($$select public.ops_start_equipment_repair_v2(
+ (select id from public.maintenance_tickets where equipment_id='c6000000-0000-4000-8000-000000000001'),
+ now()-interval '45 minutes'
+)$$,'repair can start');
+select throws_ok($$select public.ops_close_equipment_repair_v2(
+ (select id from public.maintenance_tickets where equipment_id='c6000000-0000-4000-8000-000000000001'),
+ now()-interval '10 minutes','Causa','Acción','{}'::uuid[],'{}'::text[],'{}'::numeric[],array['evidencia://repair'],'{}'::uuid[]
+)$$,'Selecciona al menos un trabajador para cerrar la reparación.','repair close requires actual workers');
+
+select lives_ok($$select public.ops_close_equipment_repair_v2(
+ (select id from public.maintenance_tickets where equipment_id='c6000000-0000-4000-8000-000000000001'),
+ now()-interval '10 minutes','Rodamiento desgastado','Cambio y ajuste','{}'::uuid[],'{}'::text[],'{}'::numeric[],array['evidencia://repair'],array['c5000000-0000-4000-8000-000000000001']::uuid[]
+)$$,'repair closes atomically with worker-aware activity');
+select is((select status from public.maintenance_tickets where equipment_id='c6000000-0000-4000-8000-000000000001'),'closed'::text,'ticket closes');
+select is((select status from public.equipment where id='c6000000-0000-4000-8000-000000000001'),'available'::text,'equipment returns available');
+select is((select count(*) from public.activities where plant_id='c2000000-0000-4000-8000-000000000001'),1::bigint,'exactly one canonical repair activity is created');
+select is((select count(*) from public.activity_workers aw join public.activities a on a.id=aw.activity_id where a.plant_id='c2000000-0000-4000-8000-000000000001'),1::bigint,'repair worker is canonical in activity_workers');
+select is((select a.equipment_id from public.activities a where a.plant_id='c2000000-0000-4000-8000-000000000001'),'c6000000-0000-4000-8000-000000000001'::uuid,'canonical activity links the repaired equipment');
+select is((select t.repair_activity_id from public.maintenance_tickets t where t.equipment_id='c6000000-0000-4000-8000-000000000001'),(select a.id from public.activities a where a.plant_id='c2000000-0000-4000-8000-000000000001'),'ticket links exactly that canonical activity');
+
+-- Create an overlapping canonical activity before a second repair closes; close must fail atomically.
+reset role;
+insert into public.equipment(id,plant_id,code,name,status,area) values
+ ('c6000000-0000-4000-8000-000000000002','c2000000-0000-4000-8000-000000000001','MNT-EQ-02','Equipo overlap QA','maintenance','QA');
+insert into public.maintenance_tickets(id,equipment_id,plant_id,severity,failure_type,title,description,status,failed_at,opened_at,repair_started_at,created_by)
+values('c7000000-0000-4000-8000-000000000002','c6000000-0000-4000-8000-000000000002','c2000000-0000-4000-8000-000000000001','medium','mechanical','Overlap','Overlap','repairing',now()-interval '40 minutes',now()-interval '39 minutes',now()-interval '30 minutes','c1000000-0000-4000-8000-000000000001');
+insert into public.activities(id,plant_id,title,process,started_at,ended_at,process_id,source_kind)
+values('c8000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','Otra actividad','Mantenimiento',now()-interval '25 minutes',now()-interval '5 minutes','c3000000-0000-4000-8000-000000000001','app');
+insert into public.activity_workers(activity_id,employee_id) values
+ ('c8000000-0000-4000-8000-000000000001','c5000000-0000-4000-8000-000000000002');
+set local role authenticated;
+set local request.jwt.claim.sub='c1000000-0000-4000-8000-000000000001';
+select throws_like($$select public.ops_close_equipment_repair_v2(
+ 'c7000000-0000-4000-8000-000000000002',now(),'Causa','Acción','{}'::uuid[],'{}'::text[],'{}'::numeric[],'{}'::text[],array['c5000000-0000-4000-8000-000000000002']::uuid[]
+)$$,'%otra actividad real%','worker overlap blocks maintenance close');
+select is((select status from public.maintenance_tickets where id='c7000000-0000-4000-8000-000000000002'),'repairing'::text,'failed close leaves ticket repairing');
+select is((select repair_activity_id from public.maintenance_tickets where id='c7000000-0000-4000-8000-000000000002'),null::uuid,'failed close leaves no activity link');
+
+reset role;
+select * from finish();
+rollback;

--- a/supabase/tests/database/maintenance_activity_link.test.sql
+++ b/supabase/tests/database/maintenance_activity_link.test.sql
@@ -16,7 +16,7 @@ select ok(exists(
 select ok(to_regprocedure('private.insert_maintenance_repair_activity(uuid,uuid[],timestamp with time zone,text,text)') is not null,'private maintenance activity bridge exists');
 select ok(not has_function_privilege('authenticated','private.insert_maintenance_repair_activity(uuid,uuid[],timestamp with time zone,text,text)','EXECUTE'),'authenticated cannot execute private maintenance bridge');
 select ok(has_function_privilege('authenticated','public.ops_close_equipment_repair_v2(uuid,timestamp with time zone,text,text,uuid[],text[],numeric[],text[],uuid[])','EXECUTE'),'authenticated can execute worker-aware repair close');
-select ok(not has_function_privilege('authenticated','public.ops_close_equipment_repair_v2(uuid,timestamp with time zone,text,text,uuid[],text[],numeric[],text[])','EXECUTE'),'legacy repair close overload cannot bypass workers');
+select ok(to_regprocedure('public.ops_close_equipment_repair_v2(uuid,timestamp with time zone,text,text,uuid[],text[],numeric[],text[])') is null,'legacy repair close overload is removed');
 
 insert into auth.users(id,email,created_at,updated_at) values
  ('c1000000-0000-4000-8000-000000000001','mnt-link-tech@greenatics.test',now(),now());

--- a/supabase/tests/database/maintenance_activity_link.test.sql
+++ b/supabase/tests/database/maintenance_activity_link.test.sql
@@ -1,6 +1,6 @@
 begin;
 create extension if not exists pgtap with schema extensions;
-select plan(17);
+select plan(20);
 
 select has_column('public','maintenance_tickets','repair_activity_id','maintenance ticket exposes canonical repair activity link');
 select ok(exists(
@@ -63,7 +63,6 @@ select is((select count(*) from public.activity_workers aw join public.activitie
 select is((select a.equipment_id from public.activities a where a.plant_id='c2000000-0000-4000-8000-000000000001'),'c6000000-0000-4000-8000-000000000001'::uuid,'canonical activity links the repaired equipment');
 select is((select t.repair_activity_id from public.maintenance_tickets t where t.equipment_id='c6000000-0000-4000-8000-000000000001'),(select a.id from public.activities a where a.plant_id='c2000000-0000-4000-8000-000000000001'),'ticket links exactly that canonical activity');
 
--- Create an overlapping canonical activity before a second repair closes; close must fail atomically.
 reset role;
 insert into public.equipment(id,plant_id,code,name,status,area) values
  ('c6000000-0000-4000-8000-000000000002','c2000000-0000-4000-8000-000000000001','MNT-EQ-02','Equipo overlap QA','maintenance','QA');

--- a/supabase/tests/database/maintenance_activity_link.test.sql
+++ b/supabase/tests/database/maintenance_activity_link.test.sql
@@ -30,9 +30,9 @@ insert into public.operational_processes(id,plant_id,code,name,active) values
  ('c3000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','MANTENIMIENTO','Mantenimiento',true);
 insert into public.activity_templates(id,plant_id,process_id,code,name,allows_unplanned,active) values
  ('c4000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','c3000000-0000-4000-8000-000000000001','MANTENIMIENTO_HERRAMIENTAS_EQUIPOS','Mantenimiento de herramientas o equipos',true,true);
-insert into public.employees(id,plant_id,code,full_name,active) values
- ('c5000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','MNT-01','Técnico QA',true),
- ('c5000000-0000-4000-8000-000000000002','c2000000-0000-4000-8000-000000000001','MNT-02','Auxiliar QA',true);
+insert into public.employees(id,plant_id,code,display_name,active,historical,provisional) values
+ ('c5000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','MNT_01','Técnico QA',true,false,false),
+ ('c5000000-0000-4000-8000-000000000002','c2000000-0000-4000-8000-000000000001','MNT_02','Auxiliar QA',true,false,false);
 insert into public.equipment(id,plant_id,code,name,status,area) values
  ('c6000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','MNT-EQ-01','Equipo mantenimiento QA','available','QA');
 

--- a/supabase/tests/database/maintenance_v2.test.sql
+++ b/supabase/tests/database/maintenance_v2.test.sql
@@ -22,6 +22,12 @@ insert into public.profiles(id,display_name) values
 insert into public.plant_memberships(user_id,plant_id,role) values
  ('a1000000-0000-4000-8000-000000000001','a2000000-0000-4000-8000-000000000001','operator'),
  ('a1000000-0000-4000-8000-000000000002','a2000000-0000-4000-8000-000000000001','maintenance');
+insert into public.operational_processes(id,plant_id,code,name,active) values
+ ('a7000000-0000-4000-8000-000000000001','a2000000-0000-4000-8000-000000000001','MANTENIMIENTO','Mantenimiento',true);
+insert into public.activity_templates(id,plant_id,process_id,code,name,allows_unplanned,active) values
+ ('a7100000-0000-4000-8000-000000000001','a2000000-0000-4000-8000-000000000001','a7000000-0000-4000-8000-000000000001','MANTENIMIENTO_HERRAMIENTAS_EQUIPOS','Mantenimiento de herramientas o equipos',true,true);
+insert into public.employees(id,plant_id,code,display_name,active,historical,provisional) values
+ ('a7200000-0000-4000-8000-000000000001','a2000000-0000-4000-8000-000000000001','MNT_QA_01','Técnico mantenimiento QA',true,false,false);
 insert into public.equipment(id,plant_id,code,name,status,area) values
  ('a3000000-0000-4000-8000-000000000001','a2000000-0000-4000-8000-000000000001','MNT-01','Equipo QA','available','Proceso QA'),
  ('a3000000-0000-4000-8000-000000000002','a2000000-0000-4000-8000-000000000001','MNT-02','Equipo sin programación','available','Proceso QA');
@@ -47,9 +53,9 @@ select lives_ok($$select public.ops_start_equipment_repair_v2((select id from pu
 select is((select status from public.maintenance_tickets where equipment_id='a3000000-0000-4000-8000-000000000001'),'repairing'::text,'ticket moves to repairing');
 select is((select status from public.equipment where id='a3000000-0000-4000-8000-000000000001'),'maintenance'::text,'equipment moves to maintenance');
 select throws_like($$select public.consume_supply('a2000000-0000-4000-8000-000000000001','a5000000-0000-4000-8000-000000000001','LOT-MNT-QA',1,current_date,'Atajo mantenimiento','a3000000-0000-4000-8000-000000000001','maintenance:manual','No debe permitirse')$$,'%Sin permiso para registrar consumo%','maintenance cannot bypass repair lifecycle with generic supply consumption');
-select throws_like($$select public.ops_close_equipment_repair_v2((select id from public.maintenance_tickets where equipment_id='a3000000-0000-4000-8000-000000000001'),now()-interval '1 hour','Rodamiento fatigado','Cambio de rodamiento',array['a5000000-0000-4000-8000-000000000001'::uuid],array['LOT-MNT-QA'],array[6::numeric],array[]::text[])$$,'%Stock insuficiente%','close rolls back when spare stock is insufficient');
+select throws_like($$select public.ops_close_equipment_repair_v2((select id from public.maintenance_tickets where equipment_id='a3000000-0000-4000-8000-000000000001'),now()-interval '1 hour','Rodamiento fatigado','Cambio de rodamiento',array['a5000000-0000-4000-8000-000000000001'::uuid],array['LOT-MNT-QA'],array[6::numeric],array[]::text[],array['a7200000-0000-4000-8000-000000000001'::uuid])$$,'%Stock insuficiente%','close rolls back when spare stock is insufficient');
 select is((select coalesce(sum(case when kind in ('receipt','adjustment_in') then quantity else -quantity end),0) from public.supply_movements where supply_id='a5000000-0000-4000-8000-000000000001' and lot_code='LOT-MNT-QA'),5::numeric,'failed close does not consume physical stock');
-select lives_ok($$select public.ops_close_equipment_repair_v2((select id from public.maintenance_tickets where equipment_id='a3000000-0000-4000-8000-000000000001'),now()-interval '1 hour','Rodamiento fatigado','Cambio de rodamiento y prueba funcional',array['a5000000-0000-4000-8000-000000000001'::uuid],array['LOT-MNT-QA'],array[2::numeric],array['evidencia://reparacion-qa'])$$,'repair closes atomically with physical spare consumption');
+select lives_ok($$select public.ops_close_equipment_repair_v2((select id from public.maintenance_tickets where equipment_id='a3000000-0000-4000-8000-000000000001'),now()-interval '1 hour','Rodamiento fatigado','Cambio de rodamiento y prueba funcional',array['a5000000-0000-4000-8000-000000000001'::uuid],array['LOT-MNT-QA'],array[2::numeric],array['evidencia://reparacion-qa'],array['a7200000-0000-4000-8000-000000000001'::uuid])$$,'repair closes atomically with physical spare consumption');
 select is((select status from public.maintenance_tickets where equipment_id='a3000000-0000-4000-8000-000000000001'),'closed'::text,'ticket closes after repair');
 select is((select cause from public.maintenance_tickets where equipment_id='a3000000-0000-4000-8000-000000000001'),'Rodamiento fatigado'::text,'root cause is persisted');
 select is((select status from public.equipment where id='a3000000-0000-4000-8000-000000000001'),'available'::text,'closed repair returns equipment to available');


### PR DESCRIPTION
## Objetivo
Cerrar R2.4 Mantenimiento haciendo que cada reparación nueva y verificablemente cerrada produzca una única actividad canónica con trabajadores reales, conserve la trazabilidad de repuestos físicos por lote y alimente la misma Bitácora/horas-persona usada por el resto de OPS.

## Cambios
- `maintenance_tickets` incorpora `repair_activity_id` nullable para compatibilidad histórica, con FK de misma planta y vínculo 1:1.
- El cierre V2 exige al menos un trabajador activo de la planta y reutiliza `private.assert_activity_log_workers` para bloquear solapamientos con otras actividades reales.
- El cierre crea en la misma transacción una actividad del proceso `MANTENIMIENTO`, usando `MANTENIMIENTO_HERRAMIENTAS_EQUIPOS` cuando está disponible, con equipo, intervalo real, causa, acción y `activity_workers`.
- Se elimina el overload antiguo de cierre que permitía finalizar reparaciones sin trabajadores.
- Se conserva el consumo atómico de repuestos por lote y evidencia de reparación; cualquier fallo revierte stock, actividad y cierre.
- La UI permite seleccionar trabajadores y repuestos físicos disponibles por lote desde el inventario existente, sin crear un ledger paralelo.
- El historial muestra vínculo con Bitácora, trabajadores y consumos de repuestos referenciados al ticket.
- Después de un cierre remoto se refrescan Mantenimiento, Bitácora e Inventario.
- Los cierres históricos/pre-link permanecen sin `repair_activity_id`; no se inventa backfill.

## Pruebas
- nueva suite pgTAP `maintenance_activity_link.test.sql` para FK/1:1, ACL, trabajadores obligatorios, enlace actividad/equipo, overlap y rollback;
- `maintenance_v2.test.sql` actualizado para cierre con trabajadores y consumo físico;
- E2E de mantenimiento actualizado únicamente para seleccionar un trabajador antes del cierre;
- CI completo quality + database + desktop + mobile requerido antes de merge.

## Guardrails
- sin cambios manuales en Supabase hosted;
- sin doble registro de trabajadores;
- `activity_workers` es la fuente canónica de horas-persona;
- repuestos reutilizan `supply_movements` existente y quedan referenciados al ticket.