### PR TITLE
feat(public): consolidar maestros SharePoint en Biblioteca v6

### DIFF
--- a/e2e/public-shell-seo.spec.ts
+++ b/e2e/public-shell-seo.spec.ts
@@ -5,6 +5,7 @@ const shellRoutes = [
   "/wondergreen",
   "/wondergreen/cultivos",
   "/wondergreen/cultivos/cafe",
+  "/casa-jardin",
   "/soluciones",
   "/soluciones/diagnostico-caracterizacion",
   "/proyectos",
@@ -24,10 +25,19 @@ test("public home uses the shared navigation and real routes", async ({ page }) 
   await expect(nav).toBeVisible();
   await expect(nav.getByRole("link", { name: "Soluciones" })).toHaveAttribute("href", "/soluciones");
   await expect(nav.getByRole("link", { name: "Wondergreen" })).toHaveAttribute("href", "/wondergreen");
+  await expect(nav.getByRole("link", { name: "Casa y Jardín" })).toHaveAttribute("href", "/casa-jardin");
   await expect(nav.getByRole("link", { name: "Proyectos" })).toHaveAttribute("href", "/proyectos");
   await expect(nav.getByRole("link", { name: "Impacto" })).toHaveAttribute("href", "/impacto");
   await expect(header.getByRole("link", { name: "Contacto" })).toHaveAttribute("href", "/contacto");
   await expect(header.getByRole("link", { name: "Acceder a Greenatics" })).toHaveAttribute("href", "/app");
+});
+
+test("Casa y Jardín stays a real but non-indexed placeholder until its catalog is defined", async ({ page }) => {
+  await page.goto("/casa-jardin");
+
+  await expect(page.getByRole("heading", { name: "Casa y Jardín." })).toBeVisible();
+  await expect(page.getByText("Próximamente", { exact: true })).toBeVisible();
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
 });
 
 test("nested public routes inherit the same shell", async ({ page }) => {
@@ -58,6 +68,7 @@ test("sitemap exposes public routes and robots blocks OPS", async ({ request }) 
   expect(sitemapText).toContain("https://greenatics.com.co/soluciones/diagnostico-caracterizacion");
   expect(sitemapText).toContain("https://greenatics.com.co/proyectos/yarumal");
   expect(sitemapText).toContain("https://greenatics.com.co/wondergreen/cultivos/cafe");
+  expect(sitemapText).not.toContain("https://greenatics.com.co/casa-jardin");
   expect(sitemapText).not.toContain("https://greenatics.com.co/app");
 
   const robots = await request.get("/robots.txt");

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -1,13 +1,19 @@
 import { test, expect } from "@playwright/test";
 
-test("public library exposes live Wondergreen knowledge resources", async ({ page }) => {
+test("public library exposes live Wondergreen knowledge resources and governed source masters", async ({ page }) => {
   await page.goto("/biblioteca");
 
   await expect(page.getByRole("heading", { name: /La biblioteca no es un archivo/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Programas Wondergreen por cultivo" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Guía Wondergreen para café" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Guía Wondergreen para cacao" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Guía Wondergreen para aguacate" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Guía Wondergreen para limón Tahití" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Guía Wondergreen para pastos y gramíneas" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Guía práctica de deficiencias nutricionales" })).toBeVisible();
   await expect(page.getByRole("link", { name: /Abrir guía/i })).toHaveAttribute("href", "/biblioteca/guia-deficiencias");
-  await expect(page.getByText("Lectura web disponible · descarga pública en preparación", { exact: true })).toBeVisible();
+  await expect(page.getByText("Lectura web disponible · PDF maestro identificado · descarga pública en preparación", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("Maestro: Catálogo Wondergreen optimizado · 10 páginas", { exact: true })).toBeVisible();
 });
 
 test("public library routes by user intent before product selection", async ({ page }) => {

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -11,7 +11,7 @@ test("public library exposes live Wondergreen knowledge resources and governed s
   await expect(page.getByRole("heading", { name: "Guía Wondergreen para limón Tahití" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Guía Wondergreen para pastos y gramíneas" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Guía práctica de deficiencias nutricionales" })).toBeVisible();
-  await expect(page.getByRole("link", { name: /Abrir guía/i })).toHaveAttribute("href", "/biblioteca/guia-deficiencias");
+  await expect(page.getByRole("link", { name: "Abrir guía →", exact: true })).toHaveAttribute("href", "/biblioteca/guia-deficiencias");
   await expect(page.getByText("Lectura web disponible · PDF maestro identificado · descarga pública en preparación", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("Maestro: Catálogo Wondergreen optimizado · 10 páginas", { exact: true })).toBeVisible();
 });

--- a/src/app/biblioteca/page.tsx
+++ b/src/app/biblioteca/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { publicResources } from "@/data/public-resources";
+import { publicResources, type PublicResource } from "@/data/public-resources";
 import styles from "./library.module.css";
 
 export const metadata: Metadata = {
@@ -59,6 +59,14 @@ const intentRoutes = [
   },
 ] as const;
 
+function getDeliveryLabel(resource: PublicResource) {
+  if (resource.delivery === "web-native") return "Lectura web disponible";
+  if (resource.delivery === "web-native-master-pending") {
+    return "Lectura web disponible · PDF maestro identificado · descarga pública en preparación";
+  }
+  return "Lectura web disponible · descarga pública en preparación";
+}
+
 export default function LibraryPage() {
   return (
     <div className={styles.page}>
@@ -110,10 +118,11 @@ export default function LibraryPage() {
                 <article className={styles.libraryCard} key={resource.id}>
                   <div className={styles.resourceMeta}>
                     <span className={styles.status}>{resource.statusLabel}</span>
-                    <small className={styles.delivery}>{resource.delivery === "web-native" ? "Lectura web disponible" : "Lectura web disponible · descarga pública en preparación"}</small>
+                    <small className={styles.delivery}>{getDeliveryLabel(resource)}</small>
                   </div>
                   <h3>{resource.title}</h3>
                   <p>{resource.copy}</p>
+                  {resource.masterLabel ? <small className={styles.delivery}>Maestro: {resource.masterLabel}</small> : null}
                   <Link href={resource.href}>{resource.cta} →</Link>
                 </article>
               ))}

--- a/src/app/casa-jardin/layout.tsx
+++ b/src/app/casa-jardin/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { PublicShell } from "@/components/public-shell";
+
+export const metadata: Metadata = {
+  title: "Casa y Jardín | Greenatics",
+  description: "Espacio reservado para la futura línea Greenatics de soluciones para casa, jardín y autocultivo.",
+  alternates: { canonical: "/casa-jardin" },
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
+
+export default function CasaJardinLayout({ children }: { children: React.ReactNode }) {
+  return <PublicShell ownsMain={false}>{children}</PublicShell>;
+}

--- a/src/app/casa-jardin/page.tsx
+++ b/src/app/casa-jardin/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import styles from "../company-public.module.css";
+
+export default function CasaJardinPage() {
+  return (
+    <div className={styles.page}>
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Greenatics · próxima línea</span>
+              <h1>Casa y Jardín.</h1>
+              <p className={styles.lead}>
+                Estamos preparando un espacio para soluciones Greenatics y Wondergreen pensadas para plantas, huertas, jardín y autocultivo en casa.
+              </p>
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen">Conocer Wondergreen</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/biblioteca">Explorar conocimiento</Link>
+              </div>
+            </div>
+            <aside className={styles.officeCard}>
+              <span>Próximamente</span>
+              <strong>Este espacio ya hace parte de la arquitectura pública.</strong>
+              <span>Los kits, presentaciones, coberturas, precios y contenidos se publicarán únicamente cuando queden definidos y validados.</span>
+            </aside>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Espacio reservado</span>
+              <h2>Primero consolidamos la oferta. Luego abrimos la tienda.</h2>
+              <p>
+                Por ahora esta sección funciona como puerta de entrada futura. No publicamos productos, promesas, dosis ni precios provisionales.
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/components/public-shell.module.css
+++ b/src/components/public-shell.module.css
@@ -67,7 +67,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 24px;
+  gap: 20px;
   min-width: 0;
 }
 
@@ -209,7 +209,7 @@
   letter-spacing: 0.04em;
 }
 
-@media (max-width: 1080px) {
+@media (max-width: 1180px) {
   .headerInner {
     grid-template-columns: auto auto;
   }

--- a/src/data/public-indexing.test.ts
+++ b/src/data/public-indexing.test.ts
@@ -2,20 +2,20 @@ import { describe, expect, it } from "vitest";
 import sitemap from "../app/sitemap";
 import robots from "../app/robots";
 import { protectedOpsRoutePrefixes } from "../lib/ops-access-policy";
-import { publicNav, publicSite, publicStaticRoutes } from "./public-site";
+import { publicNav, publicReservedRoutes, publicSite, publicStaticRoutes } from "./public-site";
 import { services } from "./services";
 import { publicProjects } from "./projects-public";
 import { wondergreenCrops } from "./wondergreen-crops";
 import { wondergreenReferences } from "./wondergreen-public";
 
 describe("public navigation and indexing contract", () => {
-  it("keeps primary navigation on real public routes", () => {
-    const staticSet = new Set<string>(publicStaticRoutes);
+  it("keeps primary navigation on governed public routes", () => {
+    const governedSet = new Set<string>([...publicStaticRoutes, ...publicReservedRoutes]);
     expect(publicNav.map((item) => item.href)).toHaveLength(new Set(publicNav.map((item) => item.href)).size);
-    for (const item of publicNav) expect(staticSet.has(item.href)).toBe(true);
+    for (const item of publicNav) expect(governedSet.has(item.href)).toBe(true);
   });
 
-  it("builds a sitemap from governed public data only", () => {
+  it("builds a sitemap from governed indexed public data only", () => {
     const entries = sitemap();
     const urls = entries.map((item) => item.url);
     const expectedCount = publicStaticRoutes.length + services.length + publicProjects.length + wondergreenCrops.length + wondergreenReferences.length;
@@ -26,6 +26,7 @@ describe("public navigation and indexing contract", () => {
     expect(urls).toContain(`${publicSite.publicDomainTarget}/wondergreen/cultivos/cafe`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/wondergreen/productos/2grow-solido-15-3-3`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/wondergreen/productos/extracto-neem`);
+    for (const path of publicReservedRoutes) expect(urls).not.toContain(`${publicSite.publicDomainTarget}${path}`);
     expect(urls.some((url) => url.includes("/app"))).toBe(false);
     expect(urls.some((url) => url.includes("/dashboard"))).toBe(false);
   });
@@ -39,6 +40,7 @@ describe("public navigation and indexing contract", () => {
       expect(disallow).toContain(path);
     }
     for (const path of publicStaticRoutes) expect(disallow).not.toContain(path);
+    for (const path of publicReservedRoutes) expect(disallow).not.toContain(path);
     for (const stalePath of ["/maintenance", "/purchase-requests", "/settlements", "/suppliers"]) {
       expect(disallow).not.toContain(stalePath);
     }

--- a/src/data/public-resources.test.ts
+++ b/src/data/public-resources.test.ts
@@ -12,15 +12,33 @@ describe("public knowledge resource registry", () => {
     }
   });
 
-  it("uses the navigable Product Master as the public catalog authority", () => {
-    const catalog = publicResources.find((resource) => resource.id === "wondergreen-product-master");
-    expect(catalog?.href).toBe("/wondergreen/productos");
-    expect(catalog?.delivery).toBe("public-download-pending");
+  it("registers the five governed crop masters already represented by public crop routes", () => {
+    const cropMasters = publicResources.filter((resource) => resource.id.startsWith("wondergreen-guide-"));
+    expect(cropMasters).toHaveLength(5);
+    expect(cropMasters.map((resource) => resource.href).sort()).toEqual([
+      "/wondergreen/cultivos/aguacate",
+      "/wondergreen/cultivos/cacao",
+      "/wondergreen/cultivos/cafe",
+      "/wondergreen/cultivos/limon-tahiti",
+      "/wondergreen/cultivos/pastos-gramineas",
+    ]);
+    for (const resource of cropMasters) {
+      expect(resource.delivery).toBe("web-native-master-pending");
+      expect(resource.masterLabel?.trim().length).toBeGreaterThan(0);
+    }
   });
 
-  it("does not expose a fake downloadable asset before public hosting exists", () => {
-    for (const resource of publicResources.filter((item) => item.delivery === "public-download-pending")) {
+  it("uses the navigable Product Master as the public catalog authority while its PDF master awaits public hosting", () => {
+    const catalog = publicResources.find((resource) => resource.id === "wondergreen-product-master");
+    expect(catalog?.href).toBe("/wondergreen/productos");
+    expect(catalog?.delivery).toBe("web-native-master-pending");
+    expect(catalog?.masterLabel).toMatch(/10 páginas/i);
+  });
+
+  it("does not expose a private or fake downloadable asset before public hosting exists", () => {
+    for (const resource of publicResources.filter((item) => item.delivery !== "web-native")) {
       expect(resource.href).not.toMatch(/\.pdf(?:$|\?)/i);
+      expect(resource.href).not.toMatch(/sharepoint|graph\.microsoft/i);
     }
   });
 });

--- a/src/data/public-resources.ts
+++ b/src/data/public-resources.ts
@@ -35,7 +35,7 @@ export const publicResources: PublicResource[] = [
     href: "/wondergreen/cultivos/cafe",
     cta: "Abrir guía de café",
     delivery: "web-native-master-pending",
-    sourceAuthority: "Wondergreen Crop Truth · maestro comercial reconciliado",
+    sourceAuthority: "Wondergreen Crop Truth · maestro comercial localizado",
     masterLabel: "Guía Wondergreen Café · 20 páginas",
   },
   {
@@ -47,7 +47,7 @@ export const publicResources: PublicResource[] = [
     href: "/wondergreen/cultivos/cacao",
     cta: "Abrir guía de cacao",
     delivery: "web-native-master-pending",
-    sourceAuthority: "Wondergreen Crop Truth · maestro comercial reconciliado",
+    sourceAuthority: "Wondergreen Crop Truth · maestro comercial localizado",
     masterLabel: "Guía Wondergreen Cacao · 20 páginas",
   },
   {
@@ -59,7 +59,7 @@ export const publicResources: PublicResource[] = [
     href: "/wondergreen/cultivos/aguacate",
     cta: "Abrir guía de aguacate",
     delivery: "web-native-master-pending",
-    sourceAuthority: "Wondergreen Crop Truth · maestro comercial reconciliado",
+    sourceAuthority: "Wondergreen Crop Truth · maestro comercial localizado",
     masterLabel: "Guía Wondergreen Aguacate V2 · 20 páginas",
   },
   {
@@ -71,7 +71,7 @@ export const publicResources: PublicResource[] = [
     href: "/wondergreen/cultivos/limon-tahiti",
     cta: "Abrir guía de limón Tahití",
     delivery: "web-native-master-pending",
-    sourceAuthority: "Wondergreen Crop Truth · maestro comercial reconciliado",
+    sourceAuthority: "Wondergreen Crop Truth · maestro comercial localizado",
     masterLabel: "Guía Wondergreen Cítricos · 20 páginas",
   },
   {
@@ -83,7 +83,7 @@ export const publicResources: PublicResource[] = [
     href: "/wondergreen/cultivos/pastos-gramineas",
     cta: "Abrir guía de pastos",
     delivery: "web-native-master-pending",
-    sourceAuthority: "Wondergreen Crop Truth · maestro comercial reconciliado",
+    sourceAuthority: "Wondergreen Crop Truth · maestro comercial localizado",
     masterLabel: "Guía Wondergreen Pastos y Praderas · 20 páginas",
   },
   {
@@ -128,7 +128,7 @@ export const publicResources: PublicResource[] = [
     href: "/wondergreen/productos",
     cta: "Ver productos",
     delivery: "web-native-master-pending",
-    sourceAuthority: "Wondergreen Product Truth · maestro comercial reconciliado",
+    sourceAuthority: "Wondergreen Product Truth · maestro comercial localizado",
     masterLabel: "Catálogo Wondergreen optimizado · 10 páginas",
   },
   {

--- a/src/data/public-resources.ts
+++ b/src/data/public-resources.ts
@@ -1,5 +1,5 @@
 export type PublicResourceKind = "crop-library" | "manual" | "guide" | "catalog" | "technology" | "finder";
-export type PublicResourceDelivery = "web-native" | "public-download-pending";
+export type PublicResourceDelivery = "web-native" | "web-native-master-pending" | "public-download-pending";
 
 export type PublicResource = {
   id: string;
@@ -11,6 +11,7 @@ export type PublicResource = {
   cta: string;
   delivery: PublicResourceDelivery;
   sourceAuthority: string;
+  masterLabel?: string;
 };
 
 export const publicResources: PublicResource[] = [
@@ -24,6 +25,66 @@ export const publicResources: PublicResource[] = [
     cta: "Explorar cultivos",
     delivery: "web-native",
     sourceAuthority: "Wondergreen Crop Truth",
+  },
+  {
+    id: "wondergreen-guide-cafe",
+    kind: "guide",
+    statusLabel: "Guía por cultivo",
+    title: "Guía Wondergreen para café",
+    copy: "Programa navegable para café conectado con etapa, contexto de lote, familias Wondergreen y seguimiento. El maestro editorial de 20 páginas ya fue localizado para su futura descarga pública.",
+    href: "/wondergreen/cultivos/cafe",
+    cta: "Abrir guía de café",
+    delivery: "web-native-master-pending",
+    sourceAuthority: "Wondergreen Crop Truth · maestro comercial reconciliado",
+    masterLabel: "Guía Wondergreen Café · 20 páginas",
+  },
+  {
+    id: "wondergreen-guide-cacao",
+    kind: "guide",
+    statusLabel: "Guía por cultivo",
+    title: "Guía Wondergreen para cacao",
+    copy: "Programa navegable para cacao con establecimiento, formación, transición reproductiva, llenado, recuperación, alertas y seguimiento. El maestro editorial de 20 páginas ya fue localizado.",
+    href: "/wondergreen/cultivos/cacao",
+    cta: "Abrir guía de cacao",
+    delivery: "web-native-master-pending",
+    sourceAuthority: "Wondergreen Crop Truth · maestro comercial reconciliado",
+    masterLabel: "Guía Wondergreen Cacao · 20 páginas",
+  },
+  {
+    id: "wondergreen-guide-aguacate",
+    kind: "guide",
+    statusLabel: "Guía por cultivo",
+    title: "Guía Wondergreen para aguacate",
+    copy: "Programa navegable para aguacate con formación, mantenimiento, prefloración, cuajado, llenado y recuperación. El maestro editorial V2 de 20 páginas ya fue localizado.",
+    href: "/wondergreen/cultivos/aguacate",
+    cta: "Abrir guía de aguacate",
+    delivery: "web-native-master-pending",
+    sourceAuthority: "Wondergreen Crop Truth · maestro comercial reconciliado",
+    masterLabel: "Guía Wondergreen Aguacate V2 · 20 páginas",
+  },
+  {
+    id: "wondergreen-guide-limon-tahiti",
+    kind: "guide",
+    statusLabel: "Guía por cultivo",
+    title: "Guía Wondergreen para limón Tahití",
+    copy: "Programa navegable para limón Tahití organizado alrededor de flujos vegetativos y reproductivos, contexto radicular y seguimiento. El maestro editorial de cítricos de 20 páginas ya fue localizado.",
+    href: "/wondergreen/cultivos/limon-tahiti",
+    cta: "Abrir guía de limón Tahití",
+    delivery: "web-native-master-pending",
+    sourceAuthority: "Wondergreen Crop Truth · maestro comercial reconciliado",
+    masterLabel: "Guía Wondergreen Cítricos · 20 páginas",
+  },
+  {
+    id: "wondergreen-guide-pastos",
+    kind: "guide",
+    statusLabel: "Guía por cultivo",
+    title: "Guía Wondergreen para pastos y gramíneas",
+    copy: "Programa navegable para suelo, crecimiento activo, sostenimiento y rebrote por hectárea y manejo del potrero. El maestro editorial de pastos y praderas de 20 páginas ya fue localizado.",
+    href: "/wondergreen/cultivos/pastos-gramineas",
+    cta: "Abrir guía de pastos",
+    delivery: "web-native-master-pending",
+    sourceAuthority: "Wondergreen Crop Truth · maestro comercial reconciliado",
+    masterLabel: "Guía Wondergreen Pastos y Praderas · 20 páginas",
   },
   {
     id: "wondergreen-use-manual",
@@ -62,12 +123,13 @@ export const publicResources: PublicResource[] = [
     id: "wondergreen-product-master",
     kind: "catalog",
     statusLabel: "Product Master público",
-    title: "Catálogo técnico gobernado",
-    copy: "Familias, fórmulas, formatos y estado público de cada referencia conectados con el sistema Wondergreen y su versión técnica.",
+    title: "Catálogo técnico-comercial Wondergreen",
+    copy: "Familias, formulaciones, formatos, precios reconciliados y estado público se consultan desde el Product Master navegable. El catálogo comercial optimizado de 10 páginas ya fue localizado como candidato de descarga pública.",
     href: "/wondergreen/productos",
     cta: "Ver productos",
-    delivery: "public-download-pending",
-    sourceAuthority: "Wondergreen Product Truth",
+    delivery: "web-native-master-pending",
+    sourceAuthority: "Wondergreen Product Truth · maestro comercial reconciliado",
+    masterLabel: "Catálogo Wondergreen optimizado · 10 páginas",
   },
   {
     id: "wondergreen-more-than-npk",

--- a/src/data/public-site.test.ts
+++ b/src/data/public-site.test.ts
@@ -18,6 +18,6 @@ describe("public site contact configuration", () => {
 
   it("reserves Casa y Jardín in the primary navigation without promoting the placeholder to the sitemap", () => {
     expect(publicNav).toContainEqual({ href: "/casa-jardin", label: "Casa y Jardín" });
-    expect(publicStaticRoutes.some((route) => route === ("/casa-jardin" as never))).toBe(false);
+    expect([...publicStaticRoutes]).not.toContain("/casa-jardin");
   });
 });

--- a/src/data/public-site.test.ts
+++ b/src/data/public-site.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { publicNav, publicSite, publicStaticRoutes } from "./public-site";
+import { publicNav, publicReservedRoutes, publicSite, publicStaticRoutes } from "./public-site";
 
 describe("public site contact configuration", () => {
   it("keeps corporate location centralized", () => {
@@ -18,6 +18,7 @@ describe("public site contact configuration", () => {
 
   it("reserves Casa y Jardín in the primary navigation without promoting the placeholder to the sitemap", () => {
     expect(publicNav).toContainEqual({ href: "/casa-jardin", label: "Casa y Jardín" });
+    expect(publicReservedRoutes).toContain("/casa-jardin");
     expect([...publicStaticRoutes]).not.toContain("/casa-jardin");
   });
 });

--- a/src/data/public-site.test.ts
+++ b/src/data/public-site.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { publicSite } from "./public-site";
+import { publicNav, publicSite, publicStaticRoutes } from "./public-site";
 
 describe("public site contact configuration", () => {
   it("keeps corporate location centralized", () => {
@@ -14,5 +14,10 @@ describe("public site contact configuration", () => {
   it("distinguishes target and legacy indexed domains", () => {
     expect(publicSite.publicDomainTarget).toBe("https://greenatics.com.co");
     expect(publicSite.legacyIndexedDomain).toBe("https://greenatics.org");
+  });
+
+  it("reserves Casa y Jardín in the primary navigation without promoting the placeholder to the sitemap", () => {
+    expect(publicNav).toContainEqual({ href: "/casa-jardin", label: "Casa y Jardín" });
+    expect(publicStaticRoutes).not.toContain("/casa-jardin");
   });
 });

--- a/src/data/public-site.test.ts
+++ b/src/data/public-site.test.ts
@@ -18,6 +18,6 @@ describe("public site contact configuration", () => {
 
   it("reserves Casa y Jardín in the primary navigation without promoting the placeholder to the sitemap", () => {
     expect(publicNav).toContainEqual({ href: "/casa-jardin", label: "Casa y Jardín" });
-    expect(publicStaticRoutes).not.toContain("/casa-jardin");
+    expect(publicStaticRoutes.some((route) => route === ("/casa-jardin" as never))).toBe(false);
   });
 });

--- a/src/data/public-site.ts
+++ b/src/data/public-site.ts
@@ -18,6 +18,7 @@ export const publicSite = {
 export const publicNav = [
   { href: "/soluciones", label: "Soluciones" },
   { href: "/wondergreen", label: "Wondergreen" },
+  { href: "/casa-jardin", label: "Casa y Jardín" },
   { href: "/proyectos", label: "Proyectos" },
   { href: "/impacto", label: "Impacto" },
   { href: "/biblioteca", label: "Conocimiento" },

--- a/src/data/public-site.ts
+++ b/src/data/public-site.ts
@@ -71,6 +71,10 @@ export const publicStaticRoutes = [
   "/contacto",
 ] as const;
 
+export const publicReservedRoutes = [
+  "/casa-jardin",
+] as const;
+
 export const internalRoutePrefixes = [
   ...protectedOpsRoutePrefixes,
   "/login",


### PR DESCRIPTION
## Objetivo
Cerrar la primera brecha entre la Biblioteca web actual y los maestros comerciales/técnicos ya localizados en SharePoint, y reservar la futura línea Casa y Jardín sin mezclarla todavía con un catálogo incompleto. Todo ello sin exponer rutas privadas ni tocar GREENATICS OPS.

## Alcance
- registra explícitamente cinco guías por cultivo ya representadas por rutas web gobernadas: café, cacao, aguacate, limón Tahití y pastos/gramíneas;
- reconoce el catálogo Wondergreen optimizado de 10 páginas como maestro localizado, manteniendo el Product Master navegable como autoridad pública;
- diferencia `web-native`, `web-native-master-pending` y `public-download-pending`;
- la Biblioteca muestra cuándo existe un PDF maestro pero su descarga pública todavía no está hospedada;
- añade `Casa y Jardín` a la navegación superior;
- crea `/casa-jardin` como placeholder real, gobernado y deliberadamente `noindex` hasta definir kits, SKUs, coberturas, precios y contenidos;
- mantiene Casa y Jardín fuera del sitemap mientras siga siendo placeholder;
- nunca publica URLs SharePoint/Graph ni inventa un `.pdf` público inexistente;
- añade unit y Playwright para fijar estos contratos.

## Fuentes revisadas
- catálogo Wondergreen optimizado de 10 páginas;
- maestros de 20 páginas para café, cacao, aguacate, cítricos y pastos/praderas;
- validación de SharePoint: el sitio actualmente tiene deshabilitado el uso compartido anónimo, por lo que los PDF no pueden exponerse directamente sin autenticación.

## Guardrails
- cero cambios en OPS, Auth, Supabase, RLS, migraciones o workflows;
- cero cambios en fórmulas, dosis, precios, claims o Product Truth;
- no se revive GitHub Pages ni static export legacy;
- no se versionan hostname, site/drive/item IDs ni rutas privadas de SharePoint;
- Casa y Jardín no anticipa todavía un catálogo comercial.

## Próxima wave
Publicar copias aprobadas de los PDF en almacenamiento web propio y transformar `master-pending` en CTA real de descarga; después ampliar fotografía/packshots oficiales, recorridos comerciales de Soluciones/Back2Green y finalmente dotar Casa y Jardín con la oferta validada de kits y autocultivo.