### PR TITLE
feat(public): conectar Wondergreen con productos, guías y paleta Pages

### DIFF
--- a/e2e/wondergreen-crops.spec.ts
+++ b/e2e/wondergreen-crops.spec.ts
@@ -12,9 +12,9 @@ test("Wondergreen exposes exact liquid portfolio and technical statuses", async 
 
   const portfolio = page.locator("#portafolio");
   await expect(portfolio.getByText("2Grow Líquido · referencia nitrogenada · 200-0-0", { exact: true })).toBeVisible();
-  await expect(portfolio.getByText("Portafolio técnico · disponibilidad por confirmar", { exact: true })).toBeVisible();
+  await expect(portfolio.getByText(/Portafolio técnico · disponibilidad por confirmar/)).toBeVisible();
   await expect(portfolio.getByText("2Bloom Líquido · 30-80-30", { exact: true })).toBeVisible();
-  await expect(portfolio.getByText("Portafolio técnico · condición comercial por reconciliar", { exact: true })).toBeVisible();
+  await expect(portfolio.getByText(/Portafolio técnico · condición comercial por reconciliar/)).toBeVisible();
 });
 
 test("crop library exposes the five initial programs", async ({ page }) => {

--- a/e2e/wondergreen-editorial.spec.ts
+++ b/e2e/wondergreen-editorial.spec.ts
@@ -10,7 +10,16 @@ test("Wondergreen uses the canonical public shell without duplicate chrome", asy
   await expect(page.getByRole("link", { name: "GREENATICS OPS" })).toHaveAttribute("href", "/app");
 });
 
-test("Wondergreen editorial hub preserves governed product truth", async ({ page }) => {
+test("Wondergreen subnavigation connects products, crops and knowledge", async ({ page }) => {
+  await page.goto("/wondergreen");
+
+  const nav = page.getByRole("navigation", { name: "Navegación Wondergreen" });
+  await expect(nav.getByRole("link", { name: "Productos" })).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(nav.getByRole("link", { name: "Cultivos" })).toHaveAttribute("href", "/wondergreen/cultivos");
+  await expect(nav.getByRole("link", { name: "Guías" })).toHaveAttribute("href", "/biblioteca");
+});
+
+test("Wondergreen editorial hub preserves governed product truth and opens exact references", async ({ page }) => {
   await page.goto("/wondergreen");
 
   await expect(page.getByRole("heading", { name: "Nutrición que vuelve a la tierra." })).toBeVisible();
@@ -21,7 +30,21 @@ test("Wondergreen editorial hub preserves governed product truth", async ({ page
   await expect(portfolio.getByText("2Grow Sólido · 15-3-3", { exact: true })).toBeVisible();
   await expect(portfolio.getByText("Extracto de Neem", { exact: true })).toBeVisible();
   await expect(portfolio.getByText("Extracto Ajo–Ají", { exact: true })).toBeVisible();
+  await expect(portfolio.getByRole("link", { name: /2Grow Sólido · 15-3-3/ })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
+  await expect(portfolio.getByRole("link", { name: "Abrir catálogo completo" })).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(portfolio.getByRole("link", { name: "Abrir Biblioteca Wondergreen" })).toHaveAttribute("href", "/biblioteca");
   await expect(page.getByText(/únicamente desde la versión técnica vigente/i)).toBeVisible();
+});
+
+test("Wondergreen finder follows diagnosis to follow-up without automatic prescription", async ({ page }) => {
+  await page.goto("/wondergreen");
+
+  const finder = page.locator("#finder");
+  await expect(finder.getByRole("heading", { name: "Del contexto al seguimiento." })).toBeVisible();
+  await expect(finder.getByText("Diagnóstico y análisis", { exact: true })).toBeVisible();
+  await expect(finder.getByText("Seguimiento y ajuste", { exact: true })).toBeVisible();
+  await expect(finder.getByText(/no una prescripción automática/i)).toBeVisible();
+  await expect(finder.getByRole("link", { name: "Consultar guías" })).toHaveAttribute("href", "/biblioteca");
 });
 
 test("Wondergreen commercial routes end in real public destinations", async ({ page }) => {

--- a/src/app/wondergreen/page.tsx
+++ b/src/app/wondergreen/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { bioinputReferences, compostReferences, liquidFertilizers, solidFertilizers } from "@/data/wondergreen-public";
 import { wondergreenCrops } from "@/data/wondergreen-crops";
+import refresh from "./wondergreen-refresh.module.css";
 import styles from "./wondergreen.module.css";
 
 export const metadata: Metadata = {
@@ -15,7 +16,7 @@ export const metadata: Metadata = {
 const entryPaths = [
   ["01", "Tengo un cultivo", "Empieza por especie, etapa y objetivo antes de elegir producto.", "/wondergreen/cultivos"],
   ["02", "Tengo una necesidad", "Nutrición, suelo, floración, producción, raíz, plagas o enfermedades.", "#finder"],
-  ["03", "Sé qué producto busco", "Entra al mapa del portafolio por familia y formato.", "#portafolio"],
+  ["03", "Sé qué producto busco", "Entra al Product Master público y revisa familia, formato y condición comercial.", "/wondergreen/productos"],
 ];
 
 const system = [
@@ -35,11 +36,11 @@ const tech = [
 ];
 
 const finderSteps = [
-  ["01", "Selecciona cultivo", "Café, cacao, aguacate, cítricos, pastos y más."],
-  ["02", "Ubica la etapa", "Establecimiento, crecimiento, floración, producción o recuperación."],
-  ["03", "Define la necesidad", "Nutrición, suelo, raíz, plaga, enfermedad o estrés."],
-  ["04", "Completa el contexto", "Análisis de suelo/foliar, manejo previo y condición del lote."],
-  ["05", "Recibe una ruta", "Fertilizante, bioinsumo, protocolo o asesoría potencialmente relevante."],
+  ["01", "Cultivo y contexto", "Especie, etapa, objetivo, historial, suelo, agua y condición actual del lote."],
+  ["02", "Diagnóstico y análisis", "Síntomas, antecedentes y análisis disponibles antes de seleccionar una referencia."],
+  ["03", "Programa técnico", "Se organiza una ruta potencial por etapa, necesidad y condición del cultivo."],
+  ["04", "Implementación", "Producto, formato, vía y momento deben seguir la ficha y recomendación vigentes."],
+  ["05", "Seguimiento y ajuste", "La respuesta del cultivo y los nuevos datos permiten revisar la ruta técnica."],
 ];
 
 const bioFamilies = [
@@ -56,15 +57,16 @@ const audiences = [
 
 export default function WondergreenPage() {
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} ${refresh.page}`}>
       <nav className={styles.subnav} aria-label="Navegación Wondergreen">
         <div className={styles.container}>
           <span>Wondergreen</span>
           <div>
-            <a href="#portafolio">Portafolio</a>
+            <Link href="/wondergreen/productos">Productos</Link>
+            <Link href="/wondergreen/cultivos">Cultivos</Link>
             <a href="#tecnologia">Tecnología</a>
             <a href="#bioinsumos">Bioinsumos</a>
-            <Link href="/wondergreen/cultivos">Cultivos</Link>
+            <Link href="/biblioteca">Guías</Link>
           </div>
         </div>
       </nav>
@@ -90,7 +92,7 @@ export default function WondergreenPage() {
               </p>
               <div className={styles.buttonRow}>
                 <a className={`${styles.button} ${styles.primary}`} href="#finder">Encontrar mi solución</a>
-                <a className={`${styles.button} ${styles.ghost}`} href="#portafolio">Ver portafolio</a>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/wondergreen/productos">Ver productos</Link>
               </div>
             </div>
 
@@ -163,9 +165,9 @@ export default function WondergreenPage() {
                 </div>
               </div>
               <div className={styles.productTable}>
-                {compostReferences.map((item) => <div className={styles.productRow} key={item.slug}><strong>{item.name}</strong><small>{item.publicStatus}</small></div>)}
-                {solidFertilizers.map((item) => <div className={styles.productRow} key={item.slug}><strong>{item.name} · {item.formula}</strong><small>{item.publicStatus}</small></div>)}
-                {liquidFertilizers.map((item) => <div className={styles.productRow} key={item.slug}><strong>{item.name} · {item.formula}</strong><small>{item.publicStatus}</small></div>)}
+                {compostReferences.map((item) => <Link className={styles.productRow} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
+                {solidFertilizers.map((item) => <Link className={styles.productRow} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name} · {item.formula}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
+                {liquidFertilizers.map((item) => <Link className={styles.productRow} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name} · {item.formula}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
               </div>
             </div>
 
@@ -176,8 +178,13 @@ export default function WondergreenPage() {
                 <p>Microorganismos, inoculantes y extractos botánicos se seleccionan según cultivo, problema, contexto técnico y estado regulatorio/comercial.</p>
               </div>
               <div className={styles.productTable}>
-                {bioinputReferences.map((item) => <div className={styles.productRow} key={item.slug}><strong>{item.name}</strong><small>{item.publicStatus}</small></div>)}
+                {bioinputReferences.map((item) => <Link className={styles.productRow} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
               </div>
+            </div>
+
+            <div className={styles.buttonRow}>
+              <Link className={`${styles.button} ${styles.light}`} href="/wondergreen/productos">Abrir catálogo completo</Link>
+              <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/biblioteca">Abrir Biblioteca Wondergreen</Link>
             </div>
           </div>
         </section>
@@ -218,9 +225,12 @@ export default function WondergreenPage() {
           <div className={`${styles.container} ${styles.finderGrid}`}>
             <div className={styles.finderIntro}>
               <span className={`${styles.eyebrow} ${styles.lightEyebrow}`}>Wondergreen Finder</span>
-              <h2>Cultivo + etapa + necesidad + problema.</h2>
-              <p>El resultado será una orientación técnica, no una prescripción automática. Cuando falte información, el sistema debe pedir análisis o derivar a un asesor.</p>
-              <Link className={`${styles.button} ${styles.light}`} href="/wondergreen/cultivos">Empezar por cultivo</Link>
+              <h2>Del contexto al seguimiento.</h2>
+              <p>La ruta es una orientación técnica, no una prescripción automática. Cuando falte información, el sistema debe pedir análisis o derivar a un asesor antes de cerrar una recomendación.</p>
+              <div className={styles.buttonRow}>
+                <Link className={`${styles.button} ${styles.light}`} href="/wondergreen/cultivos">Empezar por cultivo</Link>
+                <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/biblioteca">Consultar guías</Link>
+              </div>
             </div>
             <div className={styles.finderSteps}>
               {finderSteps.map(([number, title, copy]) => (
@@ -246,7 +256,10 @@ export default function WondergreenPage() {
                 </article>
               ))}
             </div>
-            <div className={styles.buttonRow}><Link className={`${styles.button} ${styles.ghost}`} href="/wondergreen/cultivos">Ver biblioteca por cultivo</Link></div>
+            <div className={styles.buttonRow}>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/wondergreen/cultivos">Ver cultivos</Link>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/biblioteca">Explorar Biblioteca</Link>
+            </div>
           </div>
         </section>
 

--- a/src/app/wondergreen/page.tsx
+++ b/src/app/wondergreen/page.tsx
@@ -3,8 +3,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { bioinputReferences, compostReferences, liquidFertilizers, solidFertilizers } from "@/data/wondergreen-public";
 import { wondergreenCrops } from "@/data/wondergreen-crops";
-import refresh from "./wondergreen-refresh.module.css";
 import styles from "./wondergreen.module.css";
+import refresh from "./wondergreen-refresh.module.css";
 
 export const metadata: Metadata = {
   title: "Wondergreen | Suelo, nutrición y biología",
@@ -165,9 +165,9 @@ export default function WondergreenPage() {
                 </div>
               </div>
               <div className={styles.productTable}>
-                {compostReferences.map((item) => <Link className={styles.productRow} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
-                {solidFertilizers.map((item) => <Link className={styles.productRow} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name} · {item.formula}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
-                {liquidFertilizers.map((item) => <Link className={styles.productRow} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name} · {item.formula}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
+                {compostReferences.map((item) => <Link className={`${styles.productRow} ${refresh.productRow}`} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
+                {solidFertilizers.map((item) => <Link className={`${styles.productRow} ${refresh.productRow}`} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name} · {item.formula}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
+                {liquidFertilizers.map((item) => <Link className={`${styles.productRow} ${refresh.productRow}`} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name} · {item.formula}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
               </div>
             </div>
 
@@ -178,13 +178,13 @@ export default function WondergreenPage() {
                 <p>Microorganismos, inoculantes y extractos botánicos se seleccionan según cultivo, problema, contexto técnico y estado regulatorio/comercial.</p>
               </div>
               <div className={styles.productTable}>
-                {bioinputReferences.map((item) => <Link className={styles.productRow} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
+                {bioinputReferences.map((item) => <Link className={`${styles.productRow} ${refresh.productRow}`} href={`/wondergreen/productos/${item.slug}`} key={item.slug}><strong>{item.name}</strong><small>{item.publicStatus} · Ver ficha →</small></Link>)}
               </div>
             </div>
 
             <div className={styles.buttonRow}>
               <Link className={`${styles.button} ${styles.light}`} href="/wondergreen/productos">Abrir catálogo completo</Link>
-              <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/biblioteca">Abrir Biblioteca Wondergreen</Link>
+              <Link className={`${styles.button} ${refresh.outlineLight}`} href="/biblioteca">Abrir Biblioteca Wondergreen</Link>
             </div>
           </div>
         </section>
@@ -229,7 +229,7 @@ export default function WondergreenPage() {
               <p>La ruta es una orientación técnica, no una prescripción automática. Cuando falte información, el sistema debe pedir análisis o derivar a un asesor antes de cerrar una recomendación.</p>
               <div className={styles.buttonRow}>
                 <Link className={`${styles.button} ${styles.light}`} href="/wondergreen/cultivos">Empezar por cultivo</Link>
-                <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/biblioteca">Consultar guías</Link>
+                <Link className={`${styles.button} ${refresh.outlineLight}`} href="/biblioteca">Consultar guías</Link>
               </div>
             </div>
             <div className={styles.finderSteps}>

--- a/src/app/wondergreen/wondergreen-refresh.module.css
+++ b/src/app/wondergreen/wondergreen-refresh.module.css
@@ -1,0 +1,28 @@
+.page {
+  --forest: #14352c;
+  --forest-deep: #0d2b24;
+  --green: #008b4c;
+  --green-soft: #48a942;
+  --lime: #98cf4f;
+  --sun: #f4d944;
+  --paper: #f7f8f3;
+  --cream: #edf4e9;
+}
+
+.outlineLight {
+  border-color: rgba(255, 255, 255, 0.5) !important;
+  color: #ffffff !important;
+}
+
+.productRow {
+  transition: background-color 160ms ease, padding-left 160ms ease;
+}
+
+.productRow:hover {
+  padding-left: 10px;
+  background: rgba(152, 207, 79, 0.08);
+}
+
+.productRow:focus-visible {
+  background: rgba(244, 217, 68, 0.08);
+}

--- a/src/app/wondergreen/wondergreen-refresh.module.css
+++ b/src/app/wondergreen/wondergreen-refresh.module.css
@@ -27,3 +27,9 @@
 .productRow:focus-visible {
   background: rgba(244, 217, 68, 0.08);
 }
+
+@media (min-width: 761px) and (max-width: 1180px) {
+  .page nav[aria-label="Navegación Wondergreen"] {
+    top: 121px;
+  }
+}

--- a/src/app/wondergreen/wondergreen-refresh.module.css
+++ b/src/app/wondergreen/wondergreen-refresh.module.css
@@ -1,12 +1,13 @@
 .page {
-  --forest: #14352c;
-  --forest-deep: #0d2b24;
-  --green: #008b4c;
-  --green-soft: #48a942;
-  --lime: #98cf4f;
+  --forest: #063d2c;
+  --forest-deep: #043022;
+  --green: #2f7d32;
+  --green-soft: #5d9c3a;
+  --lime: #7db43c;
   --sun: #f4d944;
-  --paper: #f7f8f3;
-  --cream: #edf4e9;
+  --paper: #f7faf8;
+  --cream: #eaf4e4;
+  --ink: #42584e;
 }
 
 .outlineLight {
@@ -20,7 +21,7 @@
 
 .productRow:hover {
   padding-left: 10px;
-  background: rgba(152, 207, 79, 0.08);
+  background: rgba(125, 180, 60, 0.1);
 }
 
 .productRow:focus-visible {


### PR DESCRIPTION
## Objetivo
Aprovechar lo mejor de la referencia visual/comercial de GitHub Pages y del material comercial vigente sin degradar la arquitectura pública actual ni cambiar Product Truth.

## Cambios
- la subnavegación Wondergreen conecta Productos, Cultivos, Tecnología, Bioinsumos y Guías;
- el CTA de producto lleva al Product Master público;
- cada referencia listada en el resumen de portafolio abre su ficha exacta;
- se añaden accesos explícitos al catálogo completo y a la Biblioteca Wondergreen;
- el Finder se reordena como contexto → diagnóstico/análisis → programa técnico → implementación → seguimiento/ajuste, coherente con el proceso de acompañamiento del catálogo comercial;
- la capa visual toma de GitHub Pages su contraste y energía, pero reconcilia la paleta con el ADN corporativo V9: verde profundo #063D2C, verde principal #2F7D32, verde acento #7DB43C, verde pálido #EAF4E4 y fondo #F7FAF8; el amarillo #F4D944 queda como microacento;
- se añaden pruebas Playwright para navegación, fichas y guardrails de orientación técnica.

## Fuentes revisadas
- GitHub Pages actual, reconstruida desde `main` y su workflow de Pages;
- catálogo corporativo `CATALOO GREENATICS 27 ABR 26.pdf`;
- carpeta SharePoint `Material Comercial`, incluyendo catálogo Wondergreen optimizado, guías por cultivo, catálogo de Plátano y Huertas Urbanas;
- `GREENATICS_MKTG_STUDIO_SKILL_V9.zip`, en particular Asset Authority Registry, Packaging System y ADN visual corporativo.

## Guardrails
- no cambia fórmulas, dosis, precios, disponibilidad ni claims del Product Master;
- no publica URLs privadas de SharePoint;
- no activa todavía Casa y Jardín;
- no toca OPS, Auth, Supabase, RLS, migraciones ni workflows;
- no recorta láminas de packaging para fingir packshots: los activos V9 se respetan según su autoridad;
- la nueva paleta se implementa como capa separada y reversible.