### PR TITLE
test(pilot): certify hosted plan-to-real lifecycle

### DIFF
--- a/.github/workflows/hosted-pilot-uat.yml
+++ b/.github/workflows/hosted-pilot-uat.yml
@@ -1,4 +1,4 @@
-# Authenticated identity/RLS certification, one self-cleaning planning write, plus Preview deployment.
+# Authenticated identity/RLS certification, one self-cleaning plan→real lifecycle, plus Preview deployment.
 # Runtime source is always canonical develop. This workflow never deploys Production
 # and does not create, update or delete Auth users, profiles or memberships.
 name: hosted-pilot-uat
@@ -92,7 +92,7 @@ jobs:
           PILOT_OPERATOR_PLANTS: TAM
         run: npm run pilot:rls-smoke
 
-      - name: Certify hosted planning write boundary in Támesis
+      - name: Certify hosted plan vs real lifecycle in Támesis
         env:
           PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_TAM_EMAIL }}
           PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_TAM_PASSWORD }}
@@ -123,5 +123,5 @@ jobs:
           echo "Director expected scope: TAM + YAR." >> "$GITHUB_STEP_SUMMARY"
           echo "Operario Támesis expected scope: TAM; YAR read denied by RLS." >> "$GITHUB_STEP_SUMMARY"
           echo "Operario Yarumal expected scope: YAR; TAM read denied by RLS." >> "$GITHUB_STEP_SUMMARY"
-          echo "Planning write smoke: one temporary TAM schedule created by Director, visible to TAM Operario, operator write denied, exact row cleaned." >> "$GITHUB_STEP_SUMMARY"
+          echo "Plan-vs-real smoke: Director creates one temporary TAM schedule; TAM Operario reads it, cannot program, starts and finishes the linked real activity; schedule reaches done; exact UAT activity and schedule are cleaned." >> "$GITHUB_STEP_SUMMARY"
           echo "No Auth users, profiles or memberships were mutated by this workflow." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/hosted-planning-smoke-lib.mjs
+++ b/scripts/hosted-planning-smoke-lib.mjs
@@ -92,29 +92,54 @@ async function single(query, label) {
   return data;
 }
 
