### PR TITLE
test(pilot): add self-cleaning hosted planning write smoke

### DIFF
--- a/.github/workflows/hosted-pilot-uat.yml
+++ b/.github/workflows/hosted-pilot-uat.yml
@@ -1,4 +1,4 @@
-# Authenticated, read-only identity/RLS certification plus Preview deployment.
+# Authenticated identity/RLS certification, one self-cleaning planning write, plus Preview deployment.
 # Runtime source is always canonical develop. This workflow never deploys Production
 # and does not create, update or delete Auth users, profiles or memberships.
 name: hosted-pilot-uat
@@ -92,6 +92,13 @@ jobs:
           PILOT_OPERATOR_PLANTS: TAM
         run: npm run pilot:rls-smoke
 
+      - name: Certify hosted planning write boundary in Támesis
+        env:
+          PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_TAM_EMAIL }}
+          PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_TAM_PASSWORD }}
+          PILOT_PLANNING_PLANT: TAM
+        run: npm run pilot:planning-smoke
+
       - name: Certify Director vs Operario Yarumal RLS isolation
         env:
           PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_YAR_EMAIL }}
@@ -116,4 +123,5 @@ jobs:
           echo "Director expected scope: TAM + YAR." >> "$GITHUB_STEP_SUMMARY"
           echo "Operario Támesis expected scope: TAM; YAR read denied by RLS." >> "$GITHUB_STEP_SUMMARY"
           echo "Operario Yarumal expected scope: YAR; TAM read denied by RLS." >> "$GITHUB_STEP_SUMMARY"
+          echo "Planning write smoke: one temporary TAM schedule created by Director, visible to TAM Operario, operator write denied, exact row cleaned." >> "$GITHUB_STEP_SUMMARY"
           echo "No Auth users, profiles or memberships were mutated by this workflow." >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bootstrap:director": "node scripts/bootstrap-director.mjs",
     "pilot:backend-preflight": "node scripts/hosted-backend-preflight.mjs",
     "pilot:rls-smoke": "node scripts/hosted-rls-smoke.mjs",
+    "pilot:planning-smoke": "node scripts/hosted-planning-smoke.mjs",
     "pilot:preflight": "node scripts/hosted-pilot-preflight.mjs",
     "pilot:vercel-preview": "node scripts/vercel-pilot-deploy.mjs",
     "pilot:vercel-preflight": "node scripts/vercel-protected-preflight.mjs"

--- a/scripts/hosted-planning-smoke-lib.mjs
+++ b/scripts/hosted-planning-smoke-lib.mjs
@@ -29,10 +29,25 @@ function normalizeUrl(value) {
   return url.origin;
 }
 
+function decodeJwtPayload(value) {
+  const parts = value.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+    return payload && typeof payload === "object" && !Array.isArray(payload) ? payload : null;
+  } catch {
+    throw new HostedPlanningSmokeError("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY parece un JWT inválido.");
+  }
+}
+
 function validatePublishableKey(value) {
   const key = clean(value);
   if (!key || key.length > 8192 || key.startsWith("sb_secret_")) {
     throw new HostedPlanningSmokeError("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY falta o no es publicable.");
+  }
+  const payload = decodeJwtPayload(key);
+  if (payload?.role === "service_role") {
+    throw new HostedPlanningSmokeError("El smoke de planificación no acepta una clave service_role como clave publicable.");
   }
   return key;
 }
@@ -161,6 +176,9 @@ async function assertOperatorWriteDenied(client, resources, window) {
     planning_note: "UAT operator write must be denied",
   });
   if (!error || data) throw new HostedPlanningSmokeError("Fallo de autorización: el operario pudo crear una programación.");
