### PR TITLE
ci: estabilizar Playwright y gate piloto determinista

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -92,8 +92,8 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-chromium-1.62.0
       - name: Install Chromium
-        timeout-minutes: 8
-        run: npx playwright install --with-deps chromium
+        timeout-minutes: 4
+        run: npx playwright install chromium
       - name: Browser gates
         timeout-minutes: 8
         run: npx playwright test --project=${{ matrix.project }}

--- a/e2e/pilot-day-cycle.spec.ts
+++ b/e2e/pilot-day-cycle.spec.ts
@@ -29,6 +29,9 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   await expect(page).toHaveURL(/\/receptions$/);
   const reception = page.locator("article").filter({ hasText: "PILOTO Integrado" });
   await expect(reception).toContainText("TAM-FORSU-");
+  const receptionText = await reception.textContent();
+  const lotCode = receptionText?.match(/TAM-FORSU-[A-Z0-9-]+/)?.[0];
+  expect(lotCode).toBeTruthy();
 
   await page.goto("/app");
   await expect(page.getByLabel("Indicadores de hoy").locator(".metric-block").filter({ hasText: "Recibido" })).toContainText("1.50 t");
@@ -54,12 +57,14 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   await page.getByRole("button", { name: "Cerrar reparación" }).click();
   await expect(page.getByText("Disponible", { exact: true }).first()).toBeVisible();
 
-  // 5) The measured reception is physically assigned to a compost pile and closed.
+  // 5) The exact lot created by the measured reception is assigned to the compost pile and closed.
   await page.goto("/compost/new");
   await page.getByLabel("Ubicación").fill("Zona piloto integrada");
   const sourceGroup = page.getByRole("group", { name: "Lotes físicos y masa asignada" });
-  await sourceGroup.getByRole("checkbox").first().check();
-  await page.getByLabel("Asignar (kg)").fill("1500");
+  const sourceRow = sourceGroup.locator("div").filter({ has: page.getByText(lotCode!, { exact: true }) }).first();
+  await expect(sourceRow).toContainText(lotCode!);
+  await sourceRow.getByRole("checkbox").check();
+  await sourceRow.getByLabel("Asignar (kg)").fill("1500");
   await page.getByLabel("Volumen conformado (m³)").fill("8");
   await page.getByRole("group", { name: "Trabajadores de conformación" }).getByRole("checkbox").first().check();
   await page.getByRole("button", { name: "Conformar pila" }).click();

--- a/e2e/pilot-day-cycle.spec.ts
+++ b/e2e/pilot-day-cycle.spec.ts
@@ -30,12 +30,8 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   const reception = page.locator("article").filter({ hasText: "PILOTO Integrado" });
   await expect(reception).toContainText("TAM-FORSU-");
   const receptionText = await reception.textContent();
-  const lotCode = receptionText?.match(/TAM-FORSU-[A-Z0-9-]+/)?.[0];
+  const lotCode = receptionText?.match(/TAM-FORSU-\d{6}-\d{3}/)?.[0];
   expect(lotCode).toBeTruthy();
-  await expect.poll(async () => page.evaluate(({ key, code }) => window.localStorage.getItem(key)?.includes(code) ?? false, {
-    key: "greenatics-ops-mvp-001",
-    code: lotCode!,
-  })).toBe(true);
 
   await page.goto("/app");
   await expect(page.getByLabel("Indicadores de hoy").locator(".metric-block").filter({ hasText: "Recibido" })).toContainText("1.50 t");

--- a/e2e/pilot-day-cycle.spec.ts
+++ b/e2e/pilot-day-cycle.spec.ts
@@ -57,8 +57,9 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   await page.getByRole("button", { name: "Cerrar reparación" }).click();
   await expect(page.getByText("Disponible", { exact: true }).first()).toBeVisible();
 
-  // 5) The exact lot created by the measured reception is assigned to the compost pile and closed.
+  // 5) The exact Tamesis lot created by the measured reception is assigned to the compost pile and closed.
   await page.goto("/compost/new");