+async function discoverFreeWorker(admin, plantId) {
+  const { data: workers, error: workerError } = await admin
+    .from("employees")
+    .select("id,plant_id,display_name,active")
+    .eq("plant_id", plantId)
+    .eq("active", true)
+    .order("display_name");
+  if (workerError) throw new HostedPlanningSmokeError(`No fue posible consultar trabajadores: ${workerError.message || "error remoto"}.`);
+  if (!Array.isArray(workers) || workers.length === 0) throw new HostedPlanningSmokeError("La planta no tiene trabajadores activos para certificar ejecución.");
+
+  const { data: openActivities, error: activityError } = await admin
+    .from("activities")
+    .select("id")
+    .eq("plant_id", plantId)
+    .is("ended_at", null);
+  if (activityError) throw new HostedPlanningSmokeError(`No fue posible validar actividades abiertas: ${activityError.message || "error remoto"}.`);
+  const openIds = Array.isArray(openActivities) ? openActivities.map((row) => row.id).filter(Boolean) : [];
+  if (!openIds.length) return workers[0];
+
+  const { data: busyRows, error: busyError } = await admin
+    .from("activity_workers")
+    .select("employee_id")
+    .in("activity_id", openIds);
+  if (busyError) throw new HostedPlanningSmokeError(`No fue posible validar trabajadores ocupados: ${busyError.message || "error remoto"}.`);
+  const busy = new Set((busyRows || []).map((row) => row.employee_id));
+  const worker = workers.find((row) => !busy.has(row.id));
+  if (!worker) throw new HostedPlanningSmokeError("Todos los trabajadores activos de la planta tienen una actividad real abierta; el smoke no interferirá con ellas.");
+  return worker;
+}
+
 async function discoverResources(admin, plantCode) {
   const plant = await single(admin.from("plants").select("id,code,name,active").eq("code", plantCode).eq("active", true), `Planta piloto ${plantCode}`);
   const { data: templates, error: templateError } = await admin
     .from("activity_templates")
-    .select("id,plant_id,process_id,code,name,requires_equipment,active")
+    .select("id,plant_id,process_id,code,name,requires_equipment,requires_quantity,default_unit_code,active")
     .eq("plant_id", plant.id)
     .eq("active", true)
     .order("requires_equipment", { ascending: true })
+    .order("requires_quantity", { ascending: true })
     .order("code");
   if (templateError) throw new HostedPlanningSmokeError(`No fue posible consultar plantillas: ${templateError.message || "error remoto"}.`);
   if (!Array.isArray(templates) || templates.length === 0) throw new HostedPlanningSmokeError(`La planta ${plantCode} no tiene plantillas activas para certificar planificación.`);
 
-  const { data: workers, error: workerError } = await admin
-    .from("employees")
-    .select("id,plant_id,display_name,active")
-    .eq("plant_id", plant.id)
-    .eq("active", true)
-    .order("display_name");
-  if (workerError) throw new HostedPlanningSmokeError(`No fue posible consultar trabajadores: ${workerError.message || "error remoto"}.`);
-  if (!Array.isArray(workers) || workers.length === 0) throw new HostedPlanningSmokeError(`La planta ${plantCode} no tiene trabajadores activos para certificar planificación.`);
+  const worker = await discoverFreeWorker(admin, plant.id);
 
   for (const template of templates) {
-    if (!template.requires_equipment) return Object.freeze({ plant, template, worker: workers[0], equipment: null });
+    if (template.requires_quantity && !clean(template.default_unit_code)) continue;
+    if (!template.requires_equipment) return Object.freeze({ plant, template, worker, equipment: null });
     const { data: links, error: linkError } = await admin
       .from("equipment_processes")
       .select("equipment_id,active")
@@ -131,10 +156,10 @@ async function discoverResources(admin, plantCode) {
       .in("id", equipmentIds)
       .order("code");
     if (equipmentError) throw new HostedPlanningSmokeError(`No fue posible consultar equipos: ${equipmentError.message || "error remoto"}.`);
-    if (Array.isArray(equipmentRows) && equipmentRows.length) return Object.freeze({ plant, template, worker: workers[0], equipment: equipmentRows[0] });
+    if (Array.isArray(equipmentRows) && equipmentRows.length) return Object.freeze({ plant, template, worker, equipment: equipmentRows[0] });
   }
 
-  throw new HostedPlanningSmokeError(`La planta ${plantCode} no tiene una combinación activa plantilla/equipo apta para certificar planificación.`);
+  throw new HostedPlanningSmokeError(`La planta ${plantCode} no tiene una combinación activa plantilla/trabajador/equipo apta para certificar plan vs real.`);
 }
 
 function candidateWindows(now = new Date()) {
@@ -157,7 +182,7 @@ async function createDirectorSchedule(client, resources, now) {
       ends_at: window.end,
       employee_ids: [resources.worker.id],
       target_equipment: resources.equipment?.id || null,
-      planning_note: "UAT hosted planning smoke · fila temporal",
+      planning_note: "UAT hosted plan-vs-real smoke · fila temporal",
     });
     if (!error && typeof data === "string") return Object.freeze({ id: data, ...window });
     lastError = error;
@@ -181,23 +206,74 @@ async function assertOperatorWriteDenied(client, resources, window) {
   }
 }
 
