### PR TITLE
feat(public): ampliar productos B2B de aseo y GREENATICS BASE

### DIFF
--- a/e2e/public-solutions.spec.ts
+++ b/e2e/public-solutions.spec.ts
@@ -23,7 +23,7 @@ test("solutions hub exposes strategic programs, decision modules, six commercial
   await expect(page.getByRole("link", { name: /Conocer PMIRS RED/ })).toHaveAttribute("href", "/soluciones/programas/pmirs-red");
 
   await expect(page.getByRole("heading", { name: "No todo problema necesita convertirse en un servicio nuevo." })).toBeVisible();
-  for (const module of [
+  for (const moduleTitle of [
     "Puesta en marcha de operación de aseo",
     "Rutas, flota y continuidad operativa",
     "Programa de orgánicos: captura real y piloto",
@@ -31,7 +31,7 @@ test("solutions hub exposes strategic programs, decision modules, six commercial
     "Screening técnico de predios",
     "Acompañamiento por etapas",
   ]) {
-    await expect(page.getByRole("heading", { name: module, exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: moduleTitle, exact: true })).toBeVisible();
   }
   await expect(page.getByText(/no presupone una planta ni una tecnología/i)).toBeVisible();
   await expect(page.getByText(/no sustituye concepto de uso del suelo/i)).toBeVisible();

--- a/e2e/public-solutions.spec.ts
+++ b/e2e/public-solutions.spec.ts
@@ -7,18 +7,34 @@ async function jsonLdByType(page: import("@playwright/test").Page, type: string)
     .filter((payload) => payload["@type"] === type);
 }
 
-test("solutions hub exposes strategic programs, six commercial lines and the governed service catalog", async ({ page }) => {
+test("solutions hub exposes strategic programs, decision modules, six commercial lines and governed services", async ({ page }) => {
   await page.goto("/soluciones");
 
   await expect(page.getByRole("heading", { name: /Primero estructurar. Luego operar. Después valorizar./i })).toBeVisible();
   await expect(page.getByRole("img", { name: "Vista aérea documentada del caso Greenatics en Yarumal" })).toBeVisible();
   await expect(page.getByText(/Vista aérea de archivo · Yarumal/)).toBeVisible();
 
-  await expect(page.getByRole("heading", { name: "Dos formas de ordenar primero las decisiones." })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "ESP READY", exact: true })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "PMIRS RED", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Tres formas de empezar con una base más clara." })).toBeVisible();
+  for (const program of ["ESP READY", "GREENATICS BASE", "PMIRS RED"]) {
+    await expect(page.getByRole("heading", { name: program, exact: true })).toBeVisible();
+  }
   await expect(page.getByRole("link", { name: /Conocer ESP READY/ })).toHaveAttribute("href", "/soluciones/programas/esp-ready");
+  await expect(page.getByRole("link", { name: /Conocer GREENATICS BASE/ })).toHaveAttribute("href", "/soluciones/programas/greenatics-base");
   await expect(page.getByRole("link", { name: /Conocer PMIRS RED/ })).toHaveAttribute("href", "/soluciones/programas/pmirs-red");
+
+  await expect(page.getByRole("heading", { name: "No todo problema necesita convertirse en un servicio nuevo." })).toBeVisible();
+  for (const module of [
+    "Puesta en marcha de operación de aseo",
+    "Rutas, flota y continuidad operativa",
+    "Programa de orgánicos: captura real y piloto",
+    "Prefactibilidad de decisiones de infraestructura",
+    "Screening técnico de predios",
+    "Acompañamiento por etapas",
+  ]) {
+    await expect(page.getByRole("heading", { name: module, exact: true })).toBeVisible();
+  }
+  await expect(page.getByText(/no presupone una planta ni una tecnología/i)).toBeVisible();
+  await expect(page.getByText(/no sustituye concepto de uso del suelo/i)).toBeVisible();
 
   for (const line of [
     "Diagnóstico y datos",
@@ -31,7 +47,7 @@ test("solutions hub exposes strategic programs, six commercial lines and the gov
     await expect(page.getByRole("heading", { name: line, exact: true })).toBeVisible();
   }
 
-  await expect(page.getByRole("link", { name: /Diagnóstico y caracterización/ })).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
+  await expect(page.getByRole("link", { name: /Diagnóstico y caracterización/ }).first()).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
   await expect(page.getByRole("link", { name: /Trazabilidad, indicadores y datos/ })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
   await expect(page.getByRole("heading", { name: /De la planeación a una operación preparada para crecer/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: /De cumplimiento aislado a gestión medible y circular/i })).toBeVisible();
@@ -54,6 +70,30 @@ test("ESP READY keeps the ten sourced preparation dimensions and decision output
 
   const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
   expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/programas/esp-ready");
+});
+
+test("GREENATICS BASE keeps technical baseline separate from PMIRS and regulatory aforo", async ({ page }) => {
+  await page.goto("/soluciones/programas/greenatics-base");
+
+  await expect(page.getByRole("heading", { name: "GREENATICS BASE", exact: true })).toBeVisible();
+  await expect(page.getByText(/Empieza a producir información real mientras estructuras lo que sigue/i)).toBeVisible();
+  for (const item of [
+    "Línea base de generación",
+    "Caracterización de residuos",
+    "Diagnóstico de infraestructura",
+    "Lectura operativa del proyecto",
+    "Captura digital y evidencia",
+    "Consolidación y análisis",
+  ]) {
+    await expect(page.getByText(item, { exact: true })).toBeVisible();
+  }
+  for (const excluded of ["PMIRS completo", "Aforo regulatorio", "Estudio tarifario", "Diseño final de rutas", "Ingeniería", "Permisos"]) {
+    await expect(page.getByText(excluded, { exact: true })).toBeVisible();
+  }
+  await expect(page.getByText(/alcance independiente conforme al procedimiento aplicable/i)).toBeVisible();
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/programas/greenatics-base");
 });
 
 test("PMIRS RED separates unit-level implementation from network intelligence", async ({ page }) => {

--- a/src/app/soluciones/commercial-modules.module.css
+++ b/src/app/soluciones/commercial-modules.module.css
@@ -1,0 +1,124 @@
+.modules {
+  padding: 112px 0;
+  background: var(--paper);
+  border-bottom: 1px solid var(--line);
+}
+
+.moduleGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.moduleCard {
+  min-height: 430px;
+  display: flex;
+  flex-direction: column;
+  padding: 34px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: #fff;
+}
+
+.moduleCard > span {
+  color: var(--green);
+  font-size: .69rem;
+  font-weight: 800;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.moduleCard h3 {
+  max-width: 580px;
+  margin-top: 16px;
+}
+
+.moduleCard > p {
+  margin: 18px 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.decision {
+  margin-top: 26px;
+  padding: 20px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.decision small {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--green);
+  font-size: .67rem;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.decision strong {
+  font-family: var(--display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.signals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.signals span {
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  color: var(--ink);
+  font-size: .72rem;
+  font-weight: 700;
+}
+
+.guardrail {
+  margin-top: 20px !important;
+  padding-left: 16px;
+  border-left: 3px solid var(--sun);
+  font-size: .82rem;
+}
+
+.moduleLinks {
+  display: grid;
+  margin-top: auto;
+  padding-top: 24px;
+}
+
+.moduleLinks small {
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: .67rem;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.moduleLinks a {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  border-top: 1px solid var(--line);
+  color: var(--green);
+  font-size: .82rem;
+  font-weight: 800;
+}
+
+@media (max-width: 900px) {
+  .moduleGrid { grid-template-columns: 1fr; }
+  .moduleCard { min-height: auto; }
+}
+
+@media (max-width: 760px) {
+  .modules { padding: 78px 0; }
+  .moduleCard { padding: 28px 24px; }
+}

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -102,16 +102,16 @@ export default function SolutionsPage() {
               <p>Estos módulos empaquetan decisiones frecuentes y conectan capacidades ya gobernadas. Sirven para entrar por una pregunta concreta sin duplicar los 13 servicios técnicos ni prometer resultados antes de contar con evidencia.</p>
             </div>
             <div className={moduleStyles.moduleGrid}>
-              {commercialModules.map((module) => {
-                const relatedServices = module.relatedServiceSlugs.map((slug) => getService(slug)).filter(Boolean);
+              {commercialModules.map((commercialModule) => {
+                const relatedServices = commercialModule.relatedServiceSlugs.map((slug) => getService(slug)).filter(Boolean);
                 return (
-                  <article className={moduleStyles.moduleCard} key={module.id}>
-                    <span>{module.kicker}</span>
-                    <h3>{module.title}</h3>
-                    <p>{module.summary}</p>
-                    <div className={moduleStyles.decision}><small>Decisión que organiza</small><strong>{module.decision}</strong></div>
-                    <div className={moduleStyles.signals}>{module.signals.map((signal) => <span key={signal}>{signal}</span>)}</div>
-                    <p className={moduleStyles.guardrail}>{module.guardrail}</p>
+                  <article className={moduleStyles.moduleCard} key={commercialModule.id}>
+                    <span>{commercialModule.kicker}</span>
+                    <h3>{commercialModule.title}</h3>
+                    <p>{commercialModule.summary}</p>
+                    <div className={moduleStyles.decision}><small>Decisión que organiza</small><strong>{commercialModule.decision}</strong></div>
+                    <div className={moduleStyles.signals}>{commercialModule.signals.map((signal) => <span key={signal}>{signal}</span>)}</div>
+                    <p className={moduleStyles.guardrail}>{commercialModule.guardrail}</p>
                     <div className={moduleStyles.moduleLinks}>
                       <small>Servicios técnicos relacionados</small>
                       {relatedServices.slice(0, 3).map((service) => service ? <Link href={`/soluciones/${service.slug}`} key={service.slug}><span>{service.name}</span><span>→</span></Link> : null)}

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -1,23 +1,25 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { commercialModules } from "@/data/commercial-modules";
 import { serviceJourneys } from "@/data/service-journeys";
 import { getPrimaryProjectMedia } from "@/data/public-media";
-import { companyServices, municipalServices, serviceCategories, services, type ServiceCategory } from "@/data/services";
+import { companyServices, getService, municipalServices, serviceCategories, services, type ServiceCategory } from "@/data/services";
 import { strategicPrograms } from "@/data/strategic-programs";
 import styles from "./solutions.module.css";
 import refresh from "./solutions-refresh.module.css";
 import programStyles from "./strategic-programs.module.css";
+import moduleStyles from "./commercial-modules.module.css";
 
 export const metadata: Metadata = {
   title: "Soluciones | Greenatics",
-  description: "Estructuración, planeación, operación de aseo, circularidad, infraestructura, trazabilidad y acompañamiento para municipios, ESP, empresas y grandes generadores.",
+  description: "Estructuración, línea base, planeación, operación de aseo, gestión de residuos, infraestructura, trazabilidad y acompañamiento para municipios, ESP, empresas y grandes generadores.",
   alternates: { canonical: "/soluciones" },
 };
 
 const categoryIntro: Record<ServiceCategory, string> = {
   Planeación: "Entender el problema y madurar el proyecto antes de comprometer inversión.",
-  Recolección: "Conectar al generador con el aprovechamiento mediante logística, separación y datos.",
+  Recolección: "Conectar al generador con el destino previsto mediante logística, separación y datos.",
   Infraestructura: "Diseñar, construir o recuperar sistemas alrededor del residuo y de la operación real.",
   Operación: "Convertir infraestructura en rutina, control, mantenimiento, producto y mejora continua.",
   Datos: "Hacer que cada actividad deje evidencia y alimente decisiones, indicadores y trazabilidad.",
@@ -40,6 +42,7 @@ export default function SolutionsPage() {
               <p className={styles.lead}>Greenatics acompaña sistemas de gestión de residuos desde la comprensión del problema hasta la operación, la medición, la optimización, la valorización y el escalamiento. No partimos de una planta, un vehículo o un documento predeterminado: partimos de las decisiones que el sistema realmente necesita.</p>
               <div className={styles.heroLinks}>
                 <a href="#programas">Ver programas de entrada →</a>
+                <a href="#modulos">Resolver una decisión concreta →</a>
                 <a href="#recorridos">Explorar líneas de solución →</a>
                 <a href="#municipios">Municipios y ESP →</a>
                 <a href="#empresas">Empresas →</a>
@@ -71,8 +74,8 @@ export default function SolutionsPage() {
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <span className={`${styles.eyebrow} ${programStyles.eyebrow}`}>Programas estratégicos de entrada</span>
-              <h2>Dos formas de ordenar primero las decisiones.</h2>
-              <p>Estos programas no sustituyen los servicios técnicos. Organizan el punto de partida y ayudan a decidir qué capacidades conviene activar después.</p>
+              <h2>Tres formas de empezar con una base más clara.</h2>
+              <p>ESP READY ordena la preparación de una operación; GREENATICS BASE permite producir una línea base técnica desde campo; PMIRS RED convierte planes por unidad en una arquitectura común de información. Ninguno sustituye el catálogo técnico.</p>
             </div>
             <div className={programStyles.programGrid}>
               {strategicPrograms.map((program) => (
@@ -87,6 +90,35 @@ export default function SolutionsPage() {
                   <Link href={`/soluciones/programas/${program.slug}`}>Conocer {program.name} →</Link>
                 </article>
               ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={moduleStyles.modules} id="modulos">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Módulos de decisión e implementación</span>
+              <h2>No todo problema necesita convertirse en un servicio nuevo.</h2>
+              <p>Estos módulos empaquetan decisiones frecuentes y conectan capacidades ya gobernadas. Sirven para entrar por una pregunta concreta sin duplicar los 13 servicios técnicos ni prometer resultados antes de contar con evidencia.</p>
+            </div>
+            <div className={moduleStyles.moduleGrid}>
+              {commercialModules.map((module) => {
+                const relatedServices = module.relatedServiceSlugs.map((slug) => getService(slug)).filter(Boolean);
+                return (
+                  <article className={moduleStyles.moduleCard} key={module.id}>
+                    <span>{module.kicker}</span>
+                    <h3>{module.title}</h3>
+                    <p>{module.summary}</p>
+                    <div className={moduleStyles.decision}><small>Decisión que organiza</small><strong>{module.decision}</strong></div>
+                    <div className={moduleStyles.signals}>{module.signals.map((signal) => <span key={signal}>{signal}</span>)}</div>
+                    <p className={moduleStyles.guardrail}>{module.guardrail}</p>
+                    <div className={moduleStyles.moduleLinks}>
+                      <small>Servicios técnicos relacionados</small>
+                      {relatedServices.slice(0, 3).map((service) => service ? <Link href={`/soluciones/${service.slug}`} key={service.slug}><span>{service.name}</span><span>→</span></Link> : null)}
+                    </div>
+                  </article>
+                );
+              })}
             </div>
           </div>
         </section>
@@ -172,7 +204,7 @@ export default function SolutionsPage() {
         <section className={styles.guardrail}>
           <div className={`${styles.container} ${styles.guardrailGrid}`}>
             <div><span className={styles.eyebrow}>Alcance responsable</span><h2>La arquitectura orienta; el alcance contractual manda.</h2></div>
-            <p>Los programas y líneas comerciales ayudan a ordenar la conversación. Las fichas técnicas describen capacidades y entregables posibles. Cada proyecto define expresamente estudios, ingeniería, construcción, permisos, operación, personal, certificaciones, informes y responsabilidades incluidas.</p>
+            <p>Los programas y módulos comerciales ayudan a ordenar la conversación. Las fichas técnicas describen capacidades y entregables posibles. Cada proyecto define expresamente estudios, ingeniería, construcción, permisos, operación, personal, certificaciones, informes y responsabilidades incluidas.</p>
           </div>
         </section>
       </main>

--- a/src/app/soluciones/programas/[slug]/page.tsx
+++ b/src/app/soluciones/programas/[slug]/page.tsx
@@ -51,7 +51,7 @@ export default async function StrategicProgramPage({ params }: Props) {
               </div>
               <aside className={styles.detailAside}>
                 <span>Producto consultivo</span>
-                <strong>Primero claridad para decidir.</strong>
+                <strong>{program.slug === "greenatics-base" ? "Empezar ya, pero con método." : "Primero claridad para decidir."}</strong>
                 <p>{program.summary}</p>
               </aside>
             </div>
@@ -75,7 +75,7 @@ export default async function StrategicProgramPage({ params }: Props) {
         <section className={programStyles.programSection}>
           <div className={styles.container}>
             <span className={styles.eyebrow}>{program.primaryLabel}</span>
-            <h2>{program.slug === "esp-ready" ? "La preparación se revisa como un sistema." : "Cada unidad conserva su propio plan."}</h2>
+            <h2>{program.primaryHeading}</h2>
             <div className={programStyles.itemGrid}>
               {program.primaryItems.map((item, index) => <div className={programStyles.item} key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>)}
             </div>
@@ -86,7 +86,7 @@ export default async function StrategicProgramPage({ params }: Props) {
           <section className={programStyles.programSection}>
             <div className={styles.container}>
               <span className={styles.eyebrow}>{program.secondaryLabel}</span>
-              <h2>La red transforma planes separados en información comparable.</h2>
+              <h2>{program.secondaryHeading}</h2>
               <div className={programStyles.itemGrid}>
                 {program.secondaryItems.map((item, index) => <div className={programStyles.item} key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>)}
               </div>

--- a/src/app/soluciones/strategic-programs.module.css
+++ b/src/app/soluciones/strategic-programs.module.css
@@ -10,16 +10,16 @@
 
 .programGrid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   border-top: 1px solid var(--line-dark);
   border-left: 1px solid var(--line-dark);
 }
 
 .programCard {
-  min-height: 430px;
+  min-height: 470px;
   display: flex;
   flex-direction: column;
-  padding: 36px;
+  padding: 32px;
   border-right: 1px solid var(--line-dark);
   border-bottom: 1px solid var(--line-dark);
   background: rgba(255, 255, 255, .035);
@@ -34,7 +34,7 @@
   text-transform: uppercase;
 }
 
-.programCard h3 { margin-top: 18px; font-size: clamp(2.3rem, 4vw, 4rem); }
+.programCard h3 { margin-top: 18px; font-size: clamp(2.15rem, 3.2vw, 3.45rem); }
 .programCard > strong { margin-top: 16px; font-size: 1.05rem; line-height: 1.5; }
 .programCard > p { margin: 16px 0 26px; color: #b8c8bf; line-height: 1.7; }
 
@@ -127,14 +127,19 @@
 .relatedLinks { display: grid; margin-top: 32px; border-top: 1px solid var(--line); }
 .relatedLinks a { min-height: 54px; display: flex; align-items: center; justify-content: space-between; gap: 22px; border-bottom: 1px solid var(--line); color: var(--green); font-weight: 800; }
 
+@media (max-width: 1100px) {
+  .programGrid { grid-template-columns: 1fr; }
+  .programCard { min-height: auto; }
+}
+
 @media (max-width: 900px) {
-  .programGrid, .detailIntroGrid { grid-template-columns: 1fr; }
+  .detailIntroGrid { grid-template-columns: 1fr; }
   .programOutputs { grid-template-columns: repeat(2, 1fr); }
 }
 
 @media (max-width: 760px) {
   .programs, .programSection { padding: 78px 0; }
-  .programCard { min-height: auto; padding: 28px 24px; }
+  .programCard { padding: 28px 24px; }
   .itemGrid, .programOutputs { grid-template-columns: 1fr; }
   .relatedLinks a { align-items: flex-start; flex-direction: column; padding: 14px 0; }
 }

--- a/src/data/commercial-modules.test.ts
+++ b/src/data/commercial-modules.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { commercialModules } from "./commercial-modules";
+import { services } from "./services";
+
+describe("public commercial decision modules", () => {
+  it("publishes six distinct modules without creating a second technical catalog", () => {
+    expect(commercialModules).toHaveLength(6);
+    expect(new Set(commercialModules.map((module) => module.id)).size).toBe(6);
+    expect(new Set(commercialModules.map((module) => module.title)).size).toBe(6);
+  });
+
+  it("routes every module only to governed technical services", () => {
+    const serviceSlugs = new Set(services.map((service) => service.slug));
+    for (const module of commercialModules) {
+      expect(module.relatedServiceSlugs.length).toBeGreaterThan(0);
+      for (const slug of module.relatedServiceSlugs) expect(serviceSlugs.has(slug)).toBe(true);
+    }
+  });
+
+  it("keeps organics and site screening decision-first and technology-neutral", () => {
+    const organics = commercialModules.find((module) => module.id === "organicos-piloto");
+    expect(organics?.signals).toEqual(["Potencial teórico", "Separación real", "Captura efectiva", "Calidad e impropios", "Materia útil"]);
+    expect(organics?.guardrail).toMatch(/no presupone una planta ni una tecnología/i);
+
+    const sites = commercialModules.find((module) => module.id === "screening-predios");
+    expect(sites?.guardrail).toMatch(/no sustituye concepto de uso del suelo/i);
+  });
+
+  it("keeps staged accompaniment explicitly non-contractual by default", () => {
+    const module = commercialModules.find((item) => item.id === "acompanamiento-etapas");
+    expect(module?.guardrail).toMatch(/no un cronograma contractual universal/i);
+  });
+});

--- a/src/data/commercial-modules.test.ts
+++ b/src/data/commercial-modules.test.ts
@@ -5,29 +5,29 @@ import { services } from "./services";
 describe("public commercial decision modules", () => {
   it("publishes six distinct modules without creating a second technical catalog", () => {
     expect(commercialModules).toHaveLength(6);
-    expect(new Set(commercialModules.map((module) => module.id)).size).toBe(6);
-    expect(new Set(commercialModules.map((module) => module.title)).size).toBe(6);
+    expect(new Set(commercialModules.map((commercialModule) => commercialModule.id)).size).toBe(6);
+    expect(new Set(commercialModules.map((commercialModule) => commercialModule.title)).size).toBe(6);
   });
 
   it("routes every module only to governed technical services", () => {
     const serviceSlugs = new Set(services.map((service) => service.slug));
-    for (const module of commercialModules) {
-      expect(module.relatedServiceSlugs.length).toBeGreaterThan(0);
-      for (const slug of module.relatedServiceSlugs) expect(serviceSlugs.has(slug)).toBe(true);
+    for (const commercialModule of commercialModules) {
+      expect(commercialModule.relatedServiceSlugs.length).toBeGreaterThan(0);
+      for (const slug of commercialModule.relatedServiceSlugs) expect(serviceSlugs.has(slug)).toBe(true);
     }
   });
 
   it("keeps organics and site screening decision-first and technology-neutral", () => {
-    const organics = commercialModules.find((module) => module.id === "organicos-piloto");
+    const organics = commercialModules.find((commercialModule) => commercialModule.id === "organicos-piloto");
     expect(organics?.signals).toEqual(["Potencial teórico", "Separación real", "Captura efectiva", "Calidad e impropios", "Materia útil"]);
     expect(organics?.guardrail).toMatch(/no presupone una planta ni una tecnología/i);
 
-    const sites = commercialModules.find((module) => module.id === "screening-predios");
+    const sites = commercialModules.find((commercialModule) => commercialModule.id === "screening-predios");
     expect(sites?.guardrail).toMatch(/no sustituye concepto de uso del suelo/i);
   });
 
   it("keeps staged accompaniment explicitly non-contractual by default", () => {
-    const module = commercialModules.find((item) => item.id === "acompanamiento-etapas");
-    expect(module?.guardrail).toMatch(/no un cronograma contractual universal/i);
+    const stagedModule = commercialModules.find((item) => item.id === "acompanamiento-etapas");
+    expect(stagedModule?.guardrail).toMatch(/no un cronograma contractual universal/i);
   });
 });

--- a/src/data/commercial-modules.ts
+++ b/src/data/commercial-modules.ts
@@ -1,0 +1,74 @@
+export type CommercialModule = {
+  id: string;
+  kicker: string;
+  title: string;
+  summary: string;
+  decision: string;
+  signals: readonly string[];
+  relatedServiceSlugs: readonly string[];
+  guardrail: string;
+};
+
+// Commercial decision layer only. Contractual scope remains governed by services.ts.
+export const commercialModules: readonly CommercialModule[] = [
+  {
+    id: "dia-cero",
+    kicker: "Arranque operacional",
+    title: "Puesta en marcha de operación de aseo",
+    summary: "Ordena clientes, actividades, roles, jornada, rutas, vehículos, pesaje, entrega, atención y contingencias para que una operación nueva o ampliada llegue al inicio con responsabilidades y evidencias claras.",
+    decision: "¿Qué debe estar resuelto para que el servicio funcione desde el Día 0?",
+    signals: ["Clientes y actividades", "Roles y jornada", "Pesaje, entrega y evidencia", "Contingencias y cierre"],
+    relatedServiceSlugs: ["direccion-operacion", "rutas-selectivas", "trazabilidad-datos", "operacion-integral"],
+    guardrail: "Diseñar o acompañar la puesta en marcha no implica por sí mismo que Greenatics asuma la condición de prestador ni todas las actividades del servicio.",
+  },
+  {
+    id: "rutas-flota",
+    kicker: "Logística",
+    title: "Rutas, flota y continuidad operativa",
+    summary: "Dimensiona la logística a partir de demanda y condiciones reales: usuarios, toneladas, frecuencias, accesos, ventanas horarias, distancias, tiempos, destino, capacidad efectiva y respaldo.",
+    decision: "¿Qué configuración logística soporta la demanda sin sobredimensionar la operación?",
+    signals: ["Usuarios y toneladas", "Frecuencias y ventanas", "Distancias y tiempos", "Capacidad efectiva y respaldo"],
+    relatedServiceSlugs: ["rutas-selectivas", "motocarguero", "direccion-operacion", "trazabilidad-datos"],
+    guardrail: "La flota no se prescribe ni se compra desde supuestos: primero se valida demanda, recorrido, destino y continuidad requerida.",
+  },
+  {
+    id: "organicos-piloto",
+    kicker: "Orgánicos",
+    title: "Programa de orgánicos: captura real y piloto",
+    summary: "Separa el potencial teórico de la corriente que realmente puede separarse, capturarse con calidad y llegar como materia útil a un esquema de gestión o tratamiento.",
+    decision: "¿Cuánto orgánico útil existe realmente y qué piloto conviene validar antes de escalar?",
+    signals: ["Potencial teórico", "Separación real", "Captura efectiva", "Calidad e impropios", "Materia útil"],
+    relatedServiceSlugs: ["diagnostico-caracterizacion", "rutas-selectivas", "motocarguero", "recoleccion-tratamiento", "prefactibilidad"],
+    guardrail: "El módulo no presupone una planta ni una tecnología. El tratamiento se define después de validar cantidad, calidad, continuidad, logística y destino.",
+  },
+  {
+    id: "prefactibilidad-decision",
+    kicker: "Inversión",
+    title: "Prefactibilidad de decisiones de infraestructura",
+    summary: "Compara alternativas antes de comprometer inversión en transferencia, tratamiento, ampliaciones, nueva infraestructura o tecnología, incluyendo cuando aplique la alternativa de no construir.",
+    decision: "¿Existe evidencia suficiente para seguir, esperar, rediseñar o descartar?",
+    signals: ["SEGUIR", "ESPERAR", "REDISEÑAR", "DESCARTAR"],
+    relatedServiceSlugs: ["prefactibilidad", "factibilidad-ingenieria", "rehabilitacion"],
+    guardrail: "La prefactibilidad orienta la decisión y sus siguientes estudios; no equivale automáticamente a factibilidad, ingeniería de detalle, permiso o decisión de inversión.",
+  },
+  {
+    id: "screening-predios",
+    kicker: "Localización",
+    title: "Screening técnico de predios",
+    summary: "Revisión preliminar de compatibilidad física y operativa antes de comprometer un predio para infraestructura de residuos: accesos, distancias, entorno sensible, servicios, riesgos, restricciones, movilidad, expansión y proceso previsto.",
+    decision: "¿Qué predios merecen avanzar a verificaciones y estudios de mayor profundidad?",
+    signals: ["Accesos y distancias", "Entorno y restricciones", "Servicios y riesgos", "Expansión y proceso"],
+    relatedServiceSlugs: ["prefactibilidad", "factibilidad-ingenieria"],
+    guardrail: "Es un screening técnico preliminar. No sustituye concepto de uso del suelo, estudio jurídico, licencia, permiso ni pronunciamiento de autoridad competente.",
+  },
+  {
+    id: "acompanamiento-etapas",
+    kicker: "Continuidad",
+    title: "Acompañamiento por etapas",
+    summary: "Permite activar primero las brechas críticas y, a medida que aparece evidencia, avanzar hacia procesos, capacitación, trazabilidad, pilotos, optimización, prefactibilidades e infraestructura.",
+    decision: "¿Qué conviene activar ahora y qué debe esperar a que exista mejor información?",
+    signals: ["Cerrar brechas críticas", "Implementar y medir", "Pilotear y ajustar", "Madurar proyectos"],
+    relatedServiceSlugs: ["direccion-operacion", "trazabilidad-datos", "pgirs", "pmirs", "prefactibilidad"],
+    guardrail: "Las etapas son una lógica de maduración, no un cronograma contractual universal. Plazos, responsables y entregables se definen para cada proyecto.",
+  },
+] as const;

--- a/src/data/public-indexing.test.ts
+++ b/src/data/public-indexing.test.ts
@@ -23,6 +23,7 @@ describe("public navigation and indexing contract", () => {
 
     expect(entries).toHaveLength(expectedCount);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/esp-ready`);
+    expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/greenatics-base`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/pmirs-red`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/diagnostico-caracterizacion`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/proyectos/yarumal`);

--- a/src/data/strategic-programs.test.ts
+++ b/src/data/strategic-programs.test.ts
@@ -3,8 +3,8 @@ import { services } from "./services";
 import { getStrategicProgram, strategicPrograms } from "./strategic-programs";
 
 describe("strategic public programs", () => {
-  it("publishes only ESP READY and PMIRS RED in this wave", () => {
-    expect(strategicPrograms.map((program) => program.slug)).toEqual(["esp-ready", "pmirs-red"]);
+  it("publishes ESP READY, GREENATICS BASE and PMIRS RED as distinct entry products", () => {
+    expect(strategicPrograms.map((program) => program.slug)).toEqual(["esp-ready", "greenatics-base", "pmirs-red"]);
   });
 
   it("keeps every related service grounded in the governed registry", () => {
@@ -30,6 +30,21 @@ describe("strategic public programs", () => {
       "Infraestructura futura",
     ]);
     expect(program?.outputs).toEqual(["Estado actual", "Brechas", "Prioridades", "Hoja de ruta"]);
+  });
+
+  it("keeps GREENATICS BASE as technical baseline rather than regulatory aforo or PMIRS", () => {
+    const program = getStrategicProgram("greenatics-base");
+    expect(program?.primaryItems).toEqual([
+      "Línea base de generación",
+      "Caracterización de residuos",
+      "Diagnóstico de infraestructura",
+      "Lectura operativa del proyecto",
+      "Captura digital y evidencia",
+      "Consolidación y análisis",
+    ]);
+    expect(program?.secondaryItems).toContain("Aforo regulatorio");
+    expect(program?.secondaryItems).toContain("PMIRS completo");
+    expect(program?.sourceNote).toMatch(/alcance independiente conforme al procedimiento aplicable/i);
   });
 
   it("keeps PMIRS RED unit and network layers separate", () => {

--- a/src/data/strategic-programs.ts
+++ b/src/data/strategic-programs.ts
@@ -1,13 +1,15 @@
 export type StrategicProgram = {
-  slug: "esp-ready" | "pmirs-red";
+  slug: "esp-ready" | "greenatics-base" | "pmirs-red";
   name: string;
   audience: string;
   headline: string;
   summary: string;
   principle: string;
   primaryLabel: string;
+  primaryHeading: string;
   primaryItems: readonly string[];
   secondaryLabel?: string;
+  secondaryHeading?: string;
   secondaryItems?: readonly string[];
   outputs: readonly string[];
   relatedServiceSlugs: readonly string[];
@@ -24,6 +26,7 @@ export const strategicPrograms: readonly StrategicProgram[] = [
     summary: "Diagnóstico integral para ordenar el estado real de una operación, sus brechas, prioridades y decisiones antes de acelerar cobertura, infraestructura o valorización.",
     principle: "No es una auditoría para buscar errores. Es un diagnóstico para saber qué está listo y qué conviene cerrar.",
     primaryLabel: "Revisamos diez dimensiones de preparación",
+    primaryHeading: "La preparación se revisa como un sistema.",
     primaryItems: [
       "Regulación",
       "Clientes",
@@ -48,6 +51,43 @@ export const strategicPrograms: readonly StrategicProgram[] = [
     cta: "Evaluar preparación de una ESP",
   },
   {
+    slug: "greenatics-base",
+    name: "GREENATICS BASE",
+    audience: "ESP, redes multiunidad y organizaciones que necesitan producir una línea base",
+    headline: "Empieza a producir información real mientras estructuras lo que sigue.",
+    summary: "Sistema dirigido de línea base, caracterización y lectura operativa para convertir trabajo de campo en información comparable, reutilizable y sometida a control de calidad.",
+    principle: "Empezamos ya, pero con método: campo y estructuración pueden avanzar en paralelo sin confundir medición técnica con conclusiones regulatorias.",
+    primaryLabel: "Sistema dirigido de información",
+    primaryHeading: "No es solo medir. Es construir una primera base técnica reutilizable.",
+    primaryItems: [
+      "Línea base de generación",
+      "Caracterización de residuos",
+      "Diagnóstico de infraestructura",
+      "Lectura operativa del proyecto",
+      "Captura digital y evidencia",
+      "Consolidación y análisis",
+    ],
+    secondaryLabel: "Alcance y precisión",
+    secondaryHeading: "La línea base técnica no sustituye otros estudios o procedimientos.",
+    secondaryItems: [
+      "PMIRS completo",
+      "Aforo regulatorio",
+      "Estudio tarifario",
+      "Diseño final de rutas",
+      "Ingeniería",
+      "Permisos",
+    ],
+    outputs: ["Ficha GREENATICS BASE", "Base consolidada", "Evidencias organizadas", "Insumos para PMIRS y operación"],
+    relatedServiceSlugs: [
+      "diagnostico-caracterizacion",
+      "pmirs",
+      "rutas-selectivas",
+      "trazabilidad-datos",
+    ],
+    sourceNote: "GREENATICS BASE generaliza la metodología desarrollada para RED BELLO: línea base técnica, medición, caracterización, diagnóstico operativo, consolidación y análisis. No es por sí misma PMIRS, aforo regulatorio, estudio tarifario, diseño final de rutas, ingeniería ni permiso. Si se requiere aforo regulatorio, debe estructurarse como un alcance independiente conforme al procedimiento aplicable.",
+    cta: "Activar una línea base técnica",
+  },
+  {
     slug: "pmirs-red",
     name: "PMIRS RED",
     audience: "Redes de propiedad horizontal, grandes generadores y operadores",
@@ -55,8 +95,10 @@ export const strategicPrograms: readonly StrategicProgram[] = [
     summary: "Metodología para formular e implementar PMIRS bajo un estándar común, de modo que cada unidad reciba su plan y la red pueda consolidar información comparable para operación y decisiones posteriores.",
     principle: "El cumplimiento puede convertirse en inteligencia operativa cuando la información se levanta bajo una estructura común.",
     primaryLabel: "Cada unidad puede recibir",
+    primaryHeading: "Cada unidad conserva su propio plan.",
     primaryItems: ["Diagnóstico", "Caracterización", "Programas", "Implementación", "Indicadores", "Seguimiento"],
     secondaryLabel: "La red puede consolidar",
+    secondaryHeading: "La red transforma planes separados en información comparable.",
     secondaryItems: ["Demanda", "Ubicación", "Composición", "Accesos", "Horarios", "Orgánicos", "Aprovechables", "Oportunidades"],
     outputs: ["PMIRS implementables", "Base consolidada", "Indicadores comparables", "Ruta de seguimiento"],
     relatedServiceSlugs: [


### PR DESCRIPTION
## Objetivo
Convertir nuevos aprendizajes del trabajo estratégico/jurídico de aseo en una segunda capa comercial pública sin duplicar el catálogo técnico de 13 servicios.

## Cambios
- añade `GREENATICS BASE` como tercer programa estratégico público;
- generaliza la ficha de programas para soportar headings y capas propias sin condicionales de contenido rígidos;
- GREENATICS BASE conserva su alcance fuente: línea base, caracterización, diagnóstico operativo, captura/evidencia, consolidación y análisis;
- fija expresamente que GREENATICS BASE no es por sí misma PMIRS completo, aforo regulatorio, estudio tarifario, diseño final de rutas, ingeniería ni permisos;
- añade seis módulos de decisión/implementación que reutilizan servicios gobernados: puesta en marcha de operación de aseo; rutas/flota/continuidad; programa de orgánicos; prefactibilidad de infraestructura; screening técnico de predios; acompañamiento por etapas;
- cada módulo incluye decisión, señales, servicios relacionados y guardrail propio;
- ajusta lenguaje del hub para no usar `aprovechamiento` como destino genérico de cualquier corriente;
- amplía unit y E2E para fijar arquitectura, scope y navegación;
- el sitemap incorpora GREENATICS BASE automáticamente desde `strategicPrograms`.

## Guardrails
- no modifica `services.ts` ni crea un segundo catálogo técnico;
- no publica precios ni condiciones del caso ECO ABURRÁ / RED BELLO;
- no presenta medición técnica como aforo regulatorio;
- no presenta screening de predios como concepto de uso del suelo, licencia, permiso o estudio jurídico;
- no presupone planta/tecnología para orgánicos;
- no convierte etapas orientativas en cronogramas contractuales;
- cero cambios OPS/Auth/Supabase/RLS/migraciones/Product Truth/Crop Truth/Casa y Jardín.