+  if (!/No tienes permiso para programar actividades/i.test(error.message || "")) {
+    throw new HostedPlanningSmokeError(`La escritura del operario falló por una razón distinta al boundary de autorización: ${error.message || "error remoto"}.`);
+  }
 }
 
 async function assertScheduleVisible(client, scheduleId, label) {

--- a/scripts/hosted-planning-smoke-lib.mjs
+++ b/scripts/hosted-planning-smoke-lib.mjs
@@ -1,0 +1,230 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { normalizePilotPlantCodes } from "./pilot-plant-codes.mjs";
+
+export class HostedPlanningSmokeError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "HostedPlanningSmokeError";
+  }
+}
+
+function clean(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requireCredential(env, emailName, passwordName) {
+  const email = clean(env[emailName]).toLowerCase();
+  const password = typeof env[passwordName] === "string" ? env[passwordName] : "";
+  if (!email || !email.includes("@") || email.length > 320) throw new HostedPlanningSmokeError(`${emailName} falta o no es válido.`);
+  if (!password || password.length > 4096) throw new HostedPlanningSmokeError(`${passwordName} falta o no es válido.`);
+  return Object.freeze({ email, password });
+}
+
+function normalizeUrl(value) {
+  let url;
+  try { url = new URL(clean(value)); } catch { throw new HostedPlanningSmokeError("NEXT_PUBLIC_SUPABASE_URL no es una URL válida."); }
+  if (url.protocol !== "https:" || url.username || url.password || (url.pathname !== "/" && url.pathname !== "")) {
+    throw new HostedPlanningSmokeError("NEXT_PUBLIC_SUPABASE_URL debe ser un origen HTTPS sin credenciales ni ruta.");
+  }
+  return url.origin;
+}
+
+function validatePublishableKey(value) {
+  const key = clean(value);
+  if (!key || key.length > 8192 || key.startsWith("sb_secret_")) {
+    throw new HostedPlanningSmokeError("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY falta o no es publicable.");
+  }
+  return key;
+}
+
+export function parseHostedPlanningSmokeConfig(env = process.env) {
+  const url = normalizeUrl(env.NEXT_PUBLIC_SUPABASE_URL);
+  const publishableKey = validatePublishableKey(env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY);
+  const secretKey = clean(env.SUPABASE_SECRET_KEY);
+  if (!secretKey || secretKey.length > 4096) throw new HostedPlanningSmokeError("SUPABASE_SECRET_KEY falta o no es válida.");
+  const director = requireCredential(env, "PILOT_DIRECTOR_EMAIL", "PILOT_DIRECTOR_PASSWORD");
+  const operator = requireCredential(env, "PILOT_OPERATOR_EMAIL", "PILOT_OPERATOR_PASSWORD");
+  if (director.email === operator.email) throw new HostedPlanningSmokeError("Director y operario deben ser usuarios distintos.");
+  const [plantCode] = normalizePilotPlantCodes(env.PILOT_PLANNING_PLANT || "TAM");
+  return Object.freeze({ url, publishableKey, secretKey, director, operator, plantCode });
+}
+
+function createUserClient(config, createClientImpl) {
+  return createClientImpl(config.url, config.publishableKey, {
+    auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false },
+  });
+}
+
+function createAdminClient(config, createClientImpl) {
+  return createClientImpl(config.url, config.secretKey, {
+    auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false },
+  });
+}
+
+async function signIn(client, credentials, label) {
+  const { error } = await client.auth.signInWithPassword(credentials);
+  if (error) throw new HostedPlanningSmokeError(`No fue posible autenticar ${label}: ${error.message || "error remoto"}.`);
+}
+
+async function safeSignOut(client) {
+  try { await client.auth.signOut(); } catch { /* cleanup best effort */ }
+}
+
+async function single(query, label) {
+  const { data, error } = await query.maybeSingle();
+  if (error) throw new HostedPlanningSmokeError(`${label}: ${error.message || "error remoto"}.`);
+  if (!data) throw new HostedPlanningSmokeError(`${label}: no se encontró un registro requerido.`);
+  return data;
+}
+
+async function discoverResources(admin, plantCode) {
+  const plant = await single(admin.from("plants").select("id,code,name,active").eq("code", plantCode).eq("active", true), `Planta piloto ${plantCode}`);
+  const { data: templates, error: templateError } = await admin
+    .from("activity_templates")
+    .select("id,plant_id,process_id,code,name,requires_equipment,active")
+    .eq("plant_id", plant.id)
+    .eq("active", true)
+    .order("requires_equipment", { ascending: true })
+    .order("code");
+  if (templateError) throw new HostedPlanningSmokeError(`No fue posible consultar plantillas: ${templateError.message || "error remoto"}.`);
+  if (!Array.isArray(templates) || templates.length === 0) throw new HostedPlanningSmokeError(`La planta ${plantCode} no tiene plantillas activas para certificar planificación.`);
+
+  const { data: workers, error: workerError } = await admin
+    .from("employees")
+    .select("id,plant_id,display_name,active")
+    .eq("plant_id", plant.id)
+    .eq("active", true)
+    .order("display_name");
+  if (workerError) throw new HostedPlanningSmokeError(`No fue posible consultar trabajadores: ${workerError.message || "error remoto"}.`);
+  if (!Array.isArray(workers) || workers.length === 0) throw new HostedPlanningSmokeError(`La planta ${plantCode} no tiene trabajadores activos para certificar planificación.`);
+
+  for (const template of templates) {
+    if (!template.requires_equipment) return Object.freeze({ plant, template, worker: workers[0], equipment: null });
+    const { data: links, error: linkError } = await admin
+      .from("equipment_processes")
+      .select("equipment_id,active")
+      .eq("plant_id", plant.id)
+      .eq("process_id", template.process_id)
+      .eq("active", true);
+    if (linkError) throw new HostedPlanningSmokeError(`No fue posible consultar equipos compatibles: ${linkError.message || "error remoto"}.`);
+    const equipmentIds = Array.isArray(links) ? links.map((row) => row.equipment_id).filter(Boolean) : [];
+    if (!equipmentIds.length) continue;
+    const { data: equipmentRows, error: equipmentError } = await admin
+      .from("equipment")
+      .select("id,plant_id,code,name,status")
+      .eq("plant_id", plant.id)
+      .in("id", equipmentIds)
+      .order("code");
+    if (equipmentError) throw new HostedPlanningSmokeError(`No fue posible consultar equipos: ${equipmentError.message || "error remoto"}.`);
+    if (Array.isArray(equipmentRows) && equipmentRows.length) return Object.freeze({ plant, template, worker: workers[0], equipment: equipmentRows[0] });
+  }
+
+  throw new HostedPlanningSmokeError(`La planta ${plantCode} no tiene una combinación activa plantilla/equipo apta para certificar planificación.`);
+}
+
+function candidateWindows(now = new Date()) {
+  const base = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  base.setUTCHours(3, 0, 0, 0);
+  return Array.from({ length: 7 }, (_, index) => {
+    const start = new Date(base.getTime() + index * 24 * 60 * 60 * 1000);
+    const end = new Date(start.getTime() + 30 * 60 * 1000);
+    return { start: start.toISOString(), end: end.toISOString() };
+  });
+}
+
+async function createDirectorSchedule(client, resources, now) {
+  let lastError;
+  for (const window of candidateWindows(now)) {
+    const { data, error } = await client.rpc("ops_create_scheduled_activity", {
+      target_plant: resources.plant.id,
+      target_template: resources.template.id,
+      starts_at: window.start,
+      ends_at: window.end,
+      employee_ids: [resources.worker.id],
+      target_equipment: resources.equipment?.id || null,
+      planning_note: "UAT hosted planning smoke · fila temporal",
+    });
+    if (!error && typeof data === "string") return Object.freeze({ id: data, ...window });
+    lastError = error;
+  }
+  throw new HostedPlanningSmokeError(`Director no pudo crear una programación temporal en las ventanas UAT: ${lastError?.message || "error remoto"}.`);
+}
+
+async function assertOperatorWriteDenied(client, resources, window) {
+  const { data, error } = await client.rpc("ops_create_scheduled_activity", {
+    target_plant: resources.plant.id,
+    target_template: resources.template.id,
+    starts_at: window.start,
+    ends_at: window.end,
+    employee_ids: [resources.worker.id],
+    target_equipment: resources.equipment?.id || null,
+    planning_note: "UAT operator write must be denied",
+  });
+  if (!error || data) throw new HostedPlanningSmokeError("Fallo de autorización: el operario pudo crear una programación.");
+}
+
+async function assertScheduleVisible(client, scheduleId, label) {
+  const { data, error } = await client
+    .from("scheduled_activities")
+    .select("id,plant_id,title,status,planned_start,planned_end")
+    .eq("id", scheduleId)
+    .maybeSingle();
+  if (error) throw new HostedPlanningSmokeError(`${label} no pudo leer la programación UAT: ${error.message || "error remoto"}.`);
+  if (!data || data.id !== scheduleId || data.status !== "planned") {
+    throw new HostedPlanningSmokeError(`${label} no ve la programación UAT esperada por RLS.`);
+  }
+  return data;
+}
+
+async function cleanup(admin, scheduleId) {
+  if (!scheduleId) return;
+  const { error } = await admin.from("scheduled_activities").delete().eq("id", scheduleId);
+  if (error) throw new HostedPlanningSmokeError(`No fue posible limpiar la programación UAT ${scheduleId}: ${error.message || "error remoto"}.`);
+}
+
+export async function runHostedPlanningSmoke({ env = process.env, createClientImpl = createSupabaseClient, now = new Date() } = {}) {
+  const config = parseHostedPlanningSmokeConfig(env);
+  const admin = createAdminClient(config, createClientImpl);
+  const director = createUserClient(config, createClientImpl);
+  const operator = createUserClient(config, createClientImpl);
+  let directorSignedIn = false;
+  let operatorSignedIn = false;
+  let scheduleId;
+  let primaryError;
+
+  try {
+    const resources = await discoverResources(admin, config.plantCode);
+    await signIn(director, config.director, "director");
+    directorSignedIn = true;
+    await signIn(operator, config.operator, "operario");
+    operatorSignedIn = true;
+
+    const schedule = await createDirectorSchedule(director, resources, now);
+    scheduleId = schedule.id;
+    const directorRow = await assertScheduleVisible(director, scheduleId, "Director");
+    const operatorRow = await assertScheduleVisible(operator, scheduleId, "Operario");
+    await assertOperatorWriteDenied(operator, resources, schedule);
+
+    return Object.freeze({
+      plantCode: config.plantCode,
+      scheduleId,
+      templateCode: String(resources.template.code || ""),
+      workerName: String(resources.worker.display_name || ""),
+      equipmentCode: resources.equipment ? String(resources.equipment.code || "") : null,
+      title: String(directorRow.title || operatorRow.title || ""),
+      checks: Object.freeze(["director-write", "director-read", "operator-read", "operator-write-denied", "cleanup"]),
+    });
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    try {
+      await cleanup(admin, scheduleId);
+    } catch (cleanupError) {
+      if (!primaryError) throw cleanupError;
+      console.error(`GREENATICS hosted planning cleanup warning · ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`);
+    }
+    if (operatorSignedIn) await safeSignOut(operator);
+    if (directorSignedIn) await safeSignOut(director);
+  }
+}