-async function assertScheduleVisible(client, scheduleId, label) {
+async function readSchedule(client, scheduleId, label, expectedStatus) {
   const { data, error } = await client
     .from("scheduled_activities")
     .select("id,plant_id,title,status,planned_start,planned_end")
     .eq("id", scheduleId)
     .maybeSingle();
   if (error) throw new HostedPlanningSmokeError(`${label} no pudo leer la programación UAT: ${error.message || "error remoto"}.`);
-  if (!data || data.id !== scheduleId || data.status !== "planned") {
-    throw new HostedPlanningSmokeError(`${label} no ve la programación UAT esperada por RLS.`);
+  if (!data || data.id !== scheduleId || data.status !== expectedStatus) {
+    throw new HostedPlanningSmokeError(`${label} no ve la programación UAT en estado ${expectedStatus}.`);
   }
   return data;
 }
 
-async function cleanup(admin, scheduleId) {
-  if (!scheduleId) return;
-  const { error } = await admin.from("scheduled_activities").delete().eq("id", scheduleId);
-  if (error) throw new HostedPlanningSmokeError(`No fue posible limpiar la programación UAT ${scheduleId}: ${error.message || "error remoto"}.`);
+async function startScheduledActivity(operator, resources, scheduleId) {
+  const { data, error } = await operator.rpc("ops_start_scheduled_activity", {
+    scheduled_id: scheduleId,
+    employee_ids: [resources.worker.id],
+  });
+  if (error) throw new HostedPlanningSmokeError(`El operario no pudo iniciar la programación UAT: ${error.message || "error remoto"}.`);
+  if (typeof data !== "string") throw new HostedPlanningSmokeError("La ejecución UAT inició sin devolver un activity_id válido.");
+  return data;
+}
+
+async function readActivity(client, activityId, scheduleId, expectedFinished) {
+  const { data, error } = await client
+    .from("activities")
+    .select("id,plant_id,scheduled_activity_id,title,started_at,ended_at,quantity,unit")
+    .eq("id", activityId)
+    .maybeSingle();
+  if (error) throw new HostedPlanningSmokeError(`No fue posible leer la ejecución UAT: ${error.message || "error remoto"}.`);
+  if (!data || data.id !== activityId || data.scheduled_activity_id !== scheduleId) {
+    throw new HostedPlanningSmokeError("La actividad real UAT perdió el vínculo exacto con su programación.");
+  }
+  if (expectedFinished ? !data.ended_at : Boolean(data.ended_at)) {
+    throw new HostedPlanningSmokeError(`La actividad UAT no refleja el cierre esperado (${expectedFinished ? "finalizada" : "en curso"}).`);
+  }
+  return data;
+}
+
+async function finishActivity(operator, resources, activityId) {
+  const quantity = resources.template.requires_quantity ? 1 : null;
+  const unit = quantity === null ? null : clean(resources.template.default_unit_code);
+  const { data, error } = await operator.rpc("ops_finish_activity_v2", {
+    target_activity: activityId,
+    result_quantity: quantity,
+    result_unit: unit,
+    novelty_kind: null,
+    novelty_notes: null,
+    open_incident: false,
+    activity_comment: "UAT hosted plan-vs-real smoke · ejecución temporal",
+    tool_ids: [],
+  });
+  if (error) throw new HostedPlanningSmokeError(`El operario no pudo finalizar la actividad UAT: ${error.message || "error remoto"}.`);
+  if (typeof data !== "string" || Number.isNaN(Date.parse(data))) {
+    throw new HostedPlanningSmokeError("La actividad UAT finalizó sin devolver una hora válida.");
+  }
+  return data;
+}
+
+async function cleanup(admin, activityId, scheduleId) {
+  if (activityId) {
+    const { error: activityError } = await admin.from("activities").delete().eq("id", activityId);
+    if (activityError) throw new HostedPlanningSmokeError(`No fue posible limpiar la actividad UAT ${activityId}: ${activityError.message || "error remoto"}.`);
+  }
+  if (scheduleId) {
+    const { error: scheduleError } = await admin.from("scheduled_activities").delete().eq("id", scheduleId);
+    if (scheduleError) throw new HostedPlanningSmokeError(`No fue posible limpiar la programación UAT ${scheduleId}: ${scheduleError.message || "error remoto"}.`);
+  }
 }
 
 export async function runHostedPlanningSmoke({ env = process.env, createClientImpl = createSupabaseClient, now = new Date() } = {}) {
@@ -208,6 +284,7 @@ export async function runHostedPlanningSmoke({ env = process.env, createClientIm
   let directorSignedIn = false;
   let operatorSignedIn = false;
   let scheduleId;
+  let activityId;
   let primaryError;
 
   try {
@@ -219,28 +296,47 @@ export async function runHostedPlanningSmoke({ env = process.env, createClientIm
 
     const schedule = await createDirectorSchedule(director, resources, now);
     scheduleId = schedule.id;
-    const directorRow = await assertScheduleVisible(director, scheduleId, "Director");
-    const operatorRow = await assertScheduleVisible(operator, scheduleId, "Operario");
+    const directorRow = await readSchedule(director, scheduleId, "Director", "planned");
+    await readSchedule(operator, scheduleId, "Operario", "planned");
     await assertOperatorWriteDenied(operator, resources, schedule);
+
+    activityId = await startScheduledActivity(operator, resources, scheduleId);
+    await readSchedule(operator, scheduleId, "Operario", "running");
+    await readActivity(operator, activityId, scheduleId, false);
+
+    await finishActivity(operator, resources, activityId);
+    await readActivity(operator, activityId, scheduleId, true);
+    await readSchedule(director, scheduleId, "Director", "done");
 
     return Object.freeze({
       plantCode: config.plantCode,
       scheduleId,
+      activityId,
       templateCode: String(resources.template.code || ""),
       workerName: String(resources.worker.display_name || ""),
       equipmentCode: resources.equipment ? String(resources.equipment.code || "") : null,
-      title: String(directorRow.title || operatorRow.title || ""),
-      checks: Object.freeze(["director-write", "director-read", "operator-read", "operator-write-denied", "cleanup"]),
+      title: String(directorRow.title || ""),
+      checks: Object.freeze([
+        "director-plan-write",
+        "operator-plan-read",
+        "operator-plan-write-denied",
+        "operator-start-real",
+        "plan-running",
+        "plan-real-link",
+        "operator-finish-real",
+        "plan-done",
+        "cleanup",
+      ]),
     });
   } catch (error) {
     primaryError = error;
     throw error;
   } finally {
     try {
-      await cleanup(admin, scheduleId);
+      await cleanup(admin, activityId, scheduleId);
     } catch (cleanupError) {
       if (!primaryError) throw cleanupError;
-      console.error(`GREENATICS hosted planning cleanup warning · ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`);
+      console.error(`GREENATICS hosted plan-vs-real cleanup warning · ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`);
     }
     if (operatorSignedIn) await safeSignOut(operator);
     if (directorSignedIn) await safeSignOut(director);

--- a/scripts/hosted-planning-smoke.mjs
+++ b/scripts/hosted-planning-smoke.mjs
@@ -3,7 +3,7 @@
 import { runHostedPlanningSmoke } from "./hosted-planning-smoke-lib.mjs";
 
 function printHelp() {
-  console.log(`GREENATICS hosted planning smoke · escritura temporal autocontenible
+  console.log(`GREENATICS hosted plan-vs-real smoke · escritura temporal autocontenible
 
 Uso:
   npm run pilot:planning-smoke
@@ -20,7 +20,7 @@ Variables requeridas:
 Opcional:
   PILOT_PLANNING_PLANT   Default: TAM
 
-El smoke crea una sola programación temporal mediante el RPC canónico, comprueba lectura RLS y denegación de escritura al operario, y elimina únicamente la fila creada antes de terminar.
+El smoke crea una programación temporal como Director, exige denegación de programación al Operario, inicia y finaliza esa actividad como Operario, valida planned → running → done y el vínculo schedule → actividad real, y limpia únicamente los IDs UAT creados.
 `);
 }
 
@@ -32,7 +32,7 @@ async function main() {
   if (process.argv.length > 2) throw new Error("pilot:planning-smoke no acepta argumentos CLI; usa variables de entorno.");
 
   const result = await runHostedPlanningSmoke();
-  console.log("GREENATICS hosted planning smoke: PASS");
+  console.log("GREENATICS hosted plan-vs-real smoke: PASS");
   console.log(`plant: ${result.plantCode}`);
   console.log(`template: ${result.templateCode}`);
   console.log(`worker: ${result.workerName}`);
@@ -41,6 +41,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error(`GREENATICS hosted planning smoke: FAIL · ${error instanceof Error ? error.message : String(error)}`);
+  console.error(`GREENATICS hosted plan-vs-real smoke: FAIL · ${error instanceof Error ? error.message : String(error)}`);
   process.exitCode = 1;
 });

--- a/scripts/hosted-planning-smoke.test.mjs
+++ b/scripts/hosted-planning-smoke.test.mjs
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { HostedPlanningSmokeError, parseHostedPlanningSmokeConfig } from "./hosted-planning-smoke-lib.mjs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  HostedPlanningSmokeError,
+  parseHostedPlanningSmokeConfig,
+  runHostedPlanningSmoke,
+} from "./hosted-planning-smoke-lib.mjs";
 
 const baseEnv = {
   NEXT_PUBLIC_SUPABASE_URL: "https://sanitized-project.supabase.co",
@@ -14,6 +18,122 @@ const baseEnv = {
 function fakeJwt(payload) {
   const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
   return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.sanitized-signature`;
+}
+
+class FakeQuery {
+  constructor(client, table, operation = "select") {
+    this.client = client;
+    this.table = table;
+    this.operation = operation;
+    this.filters = [];
+  }
+
+  select() { return this; }
+  delete() { this.operation = "delete"; return this; }
+  eq(column, value) { this.filters.push(["eq", column, value]); return this; }
+  is(column, value) { this.filters.push(["is", column, value]); return this; }
+  in(column, values) { this.filters.push(["in", column, values]); return this; }
+  order() { return this; }
+  maybeSingle() { return Promise.resolve(this.client.resolveQuery(this, true)); }
+  then(resolve, reject) { return Promise.resolve(this.client.resolveQuery(this, false)).then(resolve, reject); }
+}
+
+function filterValue(query, column) {
+  return query.filters.find(([, key]) => key === column)?.[2];
+}
+
+function fakeHostedClients({ failFinish = false } = {}) {
+  const state = {
+    schedule: null,
+    activity: null,
+    deletedActivities: [],
+    deletedSchedules: [],
+  };
+
+  function makeClient(role) {
+    const signInWithPassword = vi.fn(async () => ({ data: { user: { id: `${role}-user` } }, error: null }));
+    const signOut = vi.fn(async () => ({ error: null }));
+    const client = {
+      role,
+      auth: { signInWithPassword, signOut },
+      from(table) { return new FakeQuery(client, table); },
+      resolveQuery(query, single) {
+        if (query.operation === "delete") {
+          const id = filterValue(query, "id");
+          if (query.table === "activities") {
+            state.deletedActivities.push(id);
+            if (state.activity?.id === id) state.activity = null;
+            return { data: null, error: null };
+          }
+          if (query.table === "scheduled_activities") {
+            state.deletedSchedules.push(id);
+            if (state.schedule?.id === id) state.schedule = null;
+            return { data: null, error: null };
+          }
+          throw new Error(`Unexpected delete table ${query.table}`);
+        }
+
+        if (role === "admin") {
+          if (query.table === "plants") return single
+            ? { data: { id: "plant-tam", code: "TAM", name: "Támesis", active: true }, error: null }
+            : { data: [{ id: "plant-tam", code: "TAM", name: "Támesis", active: true }], error: null };
+          if (query.table === "activity_templates") return { data: [{
+            id: "template-1", plant_id: "plant-tam", process_id: "process-1", code: "ASEO_HERRAMIENTAS",
+            name: "Aseo de herramientas", requires_equipment: false, requires_quantity: false,
+            default_unit_code: null, active: true,
+          }], error: null };
+          if (query.table === "employees") return { data: [{ id: "worker-1", plant_id: "plant-tam", display_name: "Operario UAT", active: true }], error: null };
+          if (query.table === "activities") return { data: [], error: null };
+          if (query.table === "activity_workers") return { data: [], error: null };
+        }
+
+        if (query.table === "scheduled_activities") {
+          const id = filterValue(query, "id");
+          const row = state.schedule?.id === id ? { ...state.schedule } : null;
+          return single ? { data: row, error: null } : { data: row ? [row] : [], error: null };
+        }
+        if (query.table === "activities") {
+          const id = filterValue(query, "id");
+          const row = state.activity?.id === id ? { ...state.activity } : null;
+          return single ? { data: row, error: null } : { data: row ? [row] : [], error: null };
+        }
+        throw new Error(`Unexpected ${role} query ${query.table}`);
+      },
+      async rpc(name) {
+        if (name === "ops_create_scheduled_activity") {
+          if (role === "operator") return { data: null, error: { message: "No tienes permiso para programar actividades en esta planta." } };
+          state.schedule = {
+            id: "schedule-1", plant_id: "plant-tam", title: "Aseo de herramientas", status: "planned",
+            planned_start: "2026-08-19T03:00:00.000Z", planned_end: "2026-08-19T03:30:00.000Z",
+          };
+          return { data: state.schedule.id, error: null };
+        }
+        if (name === "ops_start_scheduled_activity" && role === "operator") {
+          state.schedule.status = "running";
+          state.activity = {
+            id: "activity-1", plant_id: "plant-tam", scheduled_activity_id: state.schedule.id,
+            title: state.schedule.title, started_at: "2026-08-18T19:00:00.000Z", ended_at: null,
+            quantity: null, unit: null,
+          };
+          return { data: state.activity.id, error: null };
+        }
+        if (name === "ops_finish_activity_v2" && role === "operator") {
+          if (failFinish) return { data: null, error: { message: "fallo simulado de cierre" } };
+          state.activity.ended_at = "2026-08-18T19:01:00.000Z";
+          state.schedule.status = "done";
+          return { data: state.activity.ended_at, error: null };
+        }
+        throw new Error(`Unexpected ${role} RPC ${name}`);
+      },
+    };
+    return { client, signInWithPassword, signOut };
+  }
+
+  const admin = makeClient("admin");
+  const director = makeClient("director");
+  const operator = makeClient("operator");
+  const queue = [admin.client, director.client, operator.client];
+  return { state, admin, director, operator, createClientImpl: vi.fn(() => queue.shift()) };
 }
 
 describe("hosted planning smoke", () => {
@@ -51,5 +171,39 @@ describe("hosted planning smoke", () => {
   it("rejects non-origin or non-HTTPS Supabase URLs", () => {
     expect(() => parseHostedPlanningSmokeConfig({ ...baseEnv, NEXT_PUBLIC_SUPABASE_URL: "http://sanitized-project.supabase.co" })).toThrow(HostedPlanningSmokeError);
     expect(() => parseHostedPlanningSmokeConfig({ ...baseEnv, NEXT_PUBLIC_SUPABASE_URL: "https://sanitized-project.supabase.co/rest/v1" })).toThrow(HostedPlanningSmokeError);
+  });
+
+  it("certifies planned → running → done with an exact schedule-to-activity link and cleans both UAT rows", async () => {
+    const fake = fakeHostedClients();
+    const result = await runHostedPlanningSmoke({
+      env: baseEnv,
+      createClientImpl: fake.createClientImpl,
+      now: new Date("2026-08-18T19:00:00.000Z"),
+    });
+
+    expect(result.scheduleId).toBe("schedule-1");
+    expect(result.activityId).toBe("activity-1");
+    expect(result.checks).toContain("plan-real-link");
+    expect(result.checks).toContain("plan-done");
+    expect(fake.state.deletedActivities).toEqual(["activity-1"]);
+    expect(fake.state.deletedSchedules).toEqual(["schedule-1"]);
+    expect(fake.state.activity).toBeNull();
+    expect(fake.state.schedule).toBeNull();
+    expect(fake.operator.signOut).toHaveBeenCalledOnce();
+    expect(fake.director.signOut).toHaveBeenCalledOnce();
+  });
+
+  it("cleans the started activity and schedule even when finishing the real activity fails", async () => {
+    const fake = fakeHostedClients({ failFinish: true });
+    await expect(runHostedPlanningSmoke({
+      env: baseEnv,
+      createClientImpl: fake.createClientImpl,
+      now: new Date("2026-08-18T19:00:00.000Z"),
+    })).rejects.toThrow(/fallo simulado de cierre/);
+
+    expect(fake.state.deletedActivities).toEqual(["activity-1"]);
+    expect(fake.state.deletedSchedules).toEqual(["schedule-1"]);
+    expect(fake.state.activity).toBeNull();
+    expect(fake.state.schedule).toBeNull();
   });
 });

--- a/src/lib/ops-data-contract.plan-real.test.ts
+++ b/src/lib/ops-data-contract.plan-real.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { mapRemoteActivities, type PlantAccess } from "@/lib/ops-data-contract";
+
+const access: PlantAccess[] = [
+  { dbId: "db-tam", plantId: "tamesis", code: "TAM", name: "Támesis", role: "operator" },
+];
+
+describe("completed hosted plan-vs-real mapping", () => {
+  it("turns a done schedule plus its linked finished activity into one scheduled execution for analytics", () => {
+    const rows = mapRemoteActivities([
+      {
+        id: "schedule-uat",
+        plant_id: "db-tam",
+        title: "Aseo de herramientas",
+        process: "Aseo",
+        process_id: "process-aseo",
+        activity_template_id: "template-aseo",
+        planned_start: "2026-08-19T13:00:00Z",
+        planned_end: "2026-08-19T13:30:00Z",
+        status: "done",
+      },
+    ], [
+      {
+        id: "activity-uat",
+        plant_id: "db-tam",
+        scheduled_activity_id: "schedule-uat",
+        title: "Aseo de herramientas",
+        process: "Aseo",
+        started_at: "2026-08-19T13:05:00Z",
+        ended_at: "2026-08-19T13:20:00Z",
+        source_kind: "app",
+      },
+    ], [
+      { activity_id: "activity-uat", employee_id: "worker-uat" },
+    ], access);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "activity-uat",
+      plantId: "tamesis",
+      source: "scheduled",
+      status: "done",
+      plannedStart: "2026-08-19T13:00:00Z",
+      plannedEnd: "2026-08-19T13:30:00Z",
+      actualStart: "2026-08-19T13:05:00Z",
+      actualEnd: "2026-08-19T13:20:00Z",
+      workerIds: ["worker-uat"],
+      processId: "process-aseo",
+      activityTemplateId: "template-aseo",
+    });
+  });
+});


### PR DESCRIPTION
## Objetivo
Extender Pilot Readiness alojado desde una escritura de planificación hasta la relación canónica plan → ejecución real → cierre.

## Flujo UAT autocontenible
- descubre maestros reales de Támesis sin IDs hardcodeados;
- elige un trabajador activo que no tenga una actividad abierta;
- Director crea una programación temporal vía `ops_create_scheduled_activity`;
- Operario Támesis puede leer el plan por RLS pero sigue sin poder programar;
- Operario inicia ese schedule vía `ops_start_scheduled_activity`;
- se exige `scheduled_activities.status = running` y `activities.scheduled_activity_id = scheduleId` exacto;
- Operario finaliza vía `ops_finish_activity_v2` sin novedad ni incidencia;
- se exige actividad cerrada y schedule `done`;
- cleanup administrativo borra primero únicamente el `activityId` UAT y luego únicamente el `scheduleId` UAT.

## Protección de operación real
- no usa un trabajador que ya tenga actividad abierta;
- no crea usuarios, perfiles, membresías, incidencias, recepciones ni inventario;
- las filas UAT se identifican por los IDs devueltos por los RPC y se limpian incluso ante fallo de cierre;
- si no existen maestros suficientes, el UAT falla como readiness deficiency en lugar de crear fixtures alojadas.

## Cobertura
- flujo completo planned → running → done + vínculo exacto + cleanup;
- cleanup de actividad y programación cuando el cierre de actividad falla;
- rechazo de clave `service_role` accidental y validación de configuración;
- mapper remoto certificado para `schedule done + activity finished` como una sola ejecución `source=scheduled` con plan y real disponibles para analytics.

## Gate final
Head certificado: `16909d3e476beeced4de5bd69bbce6d2d7943815`
Run `32176381057`:
- Quality ✅
- Database ✅
- Desktop Chromium ✅
- Mobile Chromium ✅

## Merge
Fusionado a `develop` en `e1dd50d57b79945dca81df27fd58b1eacbf3faa7`.

## UAT alojado pendiente
El workflow `hosted-pilot-uat` ya contiene este lifecycle. Su ejecución manual contra el Supabase piloto sigue pendiente porque el conector GitHub disponible en esta sesión no expone `workflow_dispatch`; no se ha simulado esa evidencia.