### PR TITLE
feat(public): incorporar evidencia real y paleta V9 en Soluciones

### DIFF
--- a/e2e/public-solutions.spec.ts
+++ b/e2e/public-solutions.spec.ts
@@ -11,6 +11,8 @@ test("solutions hub exposes the governed service architecture and four commercia
   await page.goto("/soluciones");
 
   await expect(page.getByRole("heading", { name: /El proyecto no empieza en la planta/i })).toBeVisible();
+  await expect(page.getByRole("img", { name: "Vista aérea documentada del caso Greenatics en Yarumal" })).toBeVisible();
+  await expect(page.getByText(/Vista aérea de archivo · Yarumal/)).toBeVisible();
   await expect(page.getByRole("heading", { name: "No necesitas conocer el nombre del servicio." })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Diagnosticar y planear" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Separar y recolectar" })).toBeVisible();

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import { serviceJourneys } from "@/data/service-journeys";
+import { getPrimaryProjectMedia } from "@/data/public-media";
 import { companyServices, municipalServices, serviceCategories, services, type ServiceCategory } from "@/data/services";
 import styles from "./solutions.module.css";
+import refresh from "./solutions-refresh.module.css";
 
 export const metadata: Metadata = {
   title: "Soluciones | Greenatics",
@@ -21,8 +24,10 @@ const categoryIntro: Record<ServiceCategory, string> = {
 const path = ["Entender", "Recolectar", "Transformar", "Operar", "Medir", "Devolver valor"];
 
 export default function SolutionsPage() {
+  const yarumalEvidence = getPrimaryProjectMedia("yarumal");
+
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} ${refresh.page}`}>
       <main>
         <section className={styles.hero}>
           <div className={styles.heroAccent} aria-hidden="true" />
@@ -38,6 +43,14 @@ export default function SolutionsPage() {
               </div>
             </div>
             <aside className={styles.heroProof}>
+              {yarumalEvidence ? (
+                <figure className={refresh.proofFigure}>
+                  <div className={refresh.proofImage}>
+                    <Image src={yarumalEvidence.src} alt={yarumalEvidence.alt} fill sizes="(max-width: 1060px) 100vw, 36vw" priority />
+                  </div>
+                  <figcaption>{yarumalEvidence.caption}</figcaption>
+                </figure>
+              ) : null}
               <span>Principio de diseño</span>
               <strong>Residuo → operación → producto → dato.</strong>
               <p>No partimos de una máquina predeterminada. Partimos del origen, volumen, composición, logística, infraestructura, actores, destino de productos y capacidad real de gestión.</p>

--- a/src/app/soluciones/solutions-refresh.module.css
+++ b/src/app/soluciones/solutions-refresh.module.css
@@ -1,0 +1,45 @@
+.page {
+  --forest: #063d2c;
+  --forest-deep: #043022;
+  --green: #2f7d32;
+  --lime: #7db43c;
+  --sun: #f4d944;
+  --ink: #263b32;
+  --muted: #65776e;
+  --paper: #f7faf8;
+  --cream: #eaf4e4;
+  --line: rgba(6, 61, 44, 0.15);
+  --line-dark: rgba(255, 255, 255, 0.18);
+}
+
+.proofFigure {
+  margin: -32px -32px 28px;
+}
+
+.proofImage {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: #0b2f24;
+}
+
+.proofImage img {
+  object-fit: cover;
+}
+
+.proofFigure figcaption {
+  padding: 12px 32px 0;
+  color: #c8d7cf;
+  font-size: .72rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 760px) {
+  .proofFigure {
+    margin: -24px -24px 24px;
+  }
+
+  .proofFigure figcaption {
+    padding: 10px 24px 0;
+  }
+}


### PR DESCRIPTION
## Objetivo
Reducir la brecha visual de `/soluciones` usando únicamente evidencia ya aprobada públicamente y reconciliando su paleta con el sistema V9 ya integrado en Home, shell y Wondergreen.

## Cambios
- alinea tokens cromáticos de Soluciones con V9 mediante una capa CSS independiente y reversible;
- reutiliza la vista aérea aprobada del caso Yarumal desde `public-media.ts`;
- incorpora la imagen dentro del hero como evidencia histórica de proyecto, con alt y caption gobernados;
- conserva intactos los cuatro recorridos comerciales, 13 servicios, audiencias y guardrail contractual;
- añade Playwright para fijar que la fotografía proviene del registro público gobernado.

## Guardrails
- no se incorporan las láminas comerciales de Municipios/ESP como imágenes web;
- no se publican archivos históricos de proceso aún no contextualizados;
- no se inventan capacidades, resultados, infraestructura, cifras o claims a partir de la fotografía;
- no cambia Services Truth ni rutas;
- sin cambios OPS/Auth/Supabase/RLS/migraciones/workflows.