### PR TITLE
feat(public): consolidar arquitectura de negocio Greenatics v7

### DIFF
--- a/e2e/public-solutions.spec.ts
+++ b/e2e/public-solutions.spec.ts
@@ -7,23 +7,66 @@ async function jsonLdByType(page: import("@playwright/test").Page, type: string)
     .filter((payload) => payload["@type"] === type);
 }
 
-test("solutions hub exposes the governed service architecture and four commercial journeys", async ({ page }) => {
+test("solutions hub exposes strategic programs, six commercial lines and the governed service catalog", async ({ page }) => {
   await page.goto("/soluciones");
 
-  await expect(page.getByRole("heading", { name: /El proyecto no empieza en la planta/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Primero estructurar. Luego operar. Después valorizar./i })).toBeVisible();
   await expect(page.getByRole("img", { name: "Vista aérea documentada del caso Greenatics en Yarumal" })).toBeVisible();
   await expect(page.getByText(/Vista aérea de archivo · Yarumal/)).toBeVisible();
-  await expect(page.getByRole("heading", { name: "No necesitas conocer el nombre del servicio." })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Diagnosticar y planear" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Separar y recolectar" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Construir o recuperar capacidad" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Operar, controlar y medir" })).toBeVisible();
+
+  await expect(page.getByRole("heading", { name: "Dos formas de ordenar primero las decisiones." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "ESP READY", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "PMIRS RED", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Conocer ESP READY/ })).toHaveAttribute("href", "/soluciones/programas/esp-ready");
+  await expect(page.getByRole("link", { name: /Conocer PMIRS RED/ })).toHaveAttribute("href", "/soluciones/programas/pmirs-red");
+
+  for (const line of [
+    "Diagnóstico y datos",
+    "Planeación y gestión",
+    "Operación de aseo y logística",
+    "Circularidad y valorización",
+    "Infraestructura y proyectos",
+    "Acompañamiento y operación",
+  ]) {
+    await expect(page.getByRole("heading", { name: line, exact: true })).toBeVisible();
+  }
+
   await expect(page.getByRole("link", { name: /Diagnóstico y caracterización/ })).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
-  await expect(page.getByRole("link", { name: /Trazabilidad y datos/ })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
-  await expect(page.getByRole("heading", { name: /Del PGIRS a una operación sostenible/i })).toBeVisible();
-  await expect(page.getByRole("heading", { name: /De residuo operativo a flujo gestionado/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Trazabilidad, indicadores y datos/ })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
+  await expect(page.getByRole("heading", { name: /De la planeación a una operación preparada para crecer/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /De cumplimiento aislado a gestión medible y circular/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Diagnóstico y caracterización de residuos orgánicos" })).toBeVisible();
   await expect(page.getByRole("link", { name: /Ver solución en profundidad/i }).first()).toHaveAttribute("href", /\/soluciones\//);
+});
+
+test("ESP READY keeps the ten sourced preparation dimensions and decision outputs", async ({ page }) => {
+  await page.goto("/soluciones/programas/esp-ready");
+
+  await expect(page.getByRole("heading", { name: "ESP READY", exact: true })).toBeVisible();
+  await expect(page.getByText(/¿Qué tan preparada está la empresa para iniciar y crecer?/)).toBeVisible();
+
+  for (const dimension of ["Regulación", "Clientes", "Operación", "Tarifa", "Facturación", "Rutas", "Flota", "Datos", "Contingencias", "Infraestructura futura"]) {
+    await expect(page.getByText(dimension, { exact: true })).toBeVisible();
+  }
+  for (const output of ["Estado actual", "Brechas", "Prioridades", "Hoja de ruta"]) {
+    await expect(page.getByText(output, { exact: true })).toBeVisible();
+  }
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/programas/esp-ready");
+});
+
+test("PMIRS RED separates unit-level implementation from network intelligence", async ({ page }) => {
+  await page.goto("/soluciones/programas/pmirs-red");
+
+  await expect(page.getByRole("heading", { name: "PMIRS RED", exact: true })).toBeVisible();
+  for (const item of ["Diagnóstico", "Caracterización", "Programas", "Implementación", "Indicadores", "Seguimiento"]) {
+    await expect(page.getByText(item, { exact: true })).toBeVisible();
+  }
+  for (const item of ["Demanda", "Ubicación", "Composición", "Accesos", "Horarios", "Orgánicos", "Aprovechables", "Oportunidades"]) {
+    await expect(page.getByText(item, { exact: true })).toBeVisible();
+  }
+  await expect(page.getByText(/24 no es un mínimo ni una promesa universal/i)).toBeVisible();
 });
 
 test("solution detail preserves problem, scope, deliverables and breadcrumb semantics", async ({ page }) => {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from "next";
 import { publicProjects } from "@/data/projects-public";
 import { publicSite, publicStaticRoutes } from "@/data/public-site";
 import { services } from "@/data/services";
+import { strategicPrograms } from "@/data/strategic-programs";
 import { wondergreenCrops } from "@/data/wondergreen-crops";
 import { wondergreenReferences } from "@/data/wondergreen-public";
 
@@ -24,6 +25,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     entry(path, path === "/" ? 1 : 0.8, path === "/" ? "weekly" : "monthly"),
   );
 
+  const strategicProgramEntries = strategicPrograms.map((program) =>
+    entry(`/soluciones/programas/${program.slug}`, 0.78, "monthly"),
+  );
+
   const serviceEntries = services.map((service) =>
     entry(`/soluciones/${service.slug}`, 0.72, "monthly"),
   );
@@ -40,5 +45,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
     entry(`/wondergreen/productos/${reference.slug}`, reference.truthStatus === "commercial-reconciled" ? 0.76 : 0.64, "monthly"),
   );
 
-  return [...staticEntries, ...serviceEntries, ...projectEntries, ...cropEntries, ...productEntries];
+  return [...staticEntries, ...strategicProgramEntries, ...serviceEntries, ...projectEntries, ...cropEntries, ...productEntries];
 }

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -4,12 +4,14 @@ import Link from "next/link";
 import { serviceJourneys } from "@/data/service-journeys";
 import { getPrimaryProjectMedia } from "@/data/public-media";
 import { companyServices, municipalServices, serviceCategories, services, type ServiceCategory } from "@/data/services";
+import { strategicPrograms } from "@/data/strategic-programs";
 import styles from "./solutions.module.css";
 import refresh from "./solutions-refresh.module.css";
+import programStyles from "./strategic-programs.module.css";
 
 export const metadata: Metadata = {
   title: "Soluciones | Greenatics",
-  description: "Diagnóstico, planeación, rutas selectivas, plantas, operación y trazabilidad para municipios, ESP, empresas y grandes generadores.",
+  description: "Estructuración, planeación, operación de aseo, circularidad, infraestructura, trazabilidad y acompañamiento para municipios, ESP, empresas y grandes generadores.",
   alternates: { canonical: "/soluciones" },
 };
 
@@ -21,7 +23,7 @@ const categoryIntro: Record<ServiceCategory, string> = {
   Datos: "Hacer que cada actividad deje evidencia y alimente decisiones, indicadores y trazabilidad.",
 };
 
-const path = ["Entender", "Recolectar", "Transformar", "Operar", "Medir", "Devolver valor"];
+const path = ["Entender", "Estructurar", "Operar", "Medir", "Optimizar", "Valorizar", "Escalar"];
 
 export default function SolutionsPage() {
   const yarumalEvidence = getPrimaryProjectMedia("yarumal");
@@ -33,11 +35,12 @@ export default function SolutionsPage() {
           <div className={styles.heroAccent} aria-hidden="true" />
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Soluciones Greenatics · Del diagnóstico a la operación</span>
-              <h1>El proyecto no empieza en la planta ni termina cuando se entrega un equipo.</h1>
-              <p className={styles.lead}>Greenatics trabaja sobre toda la cadena: diagnosticar, planear, recolectar, transformar, operar, medir y devolver valor. Cada servicio puede contratarse como una fase independiente o integrarse dentro de un sistema territorial o empresarial.</p>
+              <span className={styles.eyebrow}>Soluciones Greenatics · Estructuración técnica de sistemas de residuos</span>
+              <h1>Primero estructurar. Luego operar. Después valorizar.</h1>
+              <p className={styles.lead}>Greenatics acompaña sistemas de gestión de residuos desde la comprensión del problema hasta la operación, la medición, la optimización, la valorización y el escalamiento. No partimos de una planta, un vehículo o un documento predeterminado: partimos de las decisiones que el sistema realmente necesita.</p>
               <div className={styles.heroLinks}>
-                <a href="#recorridos">Encontrar mi punto de entrada →</a>
+                <a href="#programas">Ver programas de entrada →</a>
+                <a href="#recorridos">Explorar líneas de solución →</a>
                 <a href="#municipios">Municipios y ESP →</a>
                 <a href="#empresas">Empresas →</a>
               </div>
@@ -51,25 +54,49 @@ export default function SolutionsPage() {
                   <figcaption>{yarumalEvidence.caption}</figcaption>
                 </figure>
               ) : null}
-              <span>Principio de diseño</span>
-              <strong>Residuo → operación → producto → dato.</strong>
-              <p>No partimos de una máquina predeterminada. Partimos del origen, volumen, composición, logística, infraestructura, actores, destino de productos y capacidad real de gestión.</p>
+              <span>Principio de trabajo</span>
+              <strong>Método + evidencia antes de inversión.</strong>
+              <p>El residuo, los usuarios, la logística, la operación, los datos y el destino deben entenderse como un sistema. La infraestructura y la tecnología se deciden después, no al revés.</p>
             </aside>
           </div>
         </section>
 
-        <section className={styles.path} aria-label="Ruta de solución Greenatics">
-          <div className={`${styles.container} ${styles.pathGrid}`}>
+        <section className={styles.path} aria-label="Ruta Greenatics de estructuración y crecimiento">
+          <div className={`${styles.container} ${styles.pathGrid} ${refresh.businessPath}`}>
             {path.map((item, index) => <div key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>)}
+          </div>
+        </section>
+
+        <section className={programStyles.programs} id="programas">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <span className={`${styles.eyebrow} ${programStyles.eyebrow}`}>Programas estratégicos de entrada</span>
+              <h2>Dos formas de ordenar primero las decisiones.</h2>
+              <p>Estos programas no sustituyen los servicios técnicos. Organizan el punto de partida y ayudan a decidir qué capacidades conviene activar después.</p>
+            </div>
+            <div className={programStyles.programGrid}>
+              {strategicPrograms.map((program) => (
+                <article className={programStyles.programCard} key={program.slug}>
+                  <span>{program.audience}</span>
+                  <h3>{program.name}</h3>
+                  <strong>{program.headline}</strong>
+                  <p>{program.summary}</p>
+                  <div className={programStyles.outputFlow}>
+                    {program.outputs.map((output) => <span key={output}>{output}</span>)}
+                  </div>
+                  <Link href={`/soluciones/programas/${program.slug}`}>Conocer {program.name} →</Link>
+                </article>
+              ))}
+            </div>
           </div>
         </section>
 
         <section className={styles.journeys} id="recorridos">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <span className={styles.eyebrow}>Empieza por lo que necesitas resolver</span>
-              <h2>No necesitas conocer el nombre del servicio.</h2>
-              <p>Los 13 servicios siguen siendo independientes y contratables por fase. Estos cuatro recorridos solo simplifican la entrada según el estado real del proyecto.</p>
+              <span className={styles.eyebrow}>Seis líneas de solución</span>
+              <h2>Primero ubica el problema; luego elegimos el servicio.</h2>
+              <p>Los 13 servicios siguen siendo independientes y contratables por fase. Estas seis líneas son la arquitectura comercial que conecta necesidades reales con el catálogo técnico sin duplicarlo.</p>
             </div>
             <div className={styles.journeyGrid}>
               {serviceJourneys.map((journey) => (
@@ -93,21 +120,21 @@ export default function SolutionsPage() {
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <span className={styles.eyebrow}>Ahora ubica tu contexto</span>
-              <h2>La misma corriente orgánica exige decisiones distintas según quién la genera y quién la opera.</h2>
+              <h2>Un sistema de residuos cambia según quién lo planea, quién lo opera y dónde se genera.</h2>
               <p>Por eso el portafolio distingue rutas para territorios y prestadores, y rutas para empresas o grandes generadores.</p>
             </div>
             <div className={styles.audienceGrid}>
               <article className={styles.audienceCard} id="municipios">
                 <div className={styles.audienceIndex}>01</div>
-                <div><span className={styles.eyebrow}>Municipios y ESP</span><h3>Del PGIRS a una operación sostenible.</h3><p>Planeación, rutas selectivas, infraestructura, rehabilitación, operación y trazabilidad para convertir metas territoriales en capacidad real.</p></div>
-                <div className={styles.audienceFacts}><strong>{municipalServices.length}</strong><span>servicios aplicables</span><small>Diagnóstico antes de dimensionar · operación y datos dentro del sistema.</small></div>
-                <a href="#planeación">Ver ruta →</a>
+                <div><span className={styles.eyebrow}>Municipios y ESP</span><h3>De la planeación a una operación preparada para crecer.</h3><p>Diagnóstico, PGIRS, rutas, operación, datos, infraestructura y valorización para convertir metas o nuevas oportunidades en capacidad real.</p></div>
+                <div className={styles.audienceFacts}><strong>{municipalServices.length}</strong><span>servicios aplicables</span><small>Primero claridad de modelo · luego operación e inversión.</small></div>
+                <a href="#planeación">Ver catálogo técnico →</a>
               </article>
               <article className={styles.audienceCard} id="empresas">
                 <div className={styles.audienceIndex}>02</div>
-                <div><span className={styles.eyebrow}>Empresas y grandes generadores</span><h3>De residuo operativo a flujo gestionado y trazable.</h3><p>Caracterización, PMIRS, separación, recolección, tratamiento, infraestructura y evidencia de gestión según el tipo de corriente.</p></div>
-                <div className={styles.audienceFacts}><strong>{companyServices.length}</strong><span>servicios aplicables</span><small>Logística desde el origen · tratamiento y evidencia conectados.</small></div>
-                <a href="#planeación">Ver ruta →</a>
+                <div><span className={styles.eyebrow}>Empresas y grandes generadores</span><h3>De cumplimiento aislado a gestión medible y circular.</h3><p>Caracterización, PMIRS, redes multiunidad, separación, recolección, tratamiento, infraestructura y evidencia de gestión según cada corriente.</p></div>
+                <div className={styles.audienceFacts}><strong>{companyServices.length}</strong><span>servicios aplicables</span><small>Información una vez · gestión y seguimiento sobre la misma base.</small></div>
+                <a href="#planeación">Ver catálogo técnico →</a>
               </article>
             </div>
           </div>
@@ -144,8 +171,8 @@ export default function SolutionsPage() {
 
         <section className={styles.guardrail}>
           <div className={`${styles.container} ${styles.guardrailGrid}`}>
-            <div><span className={styles.eyebrow}>Alcance responsable</span><h2>El portafolio es modular; el alcance contractual manda.</h2></div>
-            <p>Estas fichas describen capacidades y entregables posibles. Cada proyecto define expresamente estudios, ingeniería, construcción, permisos, operación, personal, certificaciones, informes y responsabilidades incluidas. La web no convierte una capacidad general en una obligación contractual automática.</p>
+            <div><span className={styles.eyebrow}>Alcance responsable</span><h2>La arquitectura orienta; el alcance contractual manda.</h2></div>
+            <p>Los programas y líneas comerciales ayudan a ordenar la conversación. Las fichas técnicas describen capacidades y entregables posibles. Cada proyecto define expresamente estudios, ingeniería, construcción, permisos, operación, personal, certificaciones, informes y responsabilidades incluidas.</p>
           </div>
         </section>
       </main>

--- a/src/app/soluciones/programas/[slug]/page.tsx
+++ b/src/app/soluciones/programas/[slug]/page.tsx
@@ -1,0 +1,127 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { getService } from "@/data/services";
+import { getStrategicProgram, strategicPrograms } from "@/data/strategic-programs";
+import styles from "../../solutions.module.css";
+import refresh from "../../solutions-refresh.module.css";
+import programStyles from "../../strategic-programs.module.css";
+
+type Props = { params: Promise<{ slug: string }> };
+
+export function generateStaticParams() {
+  return strategicPrograms.map((program) => ({ slug: program.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const program = getStrategicProgram(slug);
+  if (!program) return {};
+  return {
+    title: `${program.name} | Soluciones Greenatics`,
+    description: program.summary,
+    alternates: { canonical: `/soluciones/programas/${program.slug}` },
+  };
+}
+
+export default async function StrategicProgramPage({ params }: Props) {
+  const { slug } = await params;
+  const program = getStrategicProgram(slug);
+  if (!program) notFound();
+  const relatedServices = program.relatedServiceSlugs.map((serviceSlug) => getService(serviceSlug)).filter(Boolean);
+
+  return (
+    <div className={`${styles.page} ${refresh.page}`}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Soluciones", path: "/soluciones" },
+        { name: program.name, path: `/soluciones/programas/${program.slug}` as `/${string}` },
+      ]} />
+      <main>
+        <section className={styles.detailHero}>
+          <div className={styles.heroAccent} aria-hidden="true" />
+          <div className={styles.container}>
+            <div className={styles.breadcrumb}><Link href="/soluciones">Soluciones</Link><span>→</span><span>Programas estratégicos</span></div>
+            <div className={styles.detailGrid}>
+              <div>
+                <span className={styles.eyebrow}>{program.audience}</span>
+                <h1>{program.name}</h1>
+                <p className={styles.detailLead}>{program.headline}</p>
+              </div>
+              <aside className={styles.detailAside}>
+                <span>Producto consultivo</span>
+                <strong>Primero claridad para decidir.</strong>
+                <p>{program.summary}</p>
+              </aside>
+            </div>
+          </div>
+        </section>
+
+        <section className={programStyles.detailIntro}>
+          <div className={`${styles.container} ${programStyles.detailIntroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Cómo se usa</span>
+              <h2>Una puerta de entrada que organiza las siguientes decisiones.</h2>
+              <p>{program.summary}</p>
+            </div>
+            <aside className={programStyles.principle}>
+              <strong>Principio de trabajo</strong>
+              <p>{program.principle}</p>
+            </aside>
+          </div>
+        </section>
+
+        <section className={programStyles.programSection}>
+          <div className={styles.container}>
+            <span className={styles.eyebrow}>{program.primaryLabel}</span>
+            <h2>{program.slug === "esp-ready" ? "La preparación se revisa como un sistema." : "Cada unidad conserva su propio plan."}</h2>
+            <div className={programStyles.itemGrid}>
+              {program.primaryItems.map((item, index) => <div className={programStyles.item} key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>)}
+            </div>
+          </div>
+        </section>
+
+        {program.secondaryItems ? (
+          <section className={programStyles.programSection}>
+            <div className={styles.container}>
+              <span className={styles.eyebrow}>{program.secondaryLabel}</span>
+              <h2>La red transforma planes separados en información comparable.</h2>
+              <div className={programStyles.itemGrid}>
+                {program.secondaryItems.map((item, index) => <div className={programStyles.item} key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>)}
+              </div>
+            </div>
+          </section>
+        ) : null}
+
+        <section className={programStyles.programSection}>
+          <div className={styles.container}>
+            <span className={styles.eyebrow}>Salida del programa</span>
+            <h2>Resultados que permiten decidir qué activar después.</h2>
+            <div className={programStyles.programOutputs}>
+              {program.outputs.map((item, index) => <div key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>)}
+            </div>
+            <p className={programStyles.programNote}>{program.sourceNote}</p>
+          </div>
+        </section>
+
+        <section className={programStyles.programSection}>
+          <div className={styles.container}>
+            <span className={styles.eyebrow}>Servicios que pueden activarse después</span>
+            <h2>El programa organiza la decisión; el alcance contractual sigue en las fichas técnicas.</h2>
+            <div className={programStyles.relatedLinks}>
+              {relatedServices.map((service) => service ? <Link href={`/soluciones/${service.slug}`} key={service.slug}><span>{service.name}</span><span>Ver servicio →</span></Link> : null)}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.guardrail}>
+          <div className={`${styles.container} ${styles.guardrailGrid}`}>
+            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>{program.cta}</h2></div>
+            <div><p>La metodología se adapta al estado real del cliente. No presupone que todas las brechas existan ni convierte una capacidad general de Greenatics en obligación contractual automática.</p><Link className={`${styles.button} ${styles.primary}`} href="/contacto">Hablar con Greenatics</Link></div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/soluciones/programas/[slug]/page.tsx
+++ b/src/app/soluciones/programas/[slug]/page.tsx
@@ -118,7 +118,7 @@ export default async function StrategicProgramPage({ params }: Props) {
         <section className={styles.guardrail}>
           <div className={`${styles.container} ${styles.guardrailGrid}`}>
             <div><span className={styles.eyebrow}>Siguiente paso</span><h2>{program.cta}</h2></div>
-            <div><p>La metodología se adapta al estado real del cliente. No presupone que todas las brechas existan ni convierte una capacidad general de Greenatics en obligación contractual automática.</p><Link className={`${styles.button} ${styles.primary}`} href="/contacto">Hablar con Greenatics</Link></div>
+            <div><p>La metodología se adapta al estado real del cliente. No presupone que todas las brechas existan ni convierte una capacidad general de Greenatics en obligación contractual automática.</p><Link className={styles.button} href="/contacto">Hablar con Greenatics</Link></div>
           </div>
         </section>
       </main>

--- a/src/app/soluciones/solutions-refresh.module.css
+++ b/src/app/soluciones/solutions-refresh.module.css
@@ -34,6 +34,28 @@
   line-height: 1.45;
 }
 
+.businessPath {
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+@media (max-width: 1060px) {
+  .businessPath {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .businessPath > div:nth-child(3) {
+    border-right: 1px solid var(--line-dark);
+  }
+
+  .businessPath > div:nth-child(4) {
+    border-right: 0;
+  }
+
+  .businessPath > div:nth-child(n+5) {
+    border-top: 1px solid var(--line-dark);
+  }
+}
+
 @media (max-width: 760px) {
   .proofFigure {
     margin: -24px -24px 24px;
@@ -41,5 +63,37 @@
 
   .proofFigure figcaption {
     padding: 10px 24px 0;
+  }
+
+  .businessPath {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .businessPath > div:nth-child(4) {
+    border-right: 0;
+  }
+
+  .businessPath > div:nth-child(odd) {
+    border-right: 1px solid var(--line-dark);
+  }
+
+  .businessPath > div:nth-child(even) {
+    border-right: 0;
+  }
+
+  .businessPath > div:nth-child(n+3) {
+    border-top: 1px solid var(--line-dark);
+  }
+}
+
+@media (max-width: 480px) {
+  .businessPath {
+    grid-template-columns: 1fr;
+  }
+
+  .businessPath > div,
+  .businessPath > div:nth-child(odd),
+  .businessPath > div:nth-child(even) {
+    border-right: 0;
   }
 }

--- a/src/app/soluciones/solutions-refresh.module.css
+++ b/src/app/soluciones/solutions-refresh.module.css
@@ -48,6 +48,7 @@
   }
 
   .businessPath > div:nth-child(4) {
+    border-top: 0;
     border-right: 0;
   }
 
@@ -70,6 +71,7 @@
   }
 
   .businessPath > div:nth-child(4) {
+    border-top: 1px solid var(--line-dark);
     border-right: 0;
   }
 

--- a/src/app/soluciones/strategic-programs.module.css
+++ b/src/app/soluciones/strategic-programs.module.css
@@ -5,8 +5,8 @@
   border-bottom: 1px solid var(--line-dark);
 }
 
-.programs .sectionHead p { color: #b8c8bf; }
-.programs .eyebrow { color: #d8ed9c; }
+.programs p { color: #b8c8bf; }
+.eyebrow { color: #d8ed9c !important; }
 
 .programGrid {
   display: grid;
@@ -125,7 +125,7 @@
   line-height: 1.7;
 }
 .relatedLinks { display: grid; margin-top: 32px; border-top: 1px solid var(--line); }
-.relatedLinks a { min-height: 54px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); color: var(--green); font-weight: 800; }
+.relatedLinks a { min-height: 54px; display: flex; align-items: center; justify-content: space-between; gap: 22px; border-bottom: 1px solid var(--line); color: var(--green); font-weight: 800; }
 
 @media (max-width: 900px) {
   .programGrid, .detailIntroGrid { grid-template-columns: 1fr; }
@@ -136,4 +136,5 @@
   .programs, .programSection { padding: 78px 0; }
   .programCard { min-height: auto; padding: 28px 24px; }
   .itemGrid, .programOutputs { grid-template-columns: 1fr; }
+  .relatedLinks a { align-items: flex-start; flex-direction: column; padding: 14px 0; }
 }

--- a/src/app/soluciones/strategic-programs.module.css
+++ b/src/app/soluciones/strategic-programs.module.css
@@ -1,0 +1,139 @@
+.programs {
+  padding: 112px 0;
+  background: var(--forest-deep);
+  color: #fff;
+  border-bottom: 1px solid var(--line-dark);
+}
+
+.programs .sectionHead p { color: #b8c8bf; }
+.programs .eyebrow { color: #d8ed9c; }
+
+.programGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--line-dark);
+  border-left: 1px solid var(--line-dark);
+}
+
+.programCard {
+  min-height: 430px;
+  display: flex;
+  flex-direction: column;
+  padding: 36px;
+  border-right: 1px solid var(--line-dark);
+  border-bottom: 1px solid var(--line-dark);
+  background: rgba(255, 255, 255, .035);
+}
+
+.programCard > span,
+.programTag {
+  color: #d8ed9c;
+  font-size: .7rem;
+  font-weight: 800;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.programCard h3 { margin-top: 18px; font-size: clamp(2.3rem, 4vw, 4rem); }
+.programCard > strong { margin-top: 16px; font-size: 1.05rem; line-height: 1.5; }
+.programCard > p { margin: 16px 0 26px; color: #b8c8bf; line-height: 1.7; }
+
+.outputFlow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 24px;
+  border-top: 1px solid var(--line-dark);
+}
+.outputFlow span {
+  padding: 7px 10px;
+  border: 1px solid var(--line-dark);
+  color: #e7f2ec;
+  font-size: .72rem;
+  font-weight: 700;
+}
+.programCard a {
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  margin-top: 26px;
+  color: #d8ed9c;
+  font-weight: 800;
+}
+
+.detailIntro { padding: 94px 0 40px; }
+.detailIntroGrid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(300px, .7fr); gap: 64px; align-items: start; }
+.detailIntro p { color: var(--muted); line-height: 1.75; }
+.principle {
+  padding: 26px;
+  border-left: 6px solid var(--sun);
+  background: var(--forest);
+  color: #fff;
+}
+.principle strong { display: block; margin-bottom: 8px; font-family: var(--display); font-size: 1.45rem; font-weight: 600; }
+.principle p { margin: 0; color: #bfd0c7; }
+
+.programSection { padding: 84px 0; border-top: 1px solid var(--line); }
+.programSection:nth-of-type(even) { background: var(--cream); }
+.programSection h2 { max-width: 880px; }
+.itemGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 38px;
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+.item {
+  min-height: 78px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 18px 22px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+}
+.item span { color: var(--green); font-size: .68rem; font-weight: 800; }
+.item strong { font-size: .95rem; }
+
+.programOutputs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 38px;
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+.programOutputs div {
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 22px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+.programOutputs span { color: var(--green); font-size: .68rem; font-weight: 800; }
+.programOutputs strong { font-family: var(--display); font-size: 1.3rem; font-weight: 600; }
+
+.programNote {
+  margin-top: 38px;
+  padding: 22px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  line-height: 1.7;
+}
+.relatedLinks { display: grid; margin-top: 32px; border-top: 1px solid var(--line); }
+.relatedLinks a { min-height: 54px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); color: var(--green); font-weight: 800; }
+
+@media (max-width: 900px) {
+  .programGrid, .detailIntroGrid { grid-template-columns: 1fr; }
+  .programOutputs { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 760px) {
+  .programs, .programSection { padding: 78px 0; }
+  .programCard { min-height: auto; padding: 28px 24px; }
+  .itemGrid, .programOutputs { grid-template-columns: 1fr; }
+}

--- a/src/data/public-indexing.test.ts
+++ b/src/data/public-indexing.test.ts
@@ -4,6 +4,7 @@ import robots from "../app/robots";
 import { protectedOpsRoutePrefixes } from "../lib/ops-access-policy";
 import { publicNav, publicReservedRoutes, publicSite, publicStaticRoutes } from "./public-site";
 import { services } from "./services";
+import { strategicPrograms } from "./strategic-programs";
 import { publicProjects } from "./projects-public";
 import { wondergreenCrops } from "./wondergreen-crops";
 import { wondergreenReferences } from "./wondergreen-public";
@@ -18,9 +19,11 @@ describe("public navigation and indexing contract", () => {
   it("builds a sitemap from governed indexed public data only", () => {
     const entries = sitemap();
     const urls = entries.map((item) => item.url);
-    const expectedCount = publicStaticRoutes.length + services.length + publicProjects.length + wondergreenCrops.length + wondergreenReferences.length;
+    const expectedCount = publicStaticRoutes.length + strategicPrograms.length + services.length + publicProjects.length + wondergreenCrops.length + wondergreenReferences.length;
 
     expect(entries).toHaveLength(expectedCount);
+    expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/esp-ready`);
+    expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/pmirs-red`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/diagnostico-caracterizacion`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/proyectos/yarumal`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/wondergreen/cultivos/cafe`);

--- a/src/data/service-journeys.test.ts
+++ b/src/data/service-journeys.test.ts
@@ -3,10 +3,10 @@ import { serviceJourneys } from "./service-journeys";
 import { services } from "./services";
 
 describe("public commercial service journeys", () => {
-  it("keeps four distinct commercial entry journeys", () => {
-    expect(serviceJourneys).toHaveLength(4);
-    expect(new Set(serviceJourneys.map((journey) => journey.number)).size).toBe(4);
-    expect(new Set(serviceJourneys.map((journey) => journey.title)).size).toBe(4);
+  it("keeps six distinct commercial solution lines", () => {
+    expect(serviceJourneys).toHaveLength(6);
+    expect(new Set(serviceJourneys.map((journey) => journey.number)).size).toBe(6);
+    expect(new Set(serviceJourneys.map((journey) => journey.title)).size).toBe(6);
   });
 
   it("references only governed service slugs", () => {

--- a/src/data/service-journeys.ts
+++ b/src/data/service-journeys.ts
@@ -6,51 +6,68 @@ export type ServiceJourney = {
   services: readonly { slug: string; label: string }[];
 };
 
-// UX grouping only: the governed service registry remains the source of contractual scope.
+// UX/business grouping only: the governed service registry remains the source of contractual scope.
+// Every governed service appears exactly once in this commercial layer.
 export const serviceJourneys: readonly ServiceJourney[] = [
   {
     number: "01",
-    kicker: "Necesito entender y decidir",
-    title: "Diagnosticar y planear",
-    copy: "Para proyectos que todavía necesitan una línea base, un instrumento de planeación o una decisión de prefactibilidad antes de invertir.",
+    kicker: "Necesito entender el sistema",
+    title: "Diagnóstico y datos",
+    copy: "Para construir línea base, ordenar evidencia y convertir la operación en información útil antes de tomar decisiones de inversión, cumplimiento o crecimiento.",
     services: [
       { slug: "diagnostico-caracterizacion", label: "Diagnóstico y caracterización" },
-      { slug: "pgirs", label: "PGIRS" },
-      { slug: "pmirs", label: "PMIRS" },
-      { slug: "prefactibilidad", label: "Prefactibilidad" },
+      { slug: "trazabilidad-datos", label: "Trazabilidad, indicadores y datos" },
     ],
   },
   {
     number: "02",
-    kicker: "Necesito mover material separado",
-    title: "Separar y recolectar",
-    copy: "Para conectar generadores, frecuencias, microrrutas y criterios de aceptación con un destino real de aprovechamiento.",
+    kicker: "Necesito convertir obligaciones en gestión",
+    title: "Planeación y gestión",
+    copy: "Para llevar PGIRS y PMIRS desde el documento hacia programas, responsables, indicadores, implementación y seguimiento.",
     services: [
-      { slug: "rutas-selectivas", label: "Rutas selectivas" },
-      { slug: "motocarguero", label: "Motocarguero / piloto" },
-      { slug: "recoleccion-tratamiento", label: "Recolección y tratamiento" },
+      { slug: "pgirs", label: "PGIRS" },
+      { slug: "pmirs", label: "PMIRS" },
     ],
   },
   {
     number: "03",
-    kicker: "Necesito infraestructura",
-    title: "Construir o recuperar capacidad",
-    copy: "Para madurar ingeniería, construir una planta nueva o recuperar infraestructura existente antes de reemplazarla.",
+    kicker: "Necesito que la operación funcione",
+    title: "Operación de aseo y logística",
+    copy: "Para conectar generadores, rutas, frecuencias, vehículos, tiempos y evidencia operacional antes de ampliar cobertura o capacidad.",
     services: [
-      { slug: "factibilidad-ingenieria", label: "Factibilidad e ingeniería" },
-      { slug: "plantas-nuevas", label: "Plantas nuevas" },
-      { slug: "rehabilitacion", label: "Rehabilitación" },
+      { slug: "rutas-selectivas", label: "Rutas selectivas y microrrutas" },
+      { slug: "motocarguero", label: "Pilotos de recolección y toma de datos" },
     ],
   },
   {
     number: "04",
-    kicker: "Necesito que funcione y se pueda demostrar",
-    title: "Operar, controlar y medir",
-    copy: "Para convertir infraestructura y procesos en una operación disciplinada con mantenimiento, inventarios, evidencia y trazabilidad.",
+    kicker: "Necesito aprovechar mejor las corrientes",
+    title: "Circularidad y valorización",
+    copy: "Para integrar separación, recolección, trazabilidad y tratamiento de orgánicos de modo que la gestión no termine en una simple entrega sin evidencia de destino.",
     services: [
-      { slug: "direccion-operacion", label: "Dirección de operación" },
+      { slug: "recoleccion-tratamiento", label: "Recolección, trazabilidad y tratamiento" },
+    ],
+  },
+  {
+    number: "05",
+    kicker: "Necesito decidir si invertir y en qué",
+    title: "Infraestructura y proyectos",
+    copy: "Para comparar alternativas, madurar ingeniería, construir o recuperar capacidad solo después de validar residuos, logística, localización y modelo operativo.",
+    services: [
+      { slug: "prefactibilidad", label: "Prefactibilidad" },
+      { slug: "factibilidad-ingenieria", label: "Factibilidad e ingeniería" },
+      { slug: "plantas-nuevas", label: "Plantas nuevas" },
+      { slug: "rehabilitacion", label: "Rehabilitación y puesta en marcha" },
+    ],
+  },
+  {
+    number: "06",
+    kicker: "Necesito sostener y mejorar",
+    title: "Acompañamiento y operación",
+    copy: "Para convertir infraestructura y procesos en una operación disciplinada, medible y mejorable con responsabilidades, mantenimiento, calidad y seguimiento.",
+    services: [
+      { slug: "direccion-operacion", label: "Dirección técnica y coordinación" },
       { slug: "operacion-integral", label: "Operación integral" },
-      { slug: "trazabilidad-datos", label: "Trazabilidad y datos" },
     ],
   },
 ] as const;

--- a/src/data/strategic-programs.test.ts
+++ b/src/data/strategic-programs.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { services } from "./services";
+import { getStrategicProgram, strategicPrograms } from "./strategic-programs";
+
+describe("strategic public programs", () => {
+  it("publishes only ESP READY and PMIRS RED in this wave", () => {
+    expect(strategicPrograms.map((program) => program.slug)).toEqual(["esp-ready", "pmirs-red"]);
+  });
+
+  it("keeps every related service grounded in the governed registry", () => {
+    const serviceSlugs = new Set(services.map((service) => service.slug));
+    for (const program of strategicPrograms) {
+      expect(program.relatedServiceSlugs.length).toBeGreaterThan(0);
+      for (const slug of program.relatedServiceSlugs) expect(serviceSlugs.has(slug)).toBe(true);
+    }
+  });
+
+  it("keeps ESP READY dimensions and outputs aligned with the source methodology", () => {
+    const program = getStrategicProgram("esp-ready");
+    expect(program?.primaryItems).toEqual([
+      "Regulación",
+      "Clientes",
+      "Operación",
+      "Tarifa",
+      "Facturación",
+      "Rutas",
+      "Flota",
+      "Datos",
+      "Contingencias",
+      "Infraestructura futura",
+    ]);
+    expect(program?.outputs).toEqual(["Estado actual", "Brechas", "Prioridades", "Hoja de ruta"]);
+  });
+
+  it("keeps PMIRS RED unit and network layers separate", () => {
+    const program = getStrategicProgram("pmirs-red");
+    expect(program?.primaryItems).toHaveLength(6);
+    expect(program?.secondaryItems).toHaveLength(8);
+    expect(program?.sourceNote).toMatch(/24 no es un mínimo/i);
+  });
+});

--- a/src/data/strategic-programs.ts
+++ b/src/data/strategic-programs.ts
@@ -1,0 +1,74 @@
+export type StrategicProgram = {
+  slug: "esp-ready" | "pmirs-red";
+  name: string;
+  audience: string;
+  headline: string;
+  summary: string;
+  principle: string;
+  primaryLabel: string;
+  primaryItems: readonly string[];
+  secondaryLabel?: string;
+  secondaryItems?: readonly string[];
+  outputs: readonly string[];
+  relatedServiceSlugs: readonly string[];
+  sourceNote: string;
+  cta: string;
+};
+
+export const strategicPrograms: readonly StrategicProgram[] = [
+  {
+    slug: "esp-ready",
+    name: "ESP READY",
+    audience: "Empresas de servicios públicos y operaciones de aseo",
+    headline: "¿Qué tan preparada está la empresa para iniciar y crecer?",
+    summary: "Diagnóstico integral para ordenar el estado real de una operación, sus brechas, prioridades y decisiones antes de acelerar cobertura, infraestructura o valorización.",
+    principle: "No es una auditoría para buscar errores. Es un diagnóstico para saber qué está listo y qué conviene cerrar.",
+    primaryLabel: "Revisamos diez dimensiones de preparación",
+    primaryItems: [
+      "Regulación",
+      "Clientes",
+      "Operación",
+      "Tarifa",
+      "Facturación",
+      "Rutas",
+      "Flota",
+      "Datos",
+      "Contingencias",
+      "Infraestructura futura",
+    ],
+    outputs: ["Estado actual", "Brechas", "Prioridades", "Hoja de ruta"],
+    relatedServiceSlugs: [
+      "diagnostico-caracterizacion",
+      "rutas-selectivas",
+      "trazabilidad-datos",
+      "prefactibilidad",
+      "direccion-operacion",
+    ],
+    sourceNote: "Producto consultivo derivado de la metodología ESP READY. El alcance final se define según actividades, responsabilidades e información disponible en cada ESP.",
+    cta: "Evaluar preparación de una ESP",
+  },
+  {
+    slug: "pmirs-red",
+    name: "PMIRS RED",
+    audience: "Redes de propiedad horizontal, grandes generadores y operadores",
+    headline: "De PMIRS individuales a una arquitectura común de información.",
+    summary: "Metodología para formular e implementar PMIRS bajo un estándar común, de modo que cada unidad reciba su plan y la red pueda consolidar información comparable para operación y decisiones posteriores.",
+    principle: "El cumplimiento puede convertirse en inteligencia operativa cuando la información se levanta bajo una estructura común.",
+    primaryLabel: "Cada unidad puede recibir",
+    primaryItems: ["Diagnóstico", "Caracterización", "Programas", "Implementación", "Indicadores", "Seguimiento"],
+    secondaryLabel: "La red puede consolidar",
+    secondaryItems: ["Demanda", "Ubicación", "Composición", "Accesos", "Horarios", "Orgánicos", "Aprovechables", "Oportunidades"],
+    outputs: ["PMIRS implementables", "Base consolidada", "Indicadores comparables", "Ruta de seguimiento"],
+    relatedServiceSlugs: [
+      "pmirs",
+      "diagnostico-caracterizacion",
+      "rutas-selectivas",
+      "trazabilidad-datos",
+      "recoleccion-tratamiento",
+    ],
+    sourceNote: "PMIRS RED generaliza la metodología desarrollada para el caso PMIRS RED 24. El número de unidades, fases y entregables se define en cada alcance; 24 no es un mínimo ni una promesa universal.",
+    cta: "Estructurar una red PMIRS",
+  },
+] as const;
+
+export const getStrategicProgram = (slug: string) => strategicPrograms.find((program) => program.slug === slug);


### PR DESCRIPTION
## Objetivo
Convertir `/soluciones` en una arquitectura comercial de negocio que ayude al cliente a entrar por problema y decisión, sin reemplazar ni duplicar el catálogo técnico de 13 servicios.

## Fuente
La wave se basa en el brief maestro de la conversación estratégica de servicios de aseo/ESP, especialmente la tesis `entender → estructurar → operar → medir → optimizar → valorizar → escalar`, ESP READY y PMIRS RED 24.

## Cambios
- reorganiza los 13 servicios en 6 líneas comerciales, cubriendo cada servicio exactamente una vez;
- mantiene `services.ts` como Truth contractual/técnico sin cambiar ninguno de los 13 servicios;
- añade dos programas estratégicos de entrada: `ESP READY` y `PMIRS RED`;
- publica fichas dedicadas en `/soluciones/programas/esp-ready` y `/soluciones/programas/pmirs-red`;
- ESP READY conserva las 10 dimensiones de preparación y la salida `Estado actual → brechas → prioridades → hoja de ruta`;
- PMIRS RED separa capa por unidad y capa consolidada de red; aclara que 24 fue un caso de aplicación, no un mínimo universal;
- actualiza hero y recorrido de negocio a 7 etapas;
- indexa ambos programas en sitemap;
- amplía unit/E2E para fijar cobertura, rutas, outputs y guardrails.

## Guardrails
- cero cambios en Services Truth, Product Truth o Crop Truth;
- cero cambios OPS/Auth/Supabase/RLS/migraciones;
- no convierte capacidades generales en obligaciones contractuales;
- no inventa porcentajes, toneladas, tarifas, precios ni funcionalidades digitales;
- no activa Casa y Jardín ni ecommerce.