--- a/scripts/hosted-planning-smoke.mjs
+++ b/scripts/hosted-planning-smoke.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import { runHostedPlanningSmoke } from "./hosted-planning-smoke-lib.mjs";
+
+function printHelp() {
+  console.log(`GREENATICS hosted planning smoke · escritura temporal autocontenible
+
+Uso:
+  npm run pilot:planning-smoke
+
+Variables requeridas:
+  NEXT_PUBLIC_SUPABASE_URL
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  SUPABASE_SECRET_KEY
+  PILOT_DIRECTOR_EMAIL
+  PILOT_DIRECTOR_PASSWORD
+  PILOT_OPERATOR_EMAIL
+  PILOT_OPERATOR_PASSWORD
+
+Opcional:
+  PILOT_PLANNING_PLANT   Default: TAM
+
+El smoke crea una sola programación temporal mediante el RPC canónico, comprueba lectura RLS y denegación de escritura al operario, y elimina únicamente la fila creada antes de terminar.
+`);
+}
+
+async function main() {
+  if (process.argv.includes("--help")) {
+    printHelp();
+    return;
+  }
+  if (process.argv.length > 2) throw new Error("pilot:planning-smoke no acepta argumentos CLI; usa variables de entorno.");
+
+  const result = await runHostedPlanningSmoke();
+  console.log("GREENATICS hosted planning smoke: PASS");
+  console.log(`plant: ${result.plantCode}`);
+  console.log(`template: ${result.templateCode}`);
+  console.log(`worker: ${result.workerName}`);
+  console.log(`equipment: ${result.equipmentCode || "not-required"}`);
+  console.log(`checks: ${result.checks.join(", ")}`);
+}
+
+main().catch((error) => {
+  console.error(`GREENATICS hosted planning smoke: FAIL · ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/hosted-planning-smoke.test.mjs
+++ b/scripts/hosted-planning-smoke.test.mjs
@@ -11,6 +11,11 @@ const baseEnv = {
   PILOT_OPERATOR_PASSWORD: "operator-test-password",
 };
 
+function fakeJwt(payload) {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.sanitized-signature`;
+}
+
 describe("hosted planning smoke", () => {
   it("parses isolated hosted credentials and defaults the write smoke to TAM", () => {
     const config = parseHostedPlanningSmokeConfig(baseEnv);
@@ -25,11 +30,15 @@ describe("hosted planning smoke", () => {
     expect(config.plantCode).toBe("TAM");
   });
 
-  it("fails closed when the user-facing key is actually secret", () => {
+  it("fails closed when the user-facing key is secret or service-role", () => {
     expect(() => parseHostedPlanningSmokeConfig({
       ...baseEnv,
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_secret_should_never_be_used_as_public",
     })).toThrow(HostedPlanningSmokeError);
+    expect(() => parseHostedPlanningSmokeConfig({
+      ...baseEnv,
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: fakeJwt({ role: "service_role" }),
+    })).toThrow(/service_role/);
   });
 
   it("requires distinct director and operator identities", () => {

--- a/scripts/hosted-planning-smoke.test.mjs
+++ b/scripts/hosted-planning-smoke.test.mjs
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { HostedPlanningSmokeError, parseHostedPlanningSmokeConfig } from "./hosted-planning-smoke-lib.mjs";
+
+const baseEnv = {
+  NEXT_PUBLIC_SUPABASE_URL: "https://sanitized-project.supabase.co",
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_sanitized_test_key",
+  SUPABASE_SECRET_KEY: "sb_secret_sanitized_admin_key",
+  PILOT_DIRECTOR_EMAIL: "director@example.test",
+  PILOT_DIRECTOR_PASSWORD: "director-test-password",
+  PILOT_OPERATOR_EMAIL: "operator@example.test",
+  PILOT_OPERATOR_PASSWORD: "operator-test-password",
+};
+
+describe("hosted planning smoke", () => {
+  it("parses isolated hosted credentials and defaults the write smoke to TAM", () => {
+    const config = parseHostedPlanningSmokeConfig(baseEnv);
+    expect(config.url).toBe("https://sanitized-project.supabase.co");
+    expect(config.plantCode).toBe("TAM");
+    expect(config.director.email).toBe("director@example.test");
+    expect(config.operator.email).toBe("operator@example.test");
+  });
+
+  it("normalizes a configured pilot plant alias", () => {
+    const config = parseHostedPlanningSmokeConfig({ ...baseEnv, PILOT_PLANNING_PLANT: "Támesis" });
+    expect(config.plantCode).toBe("TAM");
+  });
+
+  it("fails closed when the user-facing key is actually secret", () => {
+    expect(() => parseHostedPlanningSmokeConfig({
+      ...baseEnv,
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_secret_should_never_be_used_as_public",
+    })).toThrow(HostedPlanningSmokeError);
+  });
+
+  it("requires distinct director and operator identities", () => {
+    expect(() => parseHostedPlanningSmokeConfig({
+      ...baseEnv,
+      PILOT_OPERATOR_EMAIL: baseEnv.PILOT_DIRECTOR_EMAIL,
+    })).toThrow(/usuarios distintos/);
+  });
+
+  it("rejects non-origin or non-HTTPS Supabase URLs", () => {
+    expect(() => parseHostedPlanningSmokeConfig({ ...baseEnv, NEXT_PUBLIC_SUPABASE_URL: "http://sanitized-project.supabase.co" })).toThrow(HostedPlanningSmokeError);
+    expect(() => parseHostedPlanningSmokeConfig({ ...baseEnv, NEXT_PUBLIC_SUPABASE_URL: "https://sanitized-project.supabase.co/rest/v1" })).toThrow(HostedPlanningSmokeError);
+  });
+});


### PR DESCRIPTION
## Objetivo
Cerrar el siguiente hueco de Pilot Readiness: el UAT alojado ya certificaba Auth/RLS y Preview, pero no ejercía una escritura transaccional real.

## Nuevo gate
Añade `pilot:planning-smoke` para Támesis:
- descubre planta, plantilla, trabajador y equipo compatibles desde los maestros alojados, sin IDs hardcodeados;
- autentica Director y Operario con la clave publicable y rechaza configuración `service_role` accidental;
- crea una única programación temporal mediante `ops_create_scheduled_activity` como Director;
- comprueba que Director y Operario Támesis pueden leer esa misma programación por RLS;
- comprueba que el Operario no puede programar y exige que la causa sea específicamente el boundary de autorización, no un conflicto horario incidental;
- elimina exclusivamente el schedule creado usando el cliente administrativo, incluso ante fallo posterior;
- no crea/modifica usuarios, perfiles ni membresías.

## Workflow
`hosted-pilot-uat.yml` deja de describirse como totalmente read-only y ejecuta este smoke entre las certificaciones RLS de Támesis y Yarumal. Continúa desplegando únicamente Preview, nunca Production.

## Readiness real
Si Támesis no tiene al menos una plantilla activa y un trabajador activo —más equipo compatible cuando la plantilla lo exige— el smoke falla. Eso se interpreta como falta real de preparación del piloto, no se maquilla con fixtures alojadas.

## Gate de PR
Head certificado: `d1c200963b94d72cbcd0377b654efeb7bde15eaf`
Run `32174782569`:
- Quality ✅
- Database ✅
- Desktop Chromium ✅
- Mobile Chromium ✅

## Merge
Fusionado a `develop` en `3141ecaac4ec20ee03fd300e929e979994174cd2`.

## Siguiente gate
Ejecutar manualmente `hosted-pilot-uat` desde GitHub Actions para certificar la escritura temporal contra el Supabase piloto real. El conector GitHub disponible en esta sesión permite leer/reintentar runs, pero no expone `workflow_dispatch`; no se ha simulado ni falsificado esa ejecución.