### PR TITLE
style(wondergreen): llevar identidad V9 al Product Master

### DIFF
--- a/e2e/wondergreen-products.spec.ts
+++ b/e2e/wondergreen-products.spec.ts
@@ -8,6 +8,12 @@ test("Wondergreen product catalog exposes governed references", async ({ page })
   await expect(page.getByRole("link", { name: /Extracto de Neem/ }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: "Buscar por cultivo →" }).first()).toHaveAttribute("href", "/wondergreen/cultivos");
   await expect(page.getByText("17 referencias", { exact: true })).toBeVisible();
+
+  await expect(page.getByRole("link", { name: /2Grow Sólido/ }).first()).toHaveAttribute("data-tone", "grow");
+  await expect(page.getByRole("link", { name: /2Balance Sólido/ }).first()).toHaveAttribute("data-tone", "balance");
+  await expect(page.getByRole("link", { name: /2Bloom Sólido/ }).first()).toHaveAttribute("data-tone", "bloom");
+  await expect(page.getByRole("link", { name: /2Fruit Sólido/ }).first()).toHaveAttribute("data-tone", "fruit");
+  await expect(page.getByRole("link", { name: /Extracto de Neem/ }).first()).toHaveAttribute("data-tone", "botanical");
 });
 
 test("catalog browser filters by search, commercial truth and format without changing Product Master", async ({ page }) => {
@@ -32,6 +38,7 @@ test("catalog browser filters by search, commercial truth and format without cha
 test("commercial product page shows reconciled state without inventing a packshot", async ({ page }) => {
   await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
 
+  await expect(page.locator('div[data-tone="grow"]').first()).toBeVisible();
   await expect(page.getByRole("heading", { name: /2Grow Sólido/ })).toBeVisible();
   await expect(page.getByText("Referencia comercial reconciliada").first()).toBeVisible();
   await expect(page.getByText("Reconciliada", { exact: true })).toBeVisible();
@@ -62,6 +69,7 @@ test("unknown product context is ignored instead of fabricating a reference", as
 test("technical bioinput page does not pretend to be commercially available", async ({ page }) => {
   await page.goto("/wondergreen/productos/extracto-neem");
 
+  await expect(page.locator('div[data-tone="botanical"]').first()).toBeVisible();
   await expect(page.getByRole("heading", { name: /Extracto de Neem/ })).toBeVisible();
   await expect(page.getByText(/Portafolio técnico · ficha\/registro por reconciliar/).first()).toBeVisible();
   await expect(page.getByText("Requiere confirmación", { exact: true })).toBeVisible();

--- a/src/app/wondergreen/productos/[slug]/page.tsx
+++ b/src/app/wondergreen/productos/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getWondergreenReference, wondergreenReferences } from "@/data/wondergreen-public";
 import { wondergreenCrops } from "@/data/wondergreen-crops";
+import { getWondergreenVisualTone } from "@/data/wondergreen-visual";
 import styles from "./product.module.css";
 
 export function generateStaticParams() {
@@ -48,9 +49,10 @@ export default async function WondergreenProductPage({ params }: { params: Promi
   const crops = relatedCrops(reference.family);
   const isCommercial = reference.truthStatus === "commercial-reconciled";
   const contactHref = `/contacto?producto=${encodeURIComponent(reference.slug)}#wondergreen`;
+  const visualTone = getWondergreenVisualTone(reference);
 
   return (
-    <div className={styles.page}>
+    <div className={styles.page} data-tone={visualTone}>
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>

--- a/src/app/wondergreen/productos/[slug]/product.module.css
+++ b/src/app/wondergreen/productos/[slug]/product.module.css
@@ -1,1 +1,137 @@
-.page{--forest:#12372c;--forestDeep:#0b241c;--green:#0a7a4b;--lime:#b8d65f;--sun:#ddc952;--ink:#18241f;--muted:#69736d;--paper:#fbfaf5;--cream:#f0ede3;--line:rgba(24,36,31,.16);--display:"Iowan Old Style","Palatino Linotype","Book Antiqua",Palatino,Georgia,serif;color:var(--ink);background:var(--paper);font-family:"Helvetica Neue",Helvetica,Arial,sans-serif}.page *{box-sizing:border-box}.page a{color:inherit;text-decoration:none}.page a:focus-visible{outline:3px solid var(--sun);outline-offset:4px}.container{width:min(1240px,calc(100% - 48px));margin:0 auto}.eyebrow{display:inline-block;color:var(--green);font-size:.69rem;font-weight:850;text-transform:uppercase;letter-spacing:.13em;margin-bottom:15px}.page h1,.page h2,.page h3{font-family:var(--display);font-weight:600;letter-spacing:-.035em;margin:0;line-height:.98}.page h1{font-size:clamp(3.6rem,7vw,7.2rem);max-width:10ch}.page h1 em{display:block;color:var(--green);font-style:normal;font-size:.62em;margin-top:12px}.page h2{font-size:clamp(2.4rem,4.6vw,4.6rem);max-width:17ch}.page h3{font-size:1.55rem;line-height:1.06}.hero{padding:72px 0 96px;background:var(--cream);border-bottom:1px solid var(--line)}.heroGrid{display:grid;grid-template-columns:1.1fr .72fr;gap:68px;align-items:end}.back{display:block;margin-bottom:58px;color:var(--muted);font-weight:750;font-size:.83rem}.lead{max-width:760px;color:#526058;font-size:1.16rem;line-height:1.7;margin:26px 0}.heroMeta{display:flex;flex-wrap:wrap;gap:8px;margin:24px 0 30px}.heroMeta span{padding:8px 11px;border:1px solid var(--line);font-size:.76rem;font-weight:800;background:rgba(255,255,255,.44)}.actions{display:flex;flex-wrap:wrap;gap:10px}.button{display:inline-flex;min-height:46px;align-items:center;justify-content:center;padding:0 18px;border-radius:4px;border:1px solid var(--forestDeep);font-weight:850}.primary{background:var(--forestDeep);color:#fff!important}.ghost{background:transparent}.identityPlate{min-height:470px;padding:30px;background:var(--forestDeep);color:#fff;display:flex;flex-direction:column;justify-content:space-between;position:relative;overflow:hidden}.identityPlate:after{content:"";position:absolute;width:260px;height:260px;border:64px solid rgba(184,214,95,.12);border-radius:50%;right:-100px;bottom:-100px}.plateTop{display:flex;justify-content:space-between;gap:20px;border-bottom:1px solid rgba(255,255,255,.18);padding-bottom:18px;position:relative;z-index:1}.plateTop span{text-transform:uppercase;letter-spacing:.12em;font-size:.65rem;font-weight:850}.plateTop small{max-width:190px;text-align:right;color:#d5e0da}.familyMark{position:relative;z-index:1;color:var(--lime);font-family:var(--display);font-size:clamp(3.4rem,6vw,5.8rem);line-height:.9;letter-spacing:-.05em}.formula{position:relative;z-index:1;font-size:1.45rem}.identityPlate p{position:relative;z-index:1;max-width:370px;color:#bdcbc4;line-height:1.6;font-size:.84rem}.section{padding:92px 0}.white{background:#fff}.sectionHeading{max-width:820px;margin-bottom:38px}.sectionHeading p{color:var(--muted);line-height:1.65}.truthGrid{display:grid;grid-template-columns:.8fr 1.2fr;gap:70px;align-items:start}.truthPanel{border-top:1px solid var(--line)}.statusRow{display:grid;grid-template-columns:.55fr 1fr;gap:24px;padding:20px 0;border-bottom:1px solid var(--line)}.statusRow span{color:var(--muted);font-size:.82rem}.statusRow strong{font-size:.94rem}.commercialGrid{display:grid;grid-template-columns:1.1fr .9fr;border-top:1px solid var(--line)}.infoCard{min-height:220px;padding:28px 28px 28px 0;border-bottom:1px solid var(--line);display:flex;flex-direction:column}.infoCard+.infoCard{padding-left:28px;border-left:1px solid var(--line)}.infoCard>span{font-size:.72rem;text-transform:uppercase;letter-spacing:.08em;font-weight:850;color:var(--green);margin-bottom:30px}.tags{display:flex;flex-wrap:wrap;gap:8px;margin-top:auto}.tags strong{padding:8px 10px;background:#fff;border:1px solid var(--line);font-size:.82rem}.price{font-family:var(--display);font-size:clamp(2.4rem,4vw,4rem);font-weight:600;letter-spacing:-.04em;margin-top:auto}.infoCard small{color:var(--muted);margin-top:8px}.dark{background:var(--forestDeep);color:#fff}.dark .eyebrow{color:#d9ec9f}.dark .sectionHeading p{color:#b8c7c0}.notesGrid{display:grid;grid-template-columns:repeat(3,1fr);border-top:1px solid rgba(255,255,255,.18)}.notesGrid article{min-height:180px;padding:24px 22px 24px 0;border-bottom:1px solid rgba(255,255,255,.18)}.notesGrid article+article{padding-left:22px;border-left:1px solid rgba(255,255,255,.18)}.notesGrid span{display:block;color:var(--lime);font-size:.72rem;font-weight:850;margin-bottom:34px}.notesGrid p{margin:0;color:#d3ddd8;line-height:1.6}.cropGrid{display:grid;grid-template-columns:repeat(3,1fr);border-top:1px solid var(--line)}.cropGrid a{min-height:250px;padding:26px 24px 28px 0;border-bottom:1px solid var(--line);display:flex;flex-direction:column}.cropGrid a+a{padding-left:24px;border-left:1px solid var(--line)}.cropGrid span{color:var(--green);font-size:.68rem;text-transform:uppercase;font-weight:850;letter-spacing:.08em;margin-bottom:32px}.cropGrid p{color:var(--muted);line-height:1.55}.cropGrid strong{margin-top:auto;color:var(--green);font-size:.86rem}.resources{padding:92px 0;background:var(--cream)}.resourceGrid{display:grid;grid-template-columns:.8fr 1.2fr;gap:70px}.resourceLinks{border-top:1px solid var(--line)}.resourceLinks a{display:flex;justify-content:space-between;gap:20px;padding:20px 0;border-bottom:1px solid var(--line)}.resourceLinks span{color:var(--green);font-size:.84rem}.closing{padding:74px 0 82px;background:var(--lime)}.closingInner{display:flex;justify-content:space-between;align-items:end;gap:34px}.closing h2{font-size:clamp(2.2rem,4vw,4rem)}@media(max-width:900px){.heroGrid,.truthGrid,.resourceGrid{grid-template-columns:1fr}.identityPlate{min-height:390px}.commercialGrid{grid-template-columns:1fr}.infoCard+.infoCard{padding-left:0;border-left:0}.notesGrid,.cropGrid{grid-template-columns:repeat(2,1fr)}.notesGrid article:nth-child(odd),.cropGrid a:nth-child(odd){padding-left:0;border-left:0}.closingInner{flex-direction:column;align-items:flex-start}}@media(max-width:640px){.container{width:min(100% - 28px,1240px)}.hero{padding:54px 0 72px}.back{margin-bottom:36px}.section,.resources{padding:68px 0}.identityPlate{min-height:340px;padding:24px}.plateTop{flex-direction:column}.plateTop small{text-align:left}.statusRow{grid-template-columns:1fr;gap:7px}.notesGrid,.cropGrid{grid-template-columns:1fr}.notesGrid article,.notesGrid article+article,.cropGrid a,.cropGrid a+a{padding:22px 0;border-left:0}.resourceLinks a{flex-direction:column;gap:8px}.actions,.button{width:100%}.closing{padding:62px 0}}
+.page {
+  --forest: #063d2c;
+  --forestDeep: #043022;
+  --green: #2f7d32;
+  --lime: #7db43c;
+  --sun: #f4d944;
+  --ink: #263b32;
+  --muted: #65776e;
+  --paper: #f7faf8;
+  --cream: #eaf4e4;
+  --line: rgba(6, 61, 44, 0.15);
+  --product-accent: #2f7d32;
+  --product-wash: rgba(47, 125, 50, .055);
+  --display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, Georgia, serif;
+  color: var(--ink);
+  background: var(--paper);
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.page[data-tone="grow"] { --product-accent: #d95f02; --product-wash: rgba(217, 95, 2, .065); }
+.page[data-tone="balance"] { --product-accent: #5b2c83; --product-wash: rgba(91, 44, 131, .06); }
+.page[data-tone="bloom"] { --product-accent: #125a93; --product-wash: rgba(18, 90, 147, .06); }
+.page[data-tone="fruit"] { --product-accent: #d94035; --product-wash: rgba(217, 64, 53, .06); }
+.page[data-tone="compost"] { --product-accent: #557a36; --product-wash: rgba(85, 122, 54, .06); }
+.page[data-tone="bioinput"],
+.page[data-tone="botanical"] { --product-accent: #2f7d32; --product-wash: rgba(47, 125, 50, .055); }
+
+.page * { box-sizing: border-box; }
+.page a { color: inherit; text-decoration: none; }
+.page a:focus-visible { outline: 3px solid var(--sun); outline-offset: 4px; }
+.container { width: min(1240px, calc(100% - 48px)); margin: 0 auto; }
+.eyebrow { display: inline-block; color: var(--green); font-size: .69rem; font-weight: 850; text-transform: uppercase; letter-spacing: .13em; margin-bottom: 15px; }
+.page h1,
+.page h2,
+.page h3 { font-family: var(--display); font-weight: 600; letter-spacing: -.035em; margin: 0; line-height: .98; }
+.page h1 { font-size: clamp(3.6rem, 7vw, 7.2rem); max-width: 10ch; }
+.page h1 em { display: block; color: var(--product-accent); font-style: normal; font-size: .62em; margin-top: 12px; }
+.page h2 { font-size: clamp(2.4rem, 4.6vw, 4.6rem); max-width: 17ch; }
+.page h3 { font-size: 1.55rem; line-height: 1.06; }
+
+.hero { padding: 72px 0 96px; background: linear-gradient(135deg, var(--cream), var(--product-wash)); border-bottom: 1px solid var(--line); }
+.heroGrid { display: grid; grid-template-columns: 1.1fr .72fr; gap: 68px; align-items: end; }
+.back { display: block; margin-bottom: 58px; color: var(--muted); font-weight: 750; font-size: .83rem; }
+.lead { max-width: 760px; color: #52675c; font-size: 1.16rem; line-height: 1.7; margin: 26px 0; }
+.heroMeta { display: flex; flex-wrap: wrap; gap: 8px; margin: 24px 0 30px; }
+.heroMeta span { padding: 8px 11px; border: 1px solid var(--line); font-size: .76rem; font-weight: 800; background: rgba(255,255,255,.5); }
+.actions { display: flex; flex-wrap: wrap; gap: 10px; }
+.button { display: inline-flex; min-height: 46px; align-items: center; justify-content: center; padding: 0 18px; border-radius: 4px; border: 1px solid var(--forestDeep); font-weight: 850; }
+.primary { background: var(--forestDeep); color: #fff !important; }
+.ghost { background: transparent; }
+
+.identityPlate { min-height: 470px; padding: 30px; background: var(--forestDeep); color: #fff; display: flex; flex-direction: column; justify-content: space-between; position: relative; overflow: hidden; border-top: 6px solid var(--product-accent); }
+.identityPlate:after { content: ""; position: absolute; width: 260px; height: 260px; border: 64px solid color-mix(in srgb, var(--product-accent) 22%, transparent); border-radius: 50%; right: -100px; bottom: -100px; }
+.plateTop { display: flex; justify-content: space-between; gap: 20px; border-bottom: 1px solid rgba(255,255,255,.18); padding-bottom: 18px; position: relative; z-index: 1; }
+.plateTop span { text-transform: uppercase; letter-spacing: .12em; font-size: .65rem; font-weight: 850; }
+.plateTop small { max-width: 190px; text-align: right; color: #d5e0da; }
+.familyMark { position: relative; z-index: 1; color: var(--product-accent); font-family: var(--display); font-size: clamp(3.4rem, 6vw, 5.8rem); line-height: .9; letter-spacing: -.05em; }
+.formula { position: relative; z-index: 1; font-size: 1.45rem; }
+.identityPlate p { position: relative; z-index: 1; max-width: 370px; color: #bdcbc4; line-height: 1.6; font-size: .84rem; }
+
+.section { padding: 92px 0; }
+.white { background: #fff; }
+.sectionHeading { max-width: 820px; margin-bottom: 38px; }
+.sectionHeading p { color: var(--muted); line-height: 1.65; }
+.truthGrid { display: grid; grid-template-columns: .8fr 1.2fr; gap: 70px; align-items: start; }
+.truthPanel { border-top: 4px solid var(--product-accent); }
+.statusRow { display: grid; grid-template-columns: .55fr 1fr; gap: 24px; padding: 20px 0; border-bottom: 1px solid var(--line); }
+.statusRow span { color: var(--muted); font-size: .82rem; }
+.statusRow strong { font-size: .94rem; }
+.commercialGrid { display: grid; grid-template-columns: 1.1fr .9fr; border-top: 1px solid var(--line); }
+.infoCard { min-height: 220px; padding: 28px 28px 28px 0; border-bottom: 1px solid var(--line); display: flex; flex-direction: column; }
+.infoCard + .infoCard { padding-left: 28px; border-left: 1px solid var(--line); }
+.infoCard > span { font-size: .72rem; text-transform: uppercase; letter-spacing: .08em; font-weight: 850; color: var(--product-accent); margin-bottom: 30px; }
+.tags { display: flex; flex-wrap: wrap; gap: 8px; margin-top: auto; }
+.tags strong { padding: 8px 10px; background: #fff; border: 1px solid var(--line); font-size: .82rem; }
+.price { font-family: var(--display); font-size: clamp(2.4rem, 4vw, 4rem); font-weight: 600; letter-spacing: -.04em; margin-top: auto; color: var(--product-accent); }
+.infoCard small { color: var(--muted); margin-top: 8px; }
+
+.dark { background: var(--forestDeep); color: #fff; }
+.dark .eyebrow { color: #d9ec9f; }
+.dark .sectionHeading p { color: #b8c7c0; }
+.notesGrid { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid rgba(255,255,255,.18); }
+.notesGrid article { min-height: 180px; padding: 24px 22px 24px 0; border-bottom: 1px solid rgba(255,255,255,.18); }
+.notesGrid article + article { padding-left: 22px; border-left: 1px solid rgba(255,255,255,.18); }
+.notesGrid span { display: block; color: var(--product-accent); font-size: .72rem; font-weight: 850; margin-bottom: 34px; }
+.notesGrid p { margin: 0; color: #d3ddd8; line-height: 1.6; }
+
+.cropGrid { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--line); }
+.cropGrid a { min-height: 250px; padding: 26px 24px 28px 0; border-bottom: 1px solid var(--line); display: flex; flex-direction: column; }
+.cropGrid a + a { padding-left: 24px; border-left: 1px solid var(--line); }
+.cropGrid span { color: var(--product-accent); font-size: .68rem; text-transform: uppercase; font-weight: 850; letter-spacing: .08em; margin-bottom: 32px; }
+.cropGrid p { color: var(--muted); line-height: 1.55; }
+.cropGrid strong { margin-top: auto; color: var(--product-accent); font-size: .86rem; }
+.resources { padding: 92px 0; background: var(--cream); }
+.resourceGrid { display: grid; grid-template-columns: .8fr 1.2fr; gap: 70px; }
+.resourceLinks { border-top: 1px solid var(--line); }
+.resourceLinks a { display: flex; justify-content: space-between; gap: 20px; padding: 20px 0; border-bottom: 1px solid var(--line); }
+.resourceLinks span { color: var(--green); font-size: .84rem; }
+.closing { padding: 74px 0 82px; background: var(--lime); }
+.closingInner { display: flex; justify-content: space-between; align-items: end; gap: 34px; }
+.closing h2 { font-size: clamp(2.2rem, 4vw, 4rem); }
+
+@media (max-width: 900px) {
+  .heroGrid,
+  .truthGrid,
+  .resourceGrid { grid-template-columns: 1fr; }
+  .identityPlate { min-height: 390px; }
+  .commercialGrid { grid-template-columns: 1fr; }
+  .infoCard + .infoCard { padding-left: 0; border-left: 0; }
+  .notesGrid,
+  .cropGrid { grid-template-columns: repeat(2, 1fr); }
+  .notesGrid article:nth-child(odd),
+  .cropGrid a:nth-child(odd) { padding-left: 0; border-left: 0; }
+  .closingInner { flex-direction: column; align-items: flex-start; }
+}
+
+@media (max-width: 640px) {
+  .container { width: min(100% - 28px, 1240px); }
+  .hero { padding: 54px 0 72px; }
+  .back { margin-bottom: 36px; }
+  .section,
+  .resources { padding: 68px 0; }
+  .identityPlate { min-height: 340px; padding: 24px; }
+  .plateTop { flex-direction: column; }
+  .plateTop small { text-align: left; }
+  .statusRow { grid-template-columns: 1fr; gap: 7px; }
+  .notesGrid,
+  .cropGrid { grid-template-columns: 1fr; }
+  .notesGrid article,
+  .notesGrid article + article,
+  .cropGrid a,
+  .cropGrid a + a { padding: 22px 0; border-left: 0; }
+  .resourceLinks a { flex-direction: column; gap: 8px; }
+  .actions,
+  .button { width: 100%; }
+  .closing { padding: 62px 0; }
+}

--- a/src/app/wondergreen/productos/catalog.module.css
+++ b/src/app/wondergreen/productos/catalog.module.css
@@ -1,5 +1,159 @@
-.page{--forest:#12372c;--deep:#0b241c;--green:#0a7a4b;--lime:#b8d65f;--sun:#ddc952;--ink:#18241f;--muted:#69736d;--paper:#fbfaf5;--cream:#f0ede3;--line:rgba(24,36,31,.16);--display:"Iowan Old Style","Palatino Linotype","Book Antiqua",Palatino,Georgia,serif;background:var(--paper);color:var(--ink);font-family:"Helvetica Neue",Helvetica,Arial,sans-serif}.page *{box-sizing:border-box}.page a{color:inherit;text-decoration:none}.page a:focus-visible,.page button:focus-visible,.page input:focus-visible{outline:3px solid var(--sun);outline-offset:4px}.container{width:min(1240px,calc(100% - 48px));margin:0 auto}.eyebrow{display:inline-block;color:var(--green);font-size:.69rem;font-weight:850;text-transform:uppercase;letter-spacing:.13em;margin-bottom:15px}.page h1,.page h2,.page h3{font-family:var(--display);font-weight:600;letter-spacing:-.035em;margin:0;line-height:.98}.page h1{font-size:clamp(3.5rem,6.4vw,6.6rem);max-width:14ch}.page h2{font-size:clamp(2.5rem,4.5vw,4.4rem)}.page h3{font-size:1.45rem;line-height:1.06}.hero{padding:92px 0 100px;background:var(--cream);border-bottom:1px solid var(--line)}.heroGrid{display:grid;grid-template-columns:1.15fr .65fr;gap:70px;align-items:end}.lead{max-width:790px;color:#526058;font-size:1.15rem;line-height:1.7}.router{padding:26px 0 8px 28px;border-left:4px solid var(--green)}.router strong{font-family:var(--display);font-size:1.55rem}.router p{color:var(--muted);line-height:1.6}.router a{color:var(--green);font-weight:850}.jumpNav{position:sticky;top:68px;z-index:5;background:rgba(251,250,245,.96);backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}.jumpNav .container{display:flex;gap:24px;overflow-x:auto;padding-top:14px;padding-bottom:14px}.jumpNav a{white-space:nowrap;font-size:.73rem;font-weight:850;text-transform:uppercase;letter-spacing:.06em;color:#536159}.group{padding:88px 0;scroll-margin-top:120px}.group:nth-of-type(even){background:#fff}.groupHeading{display:grid;grid-template-columns:100px 1fr;gap:22px;align-items:start;margin-bottom:34px}.groupHeading>span{color:var(--green);font-weight:850;font-size:.75rem;padding-top:8px}.groupHeading p{max-width:720px;color:var(--muted);line-height:1.6}.productGrid{display:grid;grid-template-columns:repeat(3,1fr);border-top:1px solid var(--line)}.productCard{min-height:380px;padding:24px 24px 28px 0;border-bottom:1px solid var(--line);display:flex;flex-direction:column;transition:transform .18s ease}.productCard+.productCard{padding-left:24px;border-left:1px solid var(--line)}.productCard:hover{transform:translateY(-3px)}.cardTop{display:flex;justify-content:space-between;gap:18px;min-height:42px}.cardTop span{color:var(--green);font-size:.66rem;text-transform:uppercase;letter-spacing:.06em;font-weight:850;max-width:220px}.cardTop small{color:var(--muted);text-transform:uppercase;font-size:.61rem}.identity{margin:34px 0 26px;display:flex;align-items:baseline;gap:12px}.identity strong{font-family:var(--display);font-size:2.4rem;letter-spacing:-.05em;color:var(--forest)}.identity em{font-style:normal;color:var(--green);font-weight:850;font-size:.8rem}.productCard p{color:var(--muted);line-height:1.58}.cardBottom{margin-top:auto;padding-top:28px;display:flex;justify-content:space-between;gap:20px;border-top:1px solid var(--line)}.cardBottom span{max-width:60%;font-size:.74rem;color:var(--muted)}.cardBottom strong{color:var(--green);font-size:.8rem;white-space:nowrap}.knowledge{padding:92px 0;background:var(--deep);color:#fff}.knowledgeGrid{display:grid;grid-template-columns:.8fr 1.2fr;gap:68px}.knowledge .eyebrow{color:#d9ec9f}.knowledge p{color:#bdcbc4;line-height:1.6}.knowledgeLinks{border-top:1px solid rgba(255,255,255,.18)}.knowledgeLinks a{display:flex;justify-content:space-between;padding:18px 0;border-bottom:1px solid rgba(255,255,255,.18);font-weight:800}.knowledgeLinks span{color:var(--lime)}.closing{padding:74px 0 82px;background:var(--lime)}.closingInner{display:flex;justify-content:space-between;align-items:end;gap:30px}.closing h2{font-size:clamp(2.3rem,4vw,4rem);max-width:16ch}.button{display:inline-flex;min-height:46px;padding:0 18px;align-items:center;justify-content:center;border-radius:4px;background:var(--deep);color:#fff!important;font-weight:850}
+.page {
+  --forest: #063d2c;
+  --deep: #043022;
+  --green: #2f7d32;
+  --lime: #7db43c;
+  --sun: #f4d944;
+  --ink: #263b32;
+  --muted: #65776e;
+  --paper: #f7faf8;
+  --cream: #eaf4e4;
+  --line: rgba(6, 61, 44, 0.15);
+  --display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, Georgia, serif;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
 
-.browser{padding:72px 0 34px;background:#fff;border-bottom:1px solid var(--line)}.browserHeading{display:grid;grid-template-columns:1fr .72fr;gap:60px;align-items:end;margin-bottom:34px}.browserHeading h2{max-width:14ch}.browserHeading p{margin:0;color:var(--muted);line-height:1.65;max-width:620px}.browserControls{display:grid;grid-template-columns:minmax(260px,.8fr) 1fr 1fr;gap:22px;padding:26px;border:1px solid var(--line);background:var(--paper)}.searchField,.filterGroup{min-width:0}.searchField{display:flex;flex-direction:column;gap:10px}.searchField>span,.filterGroup legend{color:var(--forest);font-size:.68rem;font-weight:850;text-transform:uppercase;letter-spacing:.09em}.searchField input{width:100%;height:48px;border:1px solid rgba(24,36,31,.26);border-radius:2px;background:#fff;padding:0 14px;color:var(--ink);font:inherit}.searchField input::placeholder{color:#89928d}.filterGroup{margin:0;padding:0;border:0}.filterGroup legend{margin-bottom:10px}.filterChips{display:flex;flex-wrap:wrap;gap:8px}.filterChips button,.resultBar button,.emptyActions button{border:1px solid rgba(24,36,31,.22);background:#fff;color:var(--forest);font:inherit;font-size:.72rem;font-weight:800;cursor:pointer}.filterChips button{min-height:38px;padding:0 11px;border-radius:999px}.filterChips button[aria-pressed="true"]{background:var(--forest);border-color:var(--forest);color:#fff}.resultBar{display:flex;align-items:center;gap:10px;min-height:52px;border-bottom:1px solid var(--line);color:var(--muted);font-size:.78rem}.resultBar strong{color:var(--forest);font-size:.9rem}.resultBar button{margin-left:auto;border:0;border-bottom:1px solid currentColor;background:transparent;padding:4px 0;color:var(--green)}.emptyState{padding:90px 0;background:var(--cream);border-bottom:1px solid var(--line)}.emptyState h2{max-width:14ch}.emptyState p{max-width:720px;color:var(--muted);line-height:1.65}.emptyActions{display:flex;gap:20px;align-items:center;margin-top:28px}.emptyActions button{min-height:44px;padding:0 16px;background:var(--forest);border-color:var(--forest);color:#fff;border-radius:3px}.emptyActions a{color:var(--green);font-weight:850}
+.page * { box-sizing: border-box; }
+.page a { color: inherit; text-decoration: none; }
+.page a:focus-visible,
+.page button:focus-visible,
+.page input:focus-visible { outline: 3px solid var(--sun); outline-offset: 4px; }
+.container { width: min(1240px, calc(100% - 48px)); margin: 0 auto; }
+.eyebrow { display: inline-block; color: var(--green); font-size: .69rem; font-weight: 850; text-transform: uppercase; letter-spacing: .13em; margin-bottom: 15px; }
+.page h1,
+.page h2,
+.page h3 { font-family: var(--display); font-weight: 600; letter-spacing: -.035em; margin: 0; line-height: .98; }
+.page h1 { font-size: clamp(3.5rem, 6.4vw, 6.6rem); max-width: 14ch; }
+.page h2 { font-size: clamp(2.5rem, 4.5vw, 4.4rem); }
+.page h3 { font-size: 1.45rem; line-height: 1.06; }
 
-@media(max-width:1050px){.browserControls{grid-template-columns:1fr 1fr}.searchField{grid-column:1/-1}}@media(max-width:900px){.heroGrid,.knowledgeGrid,.browserHeading{grid-template-columns:1fr}.productGrid{grid-template-columns:repeat(2,1fr)}.productCard:nth-child(odd){padding-left:0;border-left:0}.productCard:nth-child(even){padding-left:24px;border-left:1px solid var(--line)}.closingInner{flex-direction:column;align-items:flex-start}}@media(max-width:640px){.container{width:min(100% - 28px,1240px)}.hero{padding:70px 0 78px}.jumpNav{top:60px}.browser{padding:58px 0 26px}.browserControls{grid-template-columns:1fr;padding:18px}.searchField{grid-column:auto}.filterChips{flex-wrap:nowrap;overflow-x:auto;padding-bottom:4px}.filterChips button{flex:0 0 auto}.resultBar{align-items:flex-start;flex-wrap:wrap;padding:14px 0}.resultBar button{margin-left:0;width:100%;text-align:left}.group{padding:68px 0}.groupHeading{grid-template-columns:1fr;gap:6px}.productGrid{grid-template-columns:1fr}.productCard,.productCard:nth-child(n){padding:24px 0;border-left:0}.emptyState{padding:68px 0}.emptyActions{align-items:flex-start;flex-direction:column}.knowledge{padding:70px 0}.closing{padding:62px 0}.button{width:100%}}
+.hero { padding: 92px 0 100px; background: var(--cream); border-bottom: 1px solid var(--line); }
+.heroGrid { display: grid; grid-template-columns: 1.15fr .65fr; gap: 70px; align-items: end; }
+.lead { max-width: 790px; color: #52675c; font-size: 1.15rem; line-height: 1.7; }
+.router { padding: 26px 0 8px 28px; border-left: 4px solid var(--lime); }
+.router strong { font-family: var(--display); font-size: 1.55rem; }
+.router p { color: var(--muted); line-height: 1.6; }
+.router a { color: var(--green); font-weight: 850; }
+.jumpNav { position: sticky; top: 68px; z-index: 5; background: rgba(247, 250, 248, .96); backdrop-filter: blur(10px); border-bottom: 1px solid var(--line); }
+.jumpNav .container { display: flex; gap: 24px; overflow-x: auto; padding-top: 14px; padding-bottom: 14px; }
+.jumpNav a { white-space: nowrap; font-size: .73rem; font-weight: 850; text-transform: uppercase; letter-spacing: .06em; color: #53675d; }
+
+.group { padding: 88px 0; scroll-margin-top: 120px; }
+.group:nth-of-type(even) { background: #fff; }
+.groupHeading { display: grid; grid-template-columns: 100px 1fr; gap: 22px; align-items: start; margin-bottom: 34px; }
+.groupHeading > span { color: var(--green); font-weight: 850; font-size: .75rem; padding-top: 8px; }
+.groupHeading p { max-width: 720px; color: var(--muted); line-height: 1.6; }
+.productGrid { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--line); }
+.productCard {
+  --product-accent: var(--green);
+  --product-wash: rgba(47, 125, 50, .055);
+  min-height: 380px;
+  padding: 24px 24px 28px 0;
+  border-top: 4px solid var(--product-accent);
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(180deg, var(--product-wash), rgba(255, 255, 255, 0) 34%);
+  display: flex;
+  flex-direction: column;
+  transition: transform .18s ease, background-color .18s ease;
+}
+.productCard[data-tone="grow"] { --product-accent: #d95f02; --product-wash: rgba(217, 95, 2, .065); }
+.productCard[data-tone="balance"] { --product-accent: #5b2c83; --product-wash: rgba(91, 44, 131, .06); }
+.productCard[data-tone="bloom"] { --product-accent: #125a93; --product-wash: rgba(18, 90, 147, .06); }
+.productCard[data-tone="fruit"] { --product-accent: #d94035; --product-wash: rgba(217, 64, 53, .06); }
+.productCard[data-tone="compost"] { --product-accent: #557a36; --product-wash: rgba(85, 122, 54, .06); }
+.productCard[data-tone="bioinput"],
+.productCard[data-tone="botanical"] { --product-accent: #2f7d32; --product-wash: rgba(47, 125, 50, .055); }
+.productCard + .productCard { padding-left: 24px; border-left: 1px solid var(--line); }
+.productCard:hover { transform: translateY(-3px); }
+.cardTop { display: flex; justify-content: space-between; gap: 18px; min-height: 42px; }
+.cardTop span { color: var(--product-accent); font-size: .66rem; text-transform: uppercase; letter-spacing: .06em; font-weight: 850; max-width: 220px; }
+.cardTop small { color: var(--muted); text-transform: uppercase; font-size: .61rem; }
+.identity { margin: 34px 0 26px; display: flex; align-items: baseline; gap: 12px; }
+.identity strong { font-family: var(--display); font-size: 2.4rem; letter-spacing: -.05em; color: var(--product-accent); }
+.identity em { font-style: normal; color: var(--forest); font-weight: 850; font-size: .8rem; }
+.productCard p { color: var(--muted); line-height: 1.58; }
+.cardBottom { margin-top: auto; padding-top: 28px; display: flex; justify-content: space-between; gap: 20px; border-top: 1px solid var(--line); }
+.cardBottom span { max-width: 60%; font-size: .74rem; color: var(--muted); }
+.cardBottom strong { color: var(--product-accent); font-size: .8rem; white-space: nowrap; }
+
+.knowledge { padding: 92px 0; background: var(--deep); color: #fff; }
+.knowledgeGrid { display: grid; grid-template-columns: .8fr 1.2fr; gap: 68px; }
+.knowledge .eyebrow { color: #d9ec9f; }
+.knowledge p { color: #bdcbc4; line-height: 1.6; }
+.knowledgeLinks { border-top: 1px solid rgba(255,255,255,.18); }
+.knowledgeLinks a { display: flex; justify-content: space-between; padding: 18px 0; border-bottom: 1px solid rgba(255,255,255,.18); font-weight: 800; }
+.knowledgeLinks span { color: var(--lime); }
+.closing { padding: 74px 0 82px; background: var(--lime); }
+.closingInner { display: flex; justify-content: space-between; align-items: end; gap: 30px; }
+.closing h2 { font-size: clamp(2.3rem, 4vw, 4rem); max-width: 16ch; }
+.button { display: inline-flex; min-height: 46px; padding: 0 18px; align-items: center; justify-content: center; border-radius: 4px; background: var(--deep); color: #fff !important; font-weight: 850; }
+
+.browser { padding: 72px 0 34px; background: #fff; border-bottom: 1px solid var(--line); }
+.browserHeading { display: grid; grid-template-columns: 1fr .72fr; gap: 60px; align-items: end; margin-bottom: 34px; }
+.browserHeading h2 { max-width: 14ch; }
+.browserHeading p { margin: 0; color: var(--muted); line-height: 1.65; max-width: 620px; }
+.browserControls { display: grid; grid-template-columns: minmax(260px,.8fr) 1fr 1fr; gap: 22px; padding: 26px; border: 1px solid var(--line); background: var(--paper); }
+.searchField,
+.filterGroup { min-width: 0; }
+.searchField { display: flex; flex-direction: column; gap: 10px; }
+.searchField > span,
+.filterGroup legend { color: var(--forest); font-size: .68rem; font-weight: 850; text-transform: uppercase; letter-spacing: .09em; }
+.searchField input { width: 100%; height: 48px; border: 1px solid rgba(6,61,44,.24); border-radius: 2px; background: #fff; padding: 0 14px; color: var(--ink); font: inherit; }
+.searchField input::placeholder { color: #89958f; }
+.filterGroup { margin: 0; padding: 0; border: 0; }
+.filterGroup legend { margin-bottom: 10px; }
+.filterChips { display: flex; flex-wrap: wrap; gap: 8px; }
+.filterChips button,
+.resultBar button,
+.emptyActions button { border: 1px solid rgba(6,61,44,.22); background: #fff; color: var(--forest); font: inherit; font-size: .72rem; font-weight: 800; cursor: pointer; }
+.filterChips button { min-height: 38px; padding: 0 11px; border-radius: 999px; }
+.filterChips button[aria-pressed="true"] { background: var(--forest); border-color: var(--forest); color: #fff; }
+.resultBar { display: flex; align-items: center; gap: 10px; min-height: 52px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: .78rem; }
+.resultBar strong { color: var(--forest); font-size: .9rem; }
+.resultBar button { margin-left: auto; border: 0; border-bottom: 1px solid currentColor; background: transparent; padding: 4px 0; color: var(--green); }
+.emptyState { padding: 90px 0; background: var(--cream); border-bottom: 1px solid var(--line); }
+.emptyState h2 { max-width: 14ch; }
+.emptyState p { max-width: 720px; color: var(--muted); line-height: 1.65; }
+.emptyActions { display: flex; gap: 20px; align-items: center; margin-top: 28px; }
+.emptyActions button { min-height: 44px; padding: 0 16px; background: var(--forest); border-color: var(--forest); color: #fff; border-radius: 3px; }
+.emptyActions a { color: var(--green); font-weight: 850; }
+
+@media (max-width: 1050px) {
+  .browserControls { grid-template-columns: 1fr 1fr; }
+  .searchField { grid-column: 1 / -1; }
+}
+
+@media (max-width: 900px) {
+  .heroGrid,
+  .knowledgeGrid,
+  .browserHeading { grid-template-columns: 1fr; }
+  .productGrid { grid-template-columns: repeat(2, 1fr); }
+  .productCard:nth-child(odd) { padding-left: 0; border-left: 0; }
+  .productCard:nth-child(even) { padding-left: 24px; border-left: 1px solid var(--line); }
+  .closingInner { flex-direction: column; align-items: flex-start; }
+}
+
+@media (max-width: 640px) {
+  .container { width: min(100% - 28px, 1240px); }
+  .hero { padding: 70px 0 78px; }
+  .jumpNav { top: 60px; }
+  .browser { padding: 58px 0 26px; }
+  .browserControls { grid-template-columns: 1fr; padding: 18px; }
+  .searchField { grid-column: auto; }
+  .filterChips { flex-wrap: nowrap; overflow-x: auto; padding-bottom: 4px; }
+  .filterChips button { flex: 0 0 auto; }
+  .resultBar { align-items: flex-start; flex-wrap: wrap; padding: 14px 0; }
+  .resultBar button { margin-left: 0; width: 100%; text-align: left; }
+  .group { padding: 68px 0; }
+  .groupHeading { grid-template-columns: 1fr; gap: 6px; }
+  .productGrid { grid-template-columns: 1fr; }
+  .productCard,
+  .productCard:nth-child(n) { padding: 24px 0; border-left: 0; }
+  .emptyState { padding: 68px 0; }
+  .emptyActions { align-items: flex-start; flex-direction: column; }
+  .knowledge { padding: 70px 0; }
+  .closing { padding: 62px 0; }
+  .button { width: 100%; }
+}

--- a/src/app/wondergreen/productos/product-catalog-browser.tsx
+++ b/src/app/wondergreen/productos/product-catalog-browser.tsx
@@ -11,6 +11,7 @@ import {
   type WondergreenReference,
   type WondergreenTruthStatus,
 } from "@/data/wondergreen-public";
+import { getWondergreenVisualTone } from "@/data/wondergreen-visual";
 import styles from "./catalog.module.css";
 
 type StatusFilter = "all" | WondergreenTruthStatus;
@@ -156,15 +157,18 @@ export function ProductCatalogBrowser() {
               <div><h2>{group.title}</h2><p>{group.copy}</p></div>
             </div>
             <div className={styles.productGrid}>
-              {group.items.map((item) => (
-                <Link className={styles.productCard} href={`/wondergreen/productos/${item.slug}`} key={item.slug}>
-                  <div className={styles.cardTop}><span>{item.publicStatus}</span><small>{item.format}</small></div>
-                  <div className={styles.identity}><strong>{item.family}</strong>{item.formula ? <em>{item.formula}</em> : null}</div>
-                  <h3>{item.name}</h3>
-                  <p>{item.role}</p>
-                  <div className={styles.cardBottom}><span>{item.stage}</span><strong>Ver ficha →</strong></div>
-                </Link>
-              ))}
+              {group.items.map((item) => {
+                const tone = getWondergreenVisualTone(item);
+                return (
+                  <Link className={styles.productCard} data-tone={tone} href={`/wondergreen/productos/${item.slug}`} key={item.slug}>
+                    <div className={styles.cardTop}><span>{item.publicStatus}</span><small>{item.format}</small></div>
+                    <div className={styles.identity}><strong>{item.family}</strong>{item.formula ? <em>{item.formula}</em> : null}</div>
+                    <h3>{item.name}</h3>
+                    <p>{item.role}</p>
+                    <div className={styles.cardBottom}><span>{item.stage}</span><strong>Ver ficha →</strong></div>
+                  </Link>
+                );
+              })}
             </div>
           </div>
         </section>

--- a/src/data/wondergreen-visual.test.ts
+++ b/src/data/wondergreen-visual.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getWondergreenVisualTone } from "./wondergreen-visual";
+import { wondergreenReferences } from "./wondergreen-public";
+
+describe("Wondergreen V9 visual routing", () => {
+  it("keeps the four nutritional families on their governed line identities", () => {
+    const byFamily = new Map(wondergreenReferences.map((reference) => [reference.family, reference]));
+
+    expect(getWondergreenVisualTone(byFamily.get("2Grow")!)).toBe("grow");
+    expect(getWondergreenVisualTone(byFamily.get("2Balance")!)).toBe("balance");
+    expect(getWondergreenVisualTone(byFamily.get("2Bloom")!)).toBe("bloom");
+    expect(getWondergreenVisualTone(byFamily.get("2Fruit")!)).toBe("fruit");
+  });
+
+  it("routes compost and bioinputs without changing Product Truth", () => {
+    const compost = wondergreenReferences.find((reference) => reference.slug === "compost")!;
+    const neem = wondergreenReferences.find((reference) => reference.slug === "extracto-neem")!;
+    const trichoderma = wondergreenReferences.find((reference) => reference.slug === "trichoderma")!;
+
+    expect(getWondergreenVisualTone(compost)).toBe("compost");
+    expect(getWondergreenVisualTone(neem)).toBe("botanical");
+    expect(getWondergreenVisualTone(trichoderma)).toBe("bioinput");
+  });
+});

--- a/src/data/wondergreen-visual.ts
+++ b/src/data/wondergreen-visual.ts
@@ -1,0 +1,29 @@
+import type { WondergreenReference } from "./wondergreen-public";
+
+export type WondergreenVisualTone =
+  | "compost"
+  | "grow"
+  | "balance"
+  | "bloom"
+  | "fruit"
+  | "bioinput"
+  | "botanical";
+
+/**
+ * V9 visual routing only.
+ *
+ * Product Truth remains in wondergreen-public.ts. This mapping translates the
+ * V9 line-color system into UI tones without changing formula, role, status,
+ * presentation, price or agronomic claims.
+ */
+export function getWondergreenVisualTone(
+  reference: Pick<WondergreenReference, "family" | "line" | "format">,
+): WondergreenVisualTone {
+  if (reference.family === "2Grow") return "grow";
+  if (reference.family === "2Balance") return "balance";
+  if (reference.family === "2Bloom") return "bloom";
+  if (reference.family === "2Fruit") return "fruit";
+  if (reference.format === "compost") return "compost";
+  if (reference.format === "botanical") return "botanical";
+  return "bioinput";
+}


### PR DESCRIPTION
## Objetivo
Alinear el catálogo y las fichas Wondergreen con el sistema visual V9 sin modificar Product Truth ni inventar packshots.

## Cambios
- incorpora un router visual independiente de Product Truth;
- 2Grow usa identidad naranja, 2Balance violeta, 2Bloom azul y 2Fruit coral/rojo;
- Compost conserva tierra/verde y bioinsumos una identidad botánica verde;
- actualiza la paleta base de catálogo y ficha a los tokens V9 ya usados en Home/Wondergreen;
- las tarjetas reciben un acento superior y un lavado cromático muy ligero, manteniendo mucho aire y lectura técnica;
- las fichas individuales llevan el color de familia a fórmula, placa editorial, estados y relaciones con cultivo;
- añade unit tests y Playwright para fijar el routing visual.

## Fuente
`GREENATICS_MKTG_STUDIO_SKILL_V9.zip`: `PRODUCT_TRUTH_V9.json`, `ASSET_AUTHORITY_REGISTRY_V9.json`, `AESTHETIC_SYSTEM_V9.md` y `PACKAGING_SYSTEM_V9.md`.

## Guardrails
- Product Truth sigue en `wondergreen-public.ts` y no se modifica;
- la estética queda aislada en `wondergreen-visual.ts`;
- sin cambios de fórmulas, dosis, precios, estados, presentaciones o claims;
- sin packshots generados, recortes de láminas maestras ni simulación de empaques;
- sin cambios OPS/Auth/Supabase/RLS/migraciones/workflows.