+  await page.getByLabel("Planta").selectOption("tamesis");
   await page.getByLabel("Ubicación").fill("Zona piloto integrada");
   const sourceGroup = page.getByRole("group", { name: "Lotes físicos y masa asignada" });
   const sourceRow = sourceGroup.locator("div").filter({ has: page.getByText(lotCode!, { exact: true }) }).first();

--- a/e2e/pilot-day-cycle.spec.ts
+++ b/e2e/pilot-day-cycle.spec.ts
@@ -32,6 +32,10 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   const receptionText = await reception.textContent();
   const lotCode = receptionText?.match(/TAM-FORSU-[A-Z0-9-]+/)?.[0];
   expect(lotCode).toBeTruthy();
+  await expect.poll(async () => page.evaluate(({ key, code }) => window.localStorage.getItem(key)?.includes(code) ?? false, {
+    key: "greenatics-ops-mvp-001",
+    code: lotCode!,
+  })).toBe(true);
 
   await page.goto("/app");
   await expect(page.getByLabel("Indicadores de hoy").locator(".metric-block").filter({ hasText: "Recibido" })).toContainText("1.50 t");

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -18,7 +18,7 @@ const nav = [["Hoy", "/app"], ["Calendario", "/calendar"], ["Recepciones", "/rec
 
 export function AppShell({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const { backend, access, identity, signOut } = useOpsStore();
+  const { backend, access, identity, ready: opsReady, signOut } = useOpsStore();
   const maintenance = useMaintenanceStore();
   const compost = useCompostStore();
   const inventory = useInventoryStore();
@@ -41,12 +41,13 @@ export function AppShell({ children }: { children: ReactNode }) {
   ];
   const modulesReady = remoteModules.every((module) => module.ready);
   const moduleErrors = remoteModules.filter((module) => module.error);
+  const localLoading = backend.mode === "local" && (!opsReady || !modulesReady);
   const remoteLoading = backend.mode === "supabase" && (backend.status === "booting" || (backend.status === "ready" && !modulesReady));
   const remoteError = backend.mode === "supabase" && (backend.status === "error" || moduleErrors.length > 0);
   const canManageUsers = backend.mode === "supabase" && access.some((plant) => plant.role === "admin" || plant.role === "director");
   const canManageOperations = backend.mode === "supabase" && access.some((plant) => canManageOperationalMasters(plant.role));
   const sourceLabel = backend.mode === "local"
-    ? "Modo local · este navegador"
+    ? localLoading ? "Modo local · preparando navegador" : "Modo local · este navegador"
     : remoteLoading
       ? "Supabase · sincronizando módulos"
       : remoteError
@@ -62,8 +63,9 @@ export function AppShell({ children }: { children: ReactNode }) {
   };
 
   return <div className="app-shell"><aside className="sidebar" aria-label="Navegación principal"><div className="brand-block"><div className="brand-mark" aria-hidden="true">G</div><div><strong>GREENATICS</strong><span>OPS</span></div></div><nav className="side-nav">{nav.map(([label, href]) => <Link key={label} href={href}>{label}</Link>)}{canManageOperations ? <Link href="/admin/operations">Maestros operacionales</Link> : null}{canManageUsers ? <Link href="/admin/users">Usuarios y accesos</Link> : null}</nav><div className="sidebar-foot" title={backend.error}><div><span className={`status-dot ${backend.status === "ready" && modulesReady && !remoteError ? "status-ok" : ""}`} /> {sourceLabel}</div>{backend.mode === "supabase" && identity ? <div className="mt-2"><strong className="block text-[11px]">{identity.displayName}</strong><button className="mt-1 text-[11px] underline" type="button" disabled={signingOut} onClick={closeSession}>{signingOut ? "Cerrando…" : "Cerrar sesión"}</button></div> : null}{backend.mode === "supabase" && backend.status === "error" ? <Link className="mt-2 block text-[11px] underline" href="/login">Ir a acceso</Link> : null}</div></aside><main className="main-area">
+    {localLoading ? <section className="panel mx-auto max-w-3xl" aria-live="polite"><p className="eyebrow">Fuente local</p><h1 className="text-2xl">Preparando operación local</h1><p className="lede">Cargando el estado guardado de operación, mantenimiento, compostaje, inventarios y movimientos antes de habilitar nuevas escrituras.</p></section> : null}
     {backend.mode === "supabase" && remoteLoading ? <section className="panel mx-auto max-w-3xl" aria-live="polite"><p className="eyebrow">Fuente remota</p><h1 className="text-2xl">Sincronizando operación</h1><p className="lede">Cargando plantas, operación, mantenimiento, producción, inventarios, ventas y movimientos económicos. Los indicadores aparecerán cuando el snapshot esté completo.</p></section> : null}
     {backend.mode === "supabase" && remoteError ? <section className="panel mx-auto max-w-3xl" role="alert"><p className="eyebrow">Fuente remota</p><h1 className="text-2xl">No fue posible completar el snapshot</h1><p className="lede">No se muestran datos parciales como si fueran el estado real de la operación.</p>{backend.error ? <p className="mt-4 rounded-xl bg-[var(--red-soft)] p-4 text-sm font-semibold text-[var(--red)]">Operación: {backend.error}</p> : null}{moduleErrors.length ? <div className="mt-4 grid gap-2">{moduleErrors.map((module) => <p className="rounded-xl bg-[var(--red-soft)] p-3 text-sm text-[var(--red)]" key={module.name}><strong>{module.name}:</strong> {module.error}</p>)}</div> : null}<button className="button secondary mt-5" type="button" onClick={() => window.location.reload()}>Reintentar sincronización</button></section> : null}
-    {backend.mode !== "supabase" || (!remoteLoading && !remoteError) ? children : null}
+    {backend.mode === "local" ? (!localLoading ? children : null) : (!remoteLoading && !remoteError ? children : null)}
   </main></div>;
 }

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -18,7 +18,7 @@ const nav = [["Hoy", "/app"], ["Calendario", "/calendar"], ["Recepciones", "/rec
 
 export function AppShell({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const { backend, access, identity, ready: opsReady, signOut } = useOpsStore();
+  const { backend, access, identity, signOut } = useOpsStore();
   const maintenance = useMaintenanceStore();
   const compost = useCompostStore();
   const inventory = useInventoryStore();
@@ -41,13 +41,12 @@ export function AppShell({ children }: { children: ReactNode }) {
   ];
   const modulesReady = remoteModules.every((module) => module.ready);
   const moduleErrors = remoteModules.filter((module) => module.error);
-  const localLoading = backend.mode === "local" && (!opsReady || !modulesReady);
   const remoteLoading = backend.mode === "supabase" && (backend.status === "booting" || (backend.status === "ready" && !modulesReady));
   const remoteError = backend.mode === "supabase" && (backend.status === "error" || moduleErrors.length > 0);
   const canManageUsers = backend.mode === "supabase" && access.some((plant) => plant.role === "admin" || plant.role === "director");
   const canManageOperations = backend.mode === "supabase" && access.some((plant) => canManageOperationalMasters(plant.role));
   const sourceLabel = backend.mode === "local"
-    ? localLoading ? "Modo local · preparando navegador" : "Modo local · este navegador"
+    ? "Modo local · este navegador"
     : remoteLoading
       ? "Supabase · sincronizando módulos"
       : remoteError
@@ -63,9 +62,8 @@ export function AppShell({ children }: { children: ReactNode }) {
   };
 
   return <div className="app-shell"><aside className="sidebar" aria-label="Navegación principal"><div className="brand-block"><div className="brand-mark" aria-hidden="true">G</div><div><strong>GREENATICS</strong><span>OPS</span></div></div><nav className="side-nav">{nav.map(([label, href]) => <Link key={label} href={href}>{label}</Link>)}{canManageOperations ? <Link href="/admin/operations">Maestros operacionales</Link> : null}{canManageUsers ? <Link href="/admin/users">Usuarios y accesos</Link> : null}</nav><div className="sidebar-foot" title={backend.error}><div><span className={`status-dot ${backend.status === "ready" && modulesReady && !remoteError ? "status-ok" : ""}`} /> {sourceLabel}</div>{backend.mode === "supabase" && identity ? <div className="mt-2"><strong className="block text-[11px]">{identity.displayName}</strong><button className="mt-1 text-[11px] underline" type="button" disabled={signingOut} onClick={closeSession}>{signingOut ? "Cerrando…" : "Cerrar sesión"}</button></div> : null}{backend.mode === "supabase" && backend.status === "error" ? <Link className="mt-2 block text-[11px] underline" href="/login">Ir a acceso</Link> : null}</div></aside><main className="main-area">
-    {localLoading ? <section className="panel mx-auto max-w-3xl" aria-live="polite"><p className="eyebrow">Fuente local</p><h1 className="text-2xl">Preparando operación local</h1><p className="lede">Cargando el estado guardado de operación, mantenimiento, compostaje, inventarios y movimientos antes de habilitar nuevas escrituras.</p></section> : null}
     {backend.mode === "supabase" && remoteLoading ? <section className="panel mx-auto max-w-3xl" aria-live="polite"><p className="eyebrow">Fuente remota</p><h1 className="text-2xl">Sincronizando operación</h1><p className="lede">Cargando plantas, operación, mantenimiento, producción, inventarios, ventas y movimientos económicos. Los indicadores aparecerán cuando el snapshot esté completo.</p></section> : null}
     {backend.mode === "supabase" && remoteError ? <section className="panel mx-auto max-w-3xl" role="alert"><p className="eyebrow">Fuente remota</p><h1 className="text-2xl">No fue posible completar el snapshot</h1><p className="lede">No se muestran datos parciales como si fueran el estado real de la operación.</p>{backend.error ? <p className="mt-4 rounded-xl bg-[var(--red-soft)] p-4 text-sm font-semibold text-[var(--red)]">Operación: {backend.error}</p> : null}{moduleErrors.length ? <div className="mt-4 grid gap-2">{moduleErrors.map((module) => <p className="rounded-xl bg-[var(--red-soft)] p-3 text-sm text-[var(--red)]" key={module.name}><strong>{module.name}:</strong> {module.error}</p>)}</div> : null}<button className="button secondary mt-5" type="button" onClick={() => window.location.reload()}>Reintentar sincronización</button></section> : null}
-    {backend.mode === "local" ? (!localLoading ? children : null) : (!remoteLoading && !remoteError ? children : null)}
+    {backend.mode !== "supabase" || (!remoteLoading && !remoteError) ? children : null}
   </main></div>;
 }


### PR DESCRIPTION
## Problema
Los gates browser tenían dos fuentes independientes de inestabilidad:

1. `npx playwright install --with-deps chromium` dependía del mirror APT de Ubuntu y podía agotar el runner antes de ejecutar Playwright.
2. `pilot-day-cycle.spec.ts` no fijaba con precisión el lote físico de la recepción piloto: seleccionaba el primer lote disponible y, al intentar reconciliarlo, usaba un regex demasiado amplio que capturaba también la primera letra del texto siguiente (`...-001A` en vez de `...-001`).

## Cambios
- conserva la cache de Chromium;
- cambia `playwright install --with-deps chromium` por `playwright install chromium`;
- reduce el timeout de instalación de 8 a 4 minutos;
- el gate piloto extrae el código exacto con el contrato `TAM-FORSU-YYMMDD-NNN`;
- selecciona explícitamente Támesis;
- localiza la fila del lote exacto y usa su checkbox/input de asignación;
- mantiene intactas las aserciones finales: Recibido 1.50 t, Procesado 1.50 t, producción 300 kg, stock 300 kg y trazabilidad del timeline.

## Criterio de aceptación
Solo se integra si quality, database, desktop-chromium y mobile-chromium quedan verdes ejecutando la suite completa con Chromium instalado sin APT.

## Alcance
Solo `.github/workflows/quality.yml` y `e2e/pilot-day-cycle.spec.ts`. Sin cambios en comportamiento de la aplicación pública u OPS, Supabase, RLS, migraciones, Product Truth o contenido.