### PR TITLE
test(pilot): prove integrated operational day cycle

### DIFF
--- a/e2e/pilot-day-cycle.spec.ts
+++ b/e2e/pilot-day-cycle.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Pilot-readiness integration gate for the deterministic local adapter.
+ *
+ * Scheduling writes are intentionally Supabase-only, so this scenario verifies
+ * the local calendar/day surface and then proves that one physical-operational
+ * chain keeps its identity across reception, execution, maintenance, compost,
+ * finished production, inventory and the integrated dashboard.
+ */
+test("pilot day preserves cross-module traceability from intake to dashboard", async ({ page }) => {
+  // 1) The day starts from the operational planning surface.
+  await page.goto("/calendar");
+  await expect(page.getByRole("heading", { name: "Calendario operativo" })).toBeVisible();
+  await expect(page.getByText("Modo local", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Día", exact: true }).click();
+  await expect(page.getByText(/actividades$/).first()).toBeVisible();
+
+  await page.goto("/app");
+  await expect(page.getByRole("heading", { name: "Operación de hoy" })).toBeVisible();
+
+  // 2) A measured physical reception creates the day's source lot.
+  await page.goto("/receptions/new");
+  await page.getByLabel("Generador / proveedor").fill("PILOTO Integrado");
+  await page.getByLabel("Ruta / origen").fill("Ruta piloto integrada");
+  await page.getByLabel("Peso neto (kg)").fill("1500");
+  await page.getByLabel("Rechazo (kg)").fill("0");
+  await page.getByRole("button", { name: "Guardar recepción y crear lote" }).click();
+  await expect(page).toHaveURL(/\/receptions$/);
+  const reception = page.locator("article").filter({ hasText: "PILOTO Integrado" });
+  await expect(reception).toContainText("TAM-FORSU-");
+
+  await page.goto("/app");
+  await expect(page.getByLabel("Indicadores de hoy").locator(".metric-block").filter({ hasText: "Recibido" })).toContainText("1.50 t");
+  await expect(page.getByText("PILOTO Integrado")).toBeVisible();
+
+  // 3) The same day records real work, not only material movement.
+  await page.goto("/activities/new");
+  await page.getByLabel("Proceso", { exact: true }).fill("Proceso piloto integrado");
+  await page.getByLabel("Actividad", { exact: true }).fill("Actividad piloto integrada");
+  await page.getByLabel("Juan").check();
+  await page.getByRole("button", { name: "Iniciar actividad" }).click();
+  await expect(page.getByRole("heading", { name: "Actividad piloto integrada" })).toBeVisible();
+  await page.getByLabel(/Cantidad procesada/).fill("250");
+  await page.getByRole("button", { name: "Finalizar actividad" }).click();
+  await expect(page).toHaveURL(/\/app$/);
+
+  // 4) A maintenance exception is resolved without leaving the operational day.
+  await page.goto("/equipment/eq-tam-bp01");
+  await page.getByRole("button", { name: "Iniciar reparación" }).click();
+  await page.getByLabel("Causa encontrada").fill("Causa verificada en piloto integrado");
+  await page.getByLabel("Acción realizada").fill("Ajuste ejecutado en piloto integrado");
+  await page.getByRole("group", { name: "Trabajadores de reparación" }).getByRole("checkbox").first().check();
+  await page.getByRole("button", { name: "Cerrar reparación" }).click();
+  await expect(page.getByText("Disponible", { exact: true }).first()).toBeVisible();
+
+  // 5) The measured reception is physically assigned to a compost pile and closed.
+  await page.goto("/compost/new");
+  await page.getByLabel("Ubicación").fill("Zona piloto integrada");
+  const sourceGroup = page.getByRole("group", { name: "Lotes físicos y masa asignada" });
+  await sourceGroup.getByRole("checkbox").first().check();
+  await page.getByLabel("Asignar (kg)").fill("1500");
+  await page.getByLabel("Volumen conformado (m³)").fill("8");
+  await page.getByRole("group", { name: "Trabajadores de conformación" }).getByRole("checkbox").first().check();
+  await page.getByRole("button", { name: "Conformar pila" }).click();
+  await expect(page).toHaveURL(/\/compost\/[^/]+$/);
+  const pileId = new URL(page.url()).pathname.split("/").filter(Boolean).at(-1);
+  expect(pileId).toBeTruthy();
+
+  await page.getByLabel("Temperatura punto 1 (°C)").fill("58");
+  await page.getByLabel("Temperatura punto 2 (°C)").fill("58");
+  await page.getByLabel("Temperatura punto 3 (°C)").fill("58");
+  await page.getByLabel("Temperatura ambiente (°C)").fill("22");
+  await page.getByLabel(/Humedad \(%\)/).fill("52");
+  await page.getByRole("button", { name: "Guardar control" }).click();
+  await page.getByRole("button", { name: "Pasar a maduración" }).click();
+  await page.getByLabel("Peso final medido (kg)").fill("1000");
+  await page.getByRole("button", { name: "Cerrar pila" }).click();
+  await expect(page.getByText("Cerrada", { exact: true })).toBeVisible();
+
+  // 6) Finished production references that exact closed pile without copying its mass.
+  await page.goto("/production/new");
+  await page.getByLabel("Producto terminado").selectOption("wondergreen-solido");
+  await page.getByLabel(/Cantidad producida/).fill("300");
+  await page.getByLabel("Proceso fuente").fill("Peletizado piloto integrado");
+  await page.getByLabel(/Pila cerrada relacionada/).selectOption(pileId!);
+  await page.getByLabel(/Observación/).fill("Producción trazada desde la pila del piloto integrado");
+  await page.getByRole("button", { name: "Guardar producción y entrar a inventario" }).click();
+  await expect(page).toHaveURL(/\/production$/);
+  const production = page.locator("article").filter({ hasText: "Wondergreen sólido" }).first();
+  await expect(production).toContainText("300 kg");
+  await expect(production).toContainText("Pila cerrada");
+
+  // 7) The same production is the current physical stock.
+  await page.goto("/inventory");
+  const stock = page.locator("article").filter({ hasText: "Wondergreen sólido" }).first();
+  await expect(stock).toContainText("300 kg");
+
+  // 8) Direction can reconstruct the day from canonical facts in one dashboard.
+  await page.goto("/dashboard");
+  const indicators = page.getByLabel("Indicadores operativos");
+  await expect(indicators.locator("article").filter({ hasText: "Recibido" })).toContainText("1.50 t");
+  await expect(indicators.locator("article").filter({ hasText: "Procesado" })).toContainText("1.50 t");
+
+  const periodProduction = page.getByLabel("Producción del periodo");
+  const currentStock = page.getByLabel("Stock actual");
+  await expect(periodProduction).toContainText("300");
+  await expect(periodProduction).toContainText("kg");
+  await expect(currentStock).toContainText("300");
+  await expect(currentStock).toContainText("kg");
+
+  const timeline = page.locator("section.panel").filter({ has: page.getByRole("heading", { name: "Eventos operativos recientes" }) });
+  await expect(timeline).toContainText(/Producción TAM-PROD-/);
+  await expect(timeline).toContainText("Wondergreen sólido · 300 kg");
+});

--- a/e2e/pilot-day-cycle.spec.ts
+++ b/e2e/pilot-day-cycle.spec.ts
@@ -66,6 +66,8 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   await page.waitForURL((url) => url.pathname.startsWith("/compost/") && url.pathname !== "/compost/new");
   const pileId = new URL(page.url()).pathname.split("/").filter(Boolean).at(-1);
   expect(pileId).toBeTruthy();
+  const pileCode = (await page.getByRole("heading", { level: 1 }).textContent())?.trim();
+  expect(pileCode).toMatch(/^TAM-COMP-/);
 
   await page.getByLabel("Temperatura punto 1 (°C)").fill("58");
   await page.getByLabel("Temperatura punto 2 (°C)").fill("58");
@@ -89,7 +91,8 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   await expect(page).toHaveURL(/\/production$/);
   const production = page.locator("article").filter({ hasText: "Wondergreen sólido" }).first();
   await expect(production).toContainText("300 kg");
-  await expect(production).toContainText("Pila cerrada");
+  await expect(production).toContainText("Pila de compost");
+  await expect(production).toContainText(pileCode!);
 
   // 7) The same production is the current physical stock.
   await page.goto("/inventory");

--- a/e2e/pilot-day-cycle.spec.ts
+++ b/e2e/pilot-day-cycle.spec.ts
@@ -63,7 +63,7 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   await page.getByLabel("Volumen conformado (m³)").fill("8");
   await page.getByRole("group", { name: "Trabajadores de conformación" }).getByRole("checkbox").first().check();
   await page.getByRole("button", { name: "Conformar pila" }).click();
-  await expect(page).toHaveURL(/\/compost\/[^/]+$/);
+  await page.waitForURL((url) => url.pathname.startsWith("/compost/") && url.pathname !== "/compost/new");
   const pileId = new URL(page.url()).pathname.split("/").filter(Boolean).at(-1);
   expect(pileId).toBeTruthy();
 


### PR DESCRIPTION
## Objetivo
Iniciar Pilot Readiness con un gate de integración, no con otro módulo. Un único contexto Playwright demuestra continuidad operacional entre las superficies ya construidas.

## Escenario certificado
- abre Calendario/Hoy en fallback local determinista;
- registra una recepción física de 1.500 kg y verifica el KPI de Hoy;
- registra y finaliza una actividad real;
- resuelve una excepción de mantenimiento;
- asigna el lote físico a una pila, registra control técnico y la cierra;
- captura el UUID y código exactos de esa pila;
- registra 300 kg de producción terminada vinculada a esa misma pila;
- verifica el origen estructurado `Pila de compost` y el mismo código `TAM-COMP-…` en Producción;
- verifica los 300 kg en Inventario;
- reconstruye el día en Dashboard: recibido, procesado, producción, stock y evento reciente.

## Corrección durante la certificación
El primer run detectó un defecto del harness, no del producto: la expresión `/compost/[^/]+` también aceptaba `/compost/new`, por lo que el test capturaba `pileId = "new"`. El trace demostró que la pila real sí estaba disponible en Producción con su UUID exacto. Se corrigió el wait para exigir una ruta de detalle distinta de `/compost/new` y se fortaleció la prueba verificando además el código exacto de la pila en el registro de producción.

## Límite explícito
La escritura de programación es deliberadamente Supabase-only. Este E2E local verifica la superficie Calendario/Hoy y la continuidad física-operacional; no simula un write remoto que el producto no permite en fallback local. La programación remota pertenece al UAT alojado.

## Sin cambios de dominio
Este PR añade solamente evidencia E2E. No modifica migraciones, RLS, repositories, UI ni semántica de KPI.

## Gate final
Head certificado: `e526290dfb9d415ae2765332f144f1fb7e76e7c9`

Run `32167456741`:
- Quality ✅
- Database ✅ — fresh migrations + pgTAP/RLS/transaccional + PostgreSQL lint
- Desktop Chromium ✅
- Mobile Chromium ✅

## Merge
Fusionado a `develop` en `fd73d56f105b5814e71a47366a2ffcf7a649a2c1`.

## Próximo hueco de Pilot Readiness
Repetir la continuidad crítica sobre el backend Supabase alojado, incluyendo el write de programación y autorización por rol/planta, sin depender del fallback local.