### PR TITLE
feat(public): ordenar Soluciones por recorridos comerciales

### DIFF
--- a/e2e/public-solutions.spec.ts
+++ b/e2e/public-solutions.spec.ts
@@ -7,10 +7,17 @@ async function jsonLdByType(page: import("@playwright/test").Page, type: string)
     .filter((payload) => payload["@type"] === type);
 }
 
-test("solutions hub exposes the governed service architecture", async ({ page }) => {
+test("solutions hub exposes the governed service architecture and four commercial journeys", async ({ page }) => {
   await page.goto("/soluciones");
 
   await expect(page.getByRole("heading", { name: /El proyecto no empieza en la planta/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "No necesitas conocer el nombre del servicio." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Diagnosticar y planear" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Separar y recolectar" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Construir o recuperar capacidad" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Operar, controlar y medir" })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Diagnóstico y caracterización/ })).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
+  await expect(page.getByRole("link", { name: /Trazabilidad y datos/ })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
   await expect(page.getByRole("heading", { name: /Del PGIRS a una operación sostenible/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: /De residuo operativo a flujo gestionado/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Diagnóstico y caracterización de residuos orgánicos" })).toBeVisible();

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -19,6 +19,54 @@ const categoryIntro: Record<ServiceCategory, string> = {
 
 const path = ["Entender", "Recolectar", "Transformar", "Operar", "Medir", "Devolver valor"];
 
+const solutionJourneys = [
+  {
+    number: "01",
+    kicker: "Necesito entender y decidir",
+    title: "Diagnosticar y planear",
+    copy: "Para proyectos que todavía necesitan una línea base, un instrumento de planeación o una decisión de prefactibilidad antes de invertir.",
+    services: [
+      ["Diagnóstico y caracterización", "/soluciones/diagnostico-caracterizacion"],
+      ["PGIRS", "/soluciones/pgirs"],
+      ["PMIRS", "/soluciones/pmirs"],
+      ["Prefactibilidad", "/soluciones/prefactibilidad"],
+    ],
+  },
+  {
+    number: "02",
+    kicker: "Necesito mover material separado",
+    title: "Separar y recolectar",
+    copy: "Para conectar generadores, frecuencias, microrrutas y criterios de aceptación con un destino real de aprovechamiento.",
+    services: [
+      ["Rutas selectivas", "/soluciones/rutas-selectivas"],
+      ["Motocarguero / piloto", "/soluciones/motocarguero"],
+      ["Recolección y tratamiento", "/soluciones/recoleccion-tratamiento"],
+    ],
+  },
+  {
+    number: "03",
+    kicker: "Necesito infraestructura",
+    title: "Construir o recuperar capacidad",
+    copy: "Para madurar ingeniería, construir una planta nueva o recuperar infraestructura existente antes de reemplazarla.",
+    services: [
+      ["Factibilidad e ingeniería", "/soluciones/factibilidad-ingenieria"],
+      ["Plantas nuevas", "/soluciones/plantas-nuevas"],
+      ["Rehabilitación", "/soluciones/rehabilitacion"],
+    ],
+  },
+  {
+    number: "04",
+    kicker: "Necesito que funcione y se pueda demostrar",
+    title: "Operar, controlar y medir",
+    copy: "Para convertir infraestructura y procesos en una operación disciplinada con mantenimiento, inventarios, evidencia y trazabilidad.",
+    services: [
+      ["Dirección de operación", "/soluciones/direccion-operacion"],
+      ["Operación integral", "/soluciones/operacion-integral"],
+      ["Trazabilidad y datos", "/soluciones/trazabilidad-datos"],
+    ],
+  },
+] as const;
+
 export default function SolutionsPage() {
   return (
     <div className={styles.page}>
@@ -31,6 +79,7 @@ export default function SolutionsPage() {
               <h1>El proyecto no empieza en la planta ni termina cuando se entrega un equipo.</h1>
               <p className={styles.lead}>Greenatics trabaja sobre toda la cadena: diagnosticar, planear, recolectar, transformar, operar, medir y devolver valor. Cada servicio puede contratarse como una fase independiente o integrarse dentro de un sistema territorial o empresarial.</p>
               <div className={styles.heroLinks}>
+                <a href="#recorridos">Encontrar mi punto de entrada →</a>
                 <a href="#municipios">Municipios y ESP →</a>
                 <a href="#empresas">Empresas →</a>
               </div>
@@ -49,10 +98,35 @@ export default function SolutionsPage() {
           </div>
         </section>
 
+        <section className={styles.journeys} id="recorridos">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Empieza por lo que necesitas resolver</span>
+              <h2>No necesitas conocer el nombre del servicio.</h2>
+              <p>Los 13 servicios siguen siendo independientes y contratables por fase. Estos cuatro recorridos solo simplifican la entrada según el estado real del proyecto.</p>
+            </div>
+            <div className={styles.journeyGrid}>
+              {solutionJourneys.map((journey) => (
+                <article className={styles.journeyCard} key={journey.number}>
+                  <span className={styles.journeyNumber}>{journey.number}</span>
+                  <small>{journey.kicker}</small>
+                  <h3>{journey.title}</h3>
+                  <p>{journey.copy}</p>
+                  <div className={styles.journeyLinks}>
+                    {journey.services.map(([label, href]) => (
+                      <Link href={href} key={href}>{label} →</Link>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
         <section className={styles.audience}>
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <span className={styles.eyebrow}>Empieza por tu contexto</span>
+              <span className={styles.eyebrow}>Ahora ubica tu contexto</span>
               <h2>La misma corriente orgánica exige decisiones distintas según quién la genera y quién la opera.</h2>
               <p>Por eso el portafolio distingue rutas para territorios y prestadores, y rutas para empresas o grandes generadores.</p>
             </div>

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { serviceJourneys } from "@/data/service-journeys";
 import { companyServices, municipalServices, serviceCategories, services, type ServiceCategory } from "@/data/services";
 import styles from "./solutions.module.css";
 
@@ -18,54 +19,6 @@ const categoryIntro: Record<ServiceCategory, string> = {
 };
 
 const path = ["Entender", "Recolectar", "Transformar", "Operar", "Medir", "Devolver valor"];
-
-const solutionJourneys = [
-  {
-    number: "01",
-    kicker: "Necesito entender y decidir",
-    title: "Diagnosticar y planear",
-    copy: "Para proyectos que todavía necesitan una línea base, un instrumento de planeación o una decisión de prefactibilidad antes de invertir.",
-    services: [
-      ["Diagnóstico y caracterización", "/soluciones/diagnostico-caracterizacion"],
-      ["PGIRS", "/soluciones/pgirs"],
-      ["PMIRS", "/soluciones/pmirs"],
-      ["Prefactibilidad", "/soluciones/prefactibilidad"],
-    ],
-  },
-  {
-    number: "02",
-    kicker: "Necesito mover material separado",
-    title: "Separar y recolectar",
-    copy: "Para conectar generadores, frecuencias, microrrutas y criterios de aceptación con un destino real de aprovechamiento.",
-    services: [
-      ["Rutas selectivas", "/soluciones/rutas-selectivas"],
-      ["Motocarguero / piloto", "/soluciones/motocarguero"],
-      ["Recolección y tratamiento", "/soluciones/recoleccion-tratamiento"],
-    ],
-  },
-  {
-    number: "03",
-    kicker: "Necesito infraestructura",
-    title: "Construir o recuperar capacidad",
-    copy: "Para madurar ingeniería, construir una planta nueva o recuperar infraestructura existente antes de reemplazarla.",
-    services: [
-      ["Factibilidad e ingeniería", "/soluciones/factibilidad-ingenieria"],
-      ["Plantas nuevas", "/soluciones/plantas-nuevas"],
-      ["Rehabilitación", "/soluciones/rehabilitacion"],
-    ],
-  },
-  {
-    number: "04",
-    kicker: "Necesito que funcione y se pueda demostrar",
-    title: "Operar, controlar y medir",
-    copy: "Para convertir infraestructura y procesos en una operación disciplinada con mantenimiento, inventarios, evidencia y trazabilidad.",
-    services: [
-      ["Dirección de operación", "/soluciones/direccion-operacion"],
-      ["Operación integral", "/soluciones/operacion-integral"],
-      ["Trazabilidad y datos", "/soluciones/trazabilidad-datos"],
-    ],
-  },
-] as const;
 
 export default function SolutionsPage() {
   return (
@@ -106,15 +59,15 @@ export default function SolutionsPage() {
               <p>Los 13 servicios siguen siendo independientes y contratables por fase. Estos cuatro recorridos solo simplifican la entrada según el estado real del proyecto.</p>
             </div>
             <div className={styles.journeyGrid}>
-              {solutionJourneys.map((journey) => (
+              {serviceJourneys.map((journey) => (
                 <article className={styles.journeyCard} key={journey.number}>
                   <span className={styles.journeyNumber}>{journey.number}</span>
                   <small>{journey.kicker}</small>
                   <h3>{journey.title}</h3>
                   <p>{journey.copy}</p>
                   <div className={styles.journeyLinks}>
-                    {journey.services.map(([label, href]) => (
-                      <Link href={href} key={href}>{label} →</Link>
+                    {journey.services.map((service) => (
+                      <Link href={`/soluciones/${service.slug}`} key={service.slug}>{service.label} →</Link>
                     ))}
                   </div>
                 </article>

--- a/src/app/soluciones/solutions.module.css
+++ b/src/app/soluciones/solutions.module.css
@@ -91,6 +91,23 @@
 .pathGrid span { display: block; margin-bottom: 15px; color: #d8ed9c; font-size: 0.7rem; font-weight: 800; }
 .pathGrid strong { font-family: var(--display); font-size: 1.25rem; font-weight: 600; }
 
+.journeys { padding: 112px 0; background: var(--white); border-bottom: 1px solid var(--line); }
+.journeyGrid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
+.journeyCard {
+  min-height: 360px;
+  display: flex;
+  flex-direction: column;
+  padding: 34px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+}
+.journeyNumber { color: var(--green); font-size: 0.72rem; font-weight: 800; }
+.journeyCard > small { margin: 24px 0 10px; color: #8b7928; font-size: 0.7rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
+.journeyCard p { margin: 18px 0 24px; color: var(--muted); line-height: 1.7; }
+.journeyLinks { display: grid; margin-top: auto; border-top: 1px solid var(--line); }
+.journeyLinks a { min-height: 44px; display: flex; align-items: center; justify-content: space-between; gap: 18px; border-bottom: 1px solid var(--line); color: var(--green); font-size: 0.82rem; font-weight: 800; }
+
 .audience { padding: 112px 0; background: var(--paper); }
 .sectionHead { max-width: 930px; margin-bottom: 52px; }
 .sectionHead p { max-width: 760px; margin: 22px 0 0; color: var(--muted); font-size: 1.04rem; line-height: 1.7; }
@@ -191,7 +208,9 @@
   .pathGrid div:nth-child(3) { border-right: 1px solid var(--line-dark); }
   .pathGrid div:nth-child(even) { border-right: 0; }
   .pathGrid div:nth-child(n+3) { border-top: 1px solid var(--line-dark); }
-  .audience, .category, .detailBody { padding: 82px 0; }
+  .journeys, .audience, .category, .detailBody { padding: 82px 0; }
+  .journeyGrid { grid-template-columns: 1fr; }
+  .journeyCard { min-height: auto; padding: 28px 24px; }
   .audienceCard, .card { grid-template-columns: 42px 1fr; gap: 18px; }
   .categoryHead { grid-template-columns: 42px 1fr; gap: 18px; }
   .categoryHead > strong { grid-column: 2; }

--- a/src/data/service-journeys.test.ts
+++ b/src/data/service-journeys.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { serviceJourneys } from "./service-journeys";
+import { services } from "./services";
+
+describe("public commercial service journeys", () => {
+  it("keeps four distinct commercial entry journeys", () => {
+    expect(serviceJourneys).toHaveLength(4);
+    expect(new Set(serviceJourneys.map((journey) => journey.number)).size).toBe(4);
+    expect(new Set(serviceJourneys.map((journey) => journey.title)).size).toBe(4);
+  });
+
+  it("references only governed service slugs", () => {
+    const serviceSlugs = new Set(services.map((service) => service.slug));
+    for (const journey of serviceJourneys) {
+      for (const service of journey.services) expect(serviceSlugs.has(service.slug)).toBe(true);
+    }
+  });
+
+  it("covers every public service exactly once", () => {
+    const journeySlugs = serviceJourneys.flatMap((journey) => journey.services.map((service) => service.slug));
+    expect(journeySlugs).toHaveLength(services.length);
+    expect(new Set(journeySlugs).size).toBe(services.length);
+    expect([...journeySlugs].sort()).toEqual(services.map((service) => service.slug).sort());
+  });
+});

--- a/src/data/service-journeys.ts
+++ b/src/data/service-journeys.ts
@@ -1,0 +1,55 @@
+export type ServiceJourney = {
+  number: string;
+  kicker: string;
+  title: string;
+  copy: string;
+  services: readonly { slug: string; label: string }[];
+};
+
+export const serviceJourneys: readonly ServiceJourney[] = [
+  {
+    number: "01",
+    kicker: "Necesito entender y decidir",
+    title: "Diagnosticar y planear",
+    copy: "Para proyectos que todavía necesitan una línea base, un instrumento de planeación o una decisión de prefactibilidad antes de invertir.",
+    services: [
+      { slug: "diagnostico-caracterizacion", label: "Diagnóstico y caracterización" },
+      { slug: "pgirs", label: "PGIRS" },
+      { slug: "pmirs", label: "PMIRS" },
+      { slug: "prefactibilidad", label: "Prefactibilidad" },
+    ],
+  },
+  {
+    number: "02",
+    kicker: "Necesito mover material separado",
+    title: "Separar y recolectar",
+    copy: "Para conectar generadores, frecuencias, microrrutas y criterios de aceptación con un destino real de aprovechamiento.",
+    services: [
+      { slug: "rutas-selectivas", label: "Rutas selectivas" },
+      { slug: "motocarguero", label: "Motocarguero / piloto" },
+      { slug: "recoleccion-tratamiento", label: "Recolección y tratamiento" },
+    ],
+  },
+  {
+    number: "03",
+    kicker: "Necesito infraestructura",
+    title: "Construir o recuperar capacidad",
+    copy: "Para madurar ingeniería, construir una planta nueva o recuperar infraestructura existente antes de reemplazarla.",
+    services: [
+      { slug: "factibilidad-ingenieria", label: "Factibilidad e ingeniería" },
+      { slug: "plantas-nuevas", label: "Plantas nuevas" },
+      { slug: "rehabilitacion", label: "Rehabilitación" },
+    ],
+  },
+  {
+    number: "04",
+    kicker: "Necesito que funcione y se pueda demostrar",
+    title: "Operar, controlar y medir",
+    copy: "Para convertir infraestructura y procesos en una operación disciplinada con mantenimiento, inventarios, evidencia y trazabilidad.",
+    services: [
+      { slug: "direccion-operacion", label: "Dirección de operación" },
+      { slug: "operacion-integral", label: "Operación integral" },
+      { slug: "trazabilidad-datos", label: "Trazabilidad y datos" },
+    ],
+  },
+] as const;

--- a/src/data/service-journeys.ts
+++ b/src/data/service-journeys.ts
@@ -6,6 +6,7 @@ export type ServiceJourney = {
   services: readonly { slug: string; label: string }[];
 };
 
+// UX grouping only: the governed service registry remains the source of contractual scope.
 export const serviceJourneys: readonly ServiceJourney[] = [
   {
     number: "01",


### PR DESCRIPTION
## Objetivo
Hacer el portafolio público más comprable sin cambiar los 13 servicios ni sus alcances técnicos.

## Cambio
- añade cuatro recorridos de entrada según el estado del problema: Diagnosticar y planear; Separar y recolectar; Construir o recuperar capacidad; Operar, controlar y medir;
- cada recorrido enlaza únicamente a fichas existentes y gobernadas;
- conserva la segmentación posterior por Municipios/ESP y Empresas;
- conserva íntegramente las categorías y las 13 fichas técnicas actuales;
- gobierna los recorridos en datos y prueba que cubren exactamente los 13 servicios una sola vez;
- añade cobertura Playwright para los recorridos y sus enlaces;
- diseño responsive integrado con la página actual.

## Guardrails
- no crea servicios nuevos;
- no cambia entregables, claims ni alcance contractual;
- no decide todavía el regreso público de la marca Back2Green; esa decisión queda separada de esta mejora de UX/comercial;
- no toca OPS, Auth, Supabase, RLS ni datos operativos.

## Base
La consolidación pública V6 (#173) ya está integrada en `develop`; esta PR fue retargeteada y ahora contiene únicamente la mejora de recorridos comerciales de Soluciones.