### PR TITLE
feat(r2): enforce production inventory write boundary

### DIFF
--- a/supabase/migrations/0042_production_inventory_write_boundary.sql
+++ b/supabase/migrations/0042_production_inventory_write_boundary.sql
@@ -1,0 +1,94 @@
+-- R2.5A · Production + finished-goods inventory write boundary.
+-- The app already uses guarded SECURITY DEFINER RPCs for production and dispatch,
+-- but legacy table INSERT policies still allowed authenticated clients to bypass those
+-- transactional contracts. New writes are RPC-only; the append-only ledgers remain readable.
+
+-- Remove legacy direct-DML paths.
+drop policy if exists "production_operator_insert" on public.production_records;
+drop policy if exists "inventory_dispatch_insert" on public.inventory_movements;
+drop policy if exists "inventory_adjustment_insert" on public.inventory_movements;
+
+revoke insert, update, delete on table public.production_records from authenticated;
+revoke insert, update, delete on table public.inventory_movements from authenticated;
+
+grant select on table public.production_records to authenticated;
+grant select on table public.inventory_movements to authenticated;
+
+-- Preserve governed stock corrections without reopening direct table writes.
+-- Adjustments can only target an existing physical lot and require an explicit reason.
+create or replace function public.ops_adjust_inventory(
+  target_plant uuid,
+  target_product uuid,
+  target_lot text,
+  adjustment_kind text,
+  adjustment_quantity numeric,
+  adjustment_reason text,
+  adjustment_reference uuid default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  product_active boolean;
+  movement_id uuid;
+  normalized_lot text;
+begin
+  if not private.has_plant_role(target_plant,array['supervisor','technical','admin','director']) then
+    raise exception 'No tienes permiso para ajustar inventario en esta planta.';
+  end if;
+  if adjustment_kind is null or adjustment_kind not in ('adjustment_in','adjustment_out') then
+    raise exception 'El tipo de ajuste debe ser adjustment_in o adjustment_out.';
+  end if;
+  if adjustment_quantity is null or adjustment_quantity <= 0 then
+    raise exception 'La cantidad del ajuste debe ser mayor que cero.';
+  end if;
+  if nullif(btrim(target_lot),'') is null then
+    raise exception 'Selecciona un lote físico existente.';
+  end if;
+  if nullif(btrim(adjustment_reason),'') is null then
+    raise exception 'Registra el motivo del ajuste.';
+  end if;
+  if length(btrim(adjustment_reason)) > 1000 then
+    raise exception 'El motivo del ajuste es demasiado largo.';
+  end if;
+
+  select p.active into product_active
+  from public.inventory_products p
+  where p.id=target_product;
+  if product_active is null then raise exception 'Producto no encontrado.'; end if;
+  if not product_active then raise exception 'Producto inactivo.'; end if;
+
+  normalized_lot:=btrim(target_lot);
+  if not exists (
+    select 1
+    from public.inventory_movements m
+    where m.plant_id=target_plant
+      and m.product_id=target_product
+      and m.lot_code=normalized_lot
+  ) then
+    raise exception 'El lote seleccionado no existe para este producto y planta.';
+  end if;
+
+  insert into public.inventory_movements(
+    plant_id,product_id,lot_code,kind,quantity,reference_id,note,created_by
+  ) values (
+    target_plant,target_product,normalized_lot,adjustment_kind,adjustment_quantity,
+    adjustment_reference,btrim(adjustment_reason),auth.uid()
+  ) returning inventory_movements.id into movement_id;
+
+  -- adjustment_out is still serialized and protected by inventory_outflow_guard.
+  return movement_id;
+end;
+$$;
+
+revoke all on function public.ops_adjust_inventory(uuid,uuid,text,text,numeric,text,uuid) from public,anon;
+grant execute on function public.ops_adjust_inventory(uuid,uuid,text,text,numeric,text,uuid) to authenticated;
+
+comment on table public.production_records is
+'Append-only finished-goods production ledger. Authenticated clients read through plant RLS; new production is RPC-only through ops_record_production.';
+comment on table public.inventory_movements is
+'Append-only finished-goods kardex. Authenticated clients read through plant RLS; dispatches and adjustments are RPC-only.';
+comment on function public.ops_adjust_inventory(uuid,uuid,text,text,numeric,text,uuid) is
+'Governed append-only finished-goods stock correction for an existing lot; restricted to supervisor/technical/admin/director roles.';

--- a/supabase/tests/database/production_inventory_write_boundary.test.sql
+++ b/supabase/tests/database/production_inventory_write_boundary.test.sql
@@ -1,0 +1,77 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+select plan(21);
+
+select ok(has_table_privilege('authenticated','public.production_records','SELECT'),'authenticated retains production read access');
+select ok(not has_table_privilege('authenticated','public.production_records','INSERT'),'authenticated cannot insert production directly');
+select ok(not has_table_privilege('authenticated','public.production_records','UPDATE'),'authenticated cannot update production directly');
+select ok(not has_table_privilege('authenticated','public.production_records','DELETE'),'authenticated cannot delete production directly');
+select ok(has_table_privilege('authenticated','public.inventory_movements','SELECT'),'authenticated retains kardex read access');
+select ok(not has_table_privilege('authenticated','public.inventory_movements','INSERT'),'authenticated cannot insert kardex movements directly');
+select ok(not has_table_privilege('authenticated','public.inventory_movements','UPDATE'),'authenticated cannot update kardex movements directly');
+select ok(not has_table_privilege('authenticated','public.inventory_movements','DELETE'),'authenticated cannot delete kardex movements directly');
+select is((select count(*) from pg_policies where schemaname='public' and tablename='production_records' and policyname='production_operator_insert'),0::bigint,'legacy production direct-insert policy is removed');
+select is((select count(*) from pg_policies where schemaname='public' and tablename='inventory_movements' and policyname='inventory_dispatch_insert'),0::bigint,'legacy dispatch direct-insert policy is removed');
+select is((select count(*) from pg_policies where schemaname='public' and tablename='inventory_movements' and policyname='inventory_adjustment_insert'),0::bigint,'legacy adjustment direct-insert policy is removed');
+select ok(has_function_privilege('authenticated','public.ops_adjust_inventory(uuid,uuid,text,text,numeric,text,uuid)','EXECUTE'),'authenticated can execute governed adjustment RPC');
+
+insert into auth.users(id,email,created_at,updated_at) values
+ ('c1000000-0000-4000-8000-000000000001','inventory-boundary-supervisor@greenatics.test',now(),now());
+insert into public.plants(id,code,name,active) values
+ ('c2000000-0000-4000-8000-000000000001','INV-BND','Inventory Boundary QA',true);
+insert into public.profiles(id,display_name) values
+ ('c1000000-0000-4000-8000-000000000001','Inventory Boundary Supervisor');
+insert into public.plant_memberships(user_id,plant_id,role) values
+ ('c1000000-0000-4000-8000-000000000001','c2000000-0000-4000-8000-000000000001','supervisor');
+insert into public.inventory_products(id,name,unit,active) values
+ ('c3000000-0000-4000-8000-000000000001','Producto Boundary QA','kg',true);
+
+set local role authenticated;
+set local request.jwt.claim.sub='c1000000-0000-4000-8000-000000000001';
+
+select lives_ok($$select * from public.ops_record_production(
+ 'c2000000-0000-4000-8000-000000000001',
+ 'c3000000-0000-4000-8000-000000000001',
+ 20,
+ 'Producción QA',
+ null,
+ 'Lote para validar frontera RPC'
+)$$,'production remains available through guarded RPC');
+select is((select count(*) from public.production_records where plant_id='c2000000-0000-4000-8000-000000000001' and product_id='c3000000-0000-4000-8000-000000000001'),1::bigint,'production RPC creates exactly one production record');
+select is((select count(*) from public.inventory_movements where plant_id='c2000000-0000-4000-8000-000000000001' and product_id='c3000000-0000-4000-8000-000000000001' and kind='production'),1::bigint,'production RPC still creates exactly one kardex entry');
+
+select lives_ok($$select public.ops_dispatch_inventory(
+ 'c2000000-0000-4000-8000-000000000001',
+ 'c3000000-0000-4000-8000-000000000001',
+ (select lot_code from public.production_records where plant_id='c2000000-0000-4000-8000-000000000001' and product_id='c3000000-0000-4000-8000-000000000001' limit 1),
+ 5,
+ 'Despacho QA',
+ 'Salida por RPC',
+ null
+)$$,'dispatch remains available through guarded RPC');
+select is((select count(*) from public.inventory_movements where plant_id='c2000000-0000-4000-8000-000000000001' and product_id='c3000000-0000-4000-8000-000000000001' and kind='dispatch'),1::bigint,'dispatch RPC creates one append-only kardex movement');
+
+select lives_ok($$select public.ops_adjust_inventory(
+ 'c2000000-0000-4000-8000-000000000001',
+ 'c3000000-0000-4000-8000-000000000001',
+ (select lot_code from public.production_records where plant_id='c2000000-0000-4000-8000-000000000001' and product_id='c3000000-0000-4000-8000-000000000001' limit 1),
+ 'adjustment_in',
+ 2,
+ 'Conteo físico: ajuste positivo QA',
+ null
+)$$,'supervisor can append a governed positive adjustment');
+select is((select count(*) from public.inventory_movements where plant_id='c2000000-0000-4000-8000-000000000001' and product_id='c3000000-0000-4000-8000-000000000001' and kind='adjustment_in'),1::bigint,'positive adjustment is recorded once');
+select lives_ok($$select public.ops_adjust_inventory(
+ 'c2000000-0000-4000-8000-000000000001',
+ 'c3000000-0000-4000-8000-000000000001',
+ (select lot_code from public.production_records where plant_id='c2000000-0000-4000-8000-000000000001' and product_id='c3000000-0000-4000-8000-000000000001' limit 1),
+ 'adjustment_out',
+ 1,
+ 'Conteo físico: ajuste negativo QA',
+ null
+)$$,'supervisor can append a governed negative adjustment within available stock');
+select is((select count(*) from public.inventory_movements where plant_id='c2000000-0000-4000-8000-000000000001' and product_id='c3000000-0000-4000-8000-000000000001' and kind='adjustment_out'),1::bigint,'negative adjustment is recorded once');
+
+reset role;
+select * from finish();
+rollback;


### PR DESCRIPTION
## Objetivo
Abrir R2.5 Producción + Inventario cerrando las rutas legacy de DML directo sobre producción y kardex, de modo que las mutaciones operativas queden gobernadas por RPCs transaccionales sin perder ajustes físicos auditables.

## Cambios
- elimina las políticas legacy de INSERT directo en `production_records` e `inventory_movements`;
- revoca INSERT/UPDATE/DELETE directos para `authenticated` y conserva lectura por RLS;
- mantiene producción por `ops_record_production` y despachos por `ops_dispatch_inventory`;
- añade `ops_adjust_inventory` para ajustes positivos/negativos gobernados;
- los ajustes requieren rol supervisor/technical/admin/director, lote físico existente, cantidad positiva y motivo explícito;
- los ajustes negativos continúan protegidos por el guard de stock para impedir saldos negativos;
- no se hace backfill ni se altera el historial existente.

## Pruebas
- 21 aserciones pgTAP para ACL, eliminación de políticas legacy y continuidad de producción, entrada automática al kardex, despacho y ajustes gobernados.

## Guardrails
- kardex y producción permanecen append-only;
- sin stock mutable independiente del ledger;
- sin crear lotes por ajustes;
- sin cambios manuales en Supabase hosted.

## Secuencia
Este es R2.5A. Después corresponde fortalecer trazabilidad de origen/cierre de producción y reconciliación de stock antes de cerrar R2.5.