### PR TITLE
feat(public): crear landings maestras por audiencia B2B

### DIFF
--- a/e2e/public-audience-solutions.spec.ts
+++ b/e2e/public-audience-solutions.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "@playwright/test";
+
+async function jsonLdByType(page: import("@playwright/test").Page, type: string) {
+  const payloads = await page.locator('script[type="application/ld+json"]').allTextContents();
+  return payloads
+    .map((payload) => JSON.parse(payload) as Record<string, unknown>)
+    .filter((payload) => payload["@type"] === type);
+}
+
+test("solutions hub exposes dedicated audience routes instead of internal-only anchors", async ({ page }) => {
+  await page.goto("/soluciones");
+
+  await expect(page.getByRole("link", { name: "Municipios y ESP →" })).toHaveAttribute("href", "/soluciones/esp-municipios");
+  await expect(page.getByRole("link", { name: "Empresas →" })).toHaveAttribute("href", "/soluciones/empresas-grandes-generadores");
+  await expect(page.getByRole("link", { name: /Ver ruta para ESP y municipios/ })).toHaveAttribute("href", "/soluciones/esp-municipios");
+  await expect(page.getByRole("link", { name: /Ver ruta para empresas/ })).toHaveAttribute("href", "/soluciones/empresas-grandes-generadores");
+});
+
+test("ESP and municipalities landing routes decisions to governed programs and services", async ({ page }) => {
+  await page.goto("/soluciones/esp-municipios");
+
+  await expect(page.getByRole("heading", { name: "De la planeación a una operación preparada para crecer." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "No necesitas conocer el nombre del servicio." })).toBeVisible();
+  await expect(page.getByText("ESP READY", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("GREENATICS BASE", { exact: true }).first()).toBeVisible();
+  await expect(page.getByRole("link", { name: "ESP READY →" })).toHaveAttribute("href", "/soluciones/programas/esp-ready");
+  await expect(page.getByRole("link", { name: "PGIRS →" })).toHaveAttribute("href", "/soluciones/pgirs");
+  await expect(page.getByRole("link", { name: "Prefactibilidad →" })).toHaveAttribute("href", "/soluciones/prefactibilidad");
+  await expect(page.getByRole("heading", { name: "Puesta en marcha de operación de aseo" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Programa de orgánicos: captura real y piloto" })).toBeVisible();
+  await expect(page.getByText(/no implica por sí mismo que Greenatics asuma la condición de prestador/i)).toBeVisible();
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", "https://greenatics.com.co/soluciones/esp-municipios");
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/esp-municipios");
+});
+
+test("enterprise and large-generator landing routes PMIRS, organics and data without ESP READY", async ({ page }) => {
+  await page.goto("/soluciones/empresas-grandes-generadores");
+
+  await expect(page.getByRole("heading", { name: "De cumplimiento aislado a gestión medible y circular." })).toBeVisible();
+  await expect(page.getByText("PMIRS RED", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("ESP READY", { exact: true })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "PMIRS y planes internos →" })).toHaveAttribute("href", "/soluciones/pmirs");
+  await expect(page.getByRole("link", { name: "PMIRS RED →" })).toHaveAttribute("href", "/soluciones/programas/pmirs-red");
+  await expect(page.getByRole("link", { name: "Gestión, recolección y tratamiento →" })).toHaveAttribute("href", "/soluciones/recoleccion-tratamiento");
+  await expect(page.getByRole("link", { name: "Trazabilidad digital y GREENATICS OPS →" })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
+  await expect(page.getByRole("heading", { name: "Programa de orgánicos: captura real y piloto" })).toBeVisible();
+  await expect(page.getByText(/no presupone una planta ni una tecnología/i)).toBeVisible();
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", "https://greenatics.com.co/soluciones/empresas-grandes-generadores");
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/empresas-grandes-generadores");
+});

--- a/e2e/public-audience-solutions.spec.ts
+++ b/e2e/public-audience-solutions.spec.ts
@@ -10,8 +10,8 @@ async function jsonLdByType(page: import("@playwright/test").Page, type: string)
 test("solutions hub exposes dedicated audience routes instead of internal-only anchors", async ({ page }) => {
   await page.goto("/soluciones");
 
-  await expect(page.getByRole("link", { name: "Municipios y ESP →" })).toHaveAttribute("href", "/soluciones/esp-municipios");
-  await expect(page.getByRole("link", { name: "Empresas →" })).toHaveAttribute("href", "/soluciones/empresas-grandes-generadores");
+  await expect(page.getByRole("link", { name: "Municipios y ESP →", exact: true })).toHaveAttribute("href", "/soluciones/esp-municipios");
+  await expect(page.getByRole("link", { name: "Empresas →", exact: true })).toHaveAttribute("href", "/soluciones/empresas-grandes-generadores");
   await expect(page.getByRole("link", { name: /Ver ruta para ESP y municipios/ })).toHaveAttribute("href", "/soluciones/esp-municipios");
   await expect(page.getByRole("link", { name: /Ver ruta para empresas/ })).toHaveAttribute("href", "/soluciones/empresas-grandes-generadores");
 });
@@ -23,9 +23,9 @@ test("ESP and municipalities landing routes decisions to governed programs and s
   await expect(page.getByRole("heading", { name: "No necesitas conocer el nombre del servicio." })).toBeVisible();
   await expect(page.getByText("ESP READY", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("GREENATICS BASE", { exact: true }).first()).toBeVisible();
-  await expect(page.getByRole("link", { name: "ESP READY →" })).toHaveAttribute("href", "/soluciones/programas/esp-ready");
-  await expect(page.getByRole("link", { name: "PGIRS →" })).toHaveAttribute("href", "/soluciones/pgirs");
-  await expect(page.getByRole("link", { name: "Prefactibilidad →" })).toHaveAttribute("href", "/soluciones/prefactibilidad");
+  await expect(page.getByRole("link", { name: "ESP READY →", exact: true })).toHaveAttribute("href", "/soluciones/programas/esp-ready");
+  await expect(page.getByRole("link", { name: "PGIRS →", exact: true })).toHaveAttribute("href", "/soluciones/pgirs");
+  await expect(page.getByRole("link", { name: "Prefactibilidad →", exact: true })).toHaveAttribute("href", "/soluciones/prefactibilidad");
   await expect(page.getByRole("heading", { name: "Puesta en marcha de operación de aseo" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Programa de orgánicos: captura real y piloto" })).toBeVisible();
   await expect(page.getByText(/no implica por sí mismo que Greenatics asuma la condición de prestador/i)).toBeVisible();
@@ -41,10 +41,10 @@ test("enterprise and large-generator landing routes PMIRS, organics and data wit
   await expect(page.getByRole("heading", { name: "De cumplimiento aislado a gestión medible y circular." })).toBeVisible();
   await expect(page.getByText("PMIRS RED", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("ESP READY", { exact: true })).toHaveCount(0);
-  await expect(page.getByRole("link", { name: "PMIRS y planes internos →" })).toHaveAttribute("href", "/soluciones/pmirs");
-  await expect(page.getByRole("link", { name: "PMIRS RED →" })).toHaveAttribute("href", "/soluciones/programas/pmirs-red");
-  await expect(page.getByRole("link", { name: "Gestión, recolección y tratamiento →" })).toHaveAttribute("href", "/soluciones/recoleccion-tratamiento");
-  await expect(page.getByRole("link", { name: "Trazabilidad digital y GREENATICS OPS →" })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
+  await expect(page.getByRole("link", { name: "PMIRS y planes internos →", exact: true })).toHaveAttribute("href", "/soluciones/pmirs");
+  await expect(page.getByRole("link", { name: "PMIRS RED →", exact: true })).toHaveAttribute("href", "/soluciones/programas/pmirs-red");
+  await expect(page.getByRole("link", { name: "Gestión, recolección y tratamiento →", exact: true })).toHaveAttribute("href", "/soluciones/recoleccion-tratamiento");
+  await expect(page.getByRole("link", { name: "Trazabilidad digital y GREENATICS OPS →", exact: true })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
   await expect(page.getByRole("heading", { name: "Programa de orgánicos: captura real y piloto" })).toBeVisible();
   await expect(page.getByText(/no presupone una planta ni una tecnología/i)).toBeVisible();
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", "https://greenatics.com.co/soluciones/empresas-grandes-generadores");

--- a/e2e/public-shell-seo.spec.ts
+++ b/e2e/public-shell-seo.spec.ts
@@ -7,6 +7,8 @@ const shellRoutes = [
   "/wondergreen/cultivos/cafe",
   "/casa-jardin",
   "/soluciones",
+  "/soluciones/esp-municipios",
+  "/soluciones/empresas-grandes-generadores",
   "/soluciones/diagnostico-caracterizacion",
   "/proyectos",
   "/proyectos/yarumal",
@@ -65,6 +67,8 @@ test("sitemap exposes public routes and robots blocks OPS", async ({ request }) 
   const sitemap = await request.get("/sitemap.xml");
   expect(sitemap.ok()).toBe(true);
   const sitemapText = await sitemap.text();
+  expect(sitemapText).toContain("https://greenatics.com.co/soluciones/esp-municipios");
+  expect(sitemapText).toContain("https://greenatics.com.co/soluciones/empresas-grandes-generadores");
   expect(sitemapText).toContain("https://greenatics.com.co/soluciones/diagnostico-caracterizacion");
   expect(sitemapText).toContain("https://greenatics.com.co/proyectos/yarumal");
   expect(sitemapText).toContain("https://greenatics.com.co/wondergreen/cultivos/cafe");

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { audienceSolutionPaths } from "@/data/audience-landings";
 import { publicProjects } from "@/data/projects-public";
 import { publicSite, publicStaticRoutes } from "@/data/public-site";
 import { services } from "@/data/services";
@@ -25,6 +26,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     entry(path, path === "/" ? 1 : 0.8, path === "/" ? "weekly" : "monthly"),
   );
 
+  const audienceEntries = audienceSolutionPaths.map((path) =>
+    entry(path, 0.82, "monthly"),
+  );
+
   const strategicProgramEntries = strategicPrograms.map((program) =>
     entry(`/soluciones/programas/${program.slug}`, 0.78, "monthly"),
   );
@@ -45,5 +50,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
     entry(`/wondergreen/productos/${reference.slug}`, reference.truthStatus === "commercial-reconciled" ? 0.76 : 0.64, "monthly"),
   );
 
-  return [...staticEntries, ...strategicProgramEntries, ...serviceEntries, ...projectEntries, ...cropEntries, ...productEntries];
+  return [...staticEntries, ...audienceEntries, ...strategicProgramEntries, ...serviceEntries, ...projectEntries, ...cropEntries, ...productEntries];
 }

--- a/src/app/soluciones/empresas-grandes-generadores/page.tsx
+++ b/src/app/soluciones/empresas-grandes-generadores/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
+import { getAudienceLanding } from "@/data/audience-landings";
+
+const landing = getAudienceLanding("empresas-grandes-generadores");
+
+export const metadata: Metadata = {
+  title: "Soluciones para empresas y grandes generadores | Greenatics",
+  description: "Línea base, PMIRS, redes multiunidad, separación, recolección, tratamiento, trazabilidad e infraestructura para empresas y grandes generadores.",
+  alternates: { canonical: "/soluciones/empresas-grandes-generadores" },
+};
+
+export default function EmpresasGrandesGeneradoresPage() {
+  if (!landing) return null;
+  return <AudienceSolutionLanding landing={landing} />;
+}

--- a/src/app/soluciones/esp-municipios/page.tsx
+++ b/src/app/soluciones/esp-municipios/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
+import { getAudienceLanding } from "@/data/audience-landings";
+
+const landing = getAudienceLanding("esp-municipios");
+
+export const metadata: Metadata = {
+  title: "Soluciones para ESP y municipios | Greenatics",
+  description: "Preparación, línea base, PGIRS, rutas, operación, orgánicos, datos e infraestructura para municipios y empresas de servicios públicos.",
+  alternates: { canonical: "/soluciones/esp-municipios" },
+};
+
+export default function EspMunicipiosPage() {
+  if (!landing) return null;
+  return <AudienceSolutionLanding landing={landing} />;
+}

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -44,8 +44,8 @@ export default function SolutionsPage() {
                 <a href="#programas">Ver programas de entrada →</a>
                 <a href="#modulos">Resolver una decisión concreta →</a>
                 <a href="#recorridos">Explorar líneas de solución →</a>
-                <a href="#municipios">Municipios y ESP →</a>
-                <a href="#empresas">Empresas →</a>
+                <Link href="/soluciones/esp-municipios">Municipios y ESP →</Link>
+                <Link href="/soluciones/empresas-grandes-generadores">Empresas →</Link>
               </div>
             </div>
             <aside className={styles.heroProof}>
@@ -160,13 +160,13 @@ export default function SolutionsPage() {
                 <div className={styles.audienceIndex}>01</div>
                 <div><span className={styles.eyebrow}>Municipios y ESP</span><h3>De la planeación a una operación preparada para crecer.</h3><p>Diagnóstico, PGIRS, rutas, operación, datos, infraestructura y valorización para convertir metas o nuevas oportunidades en capacidad real.</p></div>
                 <div className={styles.audienceFacts}><strong>{municipalServices.length}</strong><span>servicios aplicables</span><small>Primero claridad de modelo · luego operación e inversión.</small></div>
-                <a href="#planeación">Ver catálogo técnico →</a>
+                <Link href="/soluciones/esp-municipios">Ver ruta para ESP y municipios →</Link>
               </article>
               <article className={styles.audienceCard} id="empresas">
                 <div className={styles.audienceIndex}>02</div>
                 <div><span className={styles.eyebrow}>Empresas y grandes generadores</span><h3>De cumplimiento aislado a gestión medible y circular.</h3><p>Caracterización, PMIRS, redes multiunidad, separación, recolección, tratamiento, infraestructura y evidencia de gestión según cada corriente.</p></div>
                 <div className={styles.audienceFacts}><strong>{companyServices.length}</strong><span>servicios aplicables</span><small>Información una vez · gestión y seguimiento sobre la misma base.</small></div>
-                <a href="#planeación">Ver catálogo técnico →</a>
+                <Link href="/soluciones/empresas-grandes-generadores">Ver ruta para empresas →</Link>
               </article>
             </div>
           </div>

--- a/src/components/audience-solution-landing.tsx
+++ b/src/components/audience-solution-landing.tsx
@@ -22,7 +22,7 @@ export function AudienceSolutionLanding({ landing }: { landing: AudienceLanding 
       <BreadcrumbJsonLd items={[
         { name: "Greenatics", path: "/" },
         { name: "Soluciones", path: "/soluciones" },
-        { name: landing.audience, path: `/soluciones/${landing.slug}` },
+        { name: landing.audience, path: `/soluciones/${landing.slug}` as `/${string}` },
       ]} />
       <main>
         <section className={styles.hero}>

--- a/src/components/audience-solution-landing.tsx
+++ b/src/components/audience-solution-landing.tsx
@@ -1,0 +1,181 @@
+import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import type { AudienceLanding } from "@/data/audience-landings";
+import { commercialModules } from "@/data/commercial-modules";
+import { getService } from "@/data/services";
+import { strategicPrograms } from "@/data/strategic-programs";
+import styles from "@/app/soluciones/solutions.module.css";
+import refresh from "@/app/soluciones/solutions-refresh.module.css";
+import programStyles from "@/app/soluciones/strategic-programs.module.css";
+import moduleStyles from "@/app/soluciones/commercial-modules.module.css";
+
+export function AudienceSolutionLanding({ landing }: { landing: AudienceLanding }) {
+  const programs = landing.programSlugs
+    .map((slug) => strategicPrograms.find((program) => program.slug === slug))
+    .filter(Boolean);
+  const modules = landing.moduleIds
+    .map((id) => commercialModules.find((commercialModule) => commercialModule.id === id))
+    .filter(Boolean);
+
+  return (
+    <div className={`${styles.page} ${refresh.page}`}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Soluciones", path: "/soluciones" },
+        { name: landing.audience, path: `/soluciones/${landing.slug}` },
+      ]} />
+      <main>
+        <section className={styles.hero}>
+          <div className={styles.heroAccent} aria-hidden="true" />
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>{landing.eyebrow}</span>
+              <h1>{landing.title}</h1>
+              <p className={styles.lead}>{landing.lead}</p>
+              <div className={styles.heroLinks}>
+                <a href="#decisiones">Encontrar punto de entrada →</a>
+                <a href="#programas">Ver programas aplicables →</a>
+                <a href="#etapas">Ver ruta por etapas →</a>
+                <Link href="/contacto">Hablar con Greenatics →</Link>
+              </div>
+            </div>
+            <aside className={styles.heroProof}>
+              <span>{landing.audience}</span>
+              <strong>{landing.proofTitle}</strong>
+              <p>{landing.proofCopy}</p>
+            </aside>
+          </div>
+        </section>
+
+        <section className={styles.path} aria-label={`Ruta Greenatics para ${landing.audience}`}>
+          <div className={`${styles.container} ${styles.pathGrid} ${refresh.businessPath}`}>
+            {landing.path.map((item, index) => (
+              <div key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.journeys} id="decisiones">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Empieza por la situación actual</span>
+              <h2>No necesitas conocer el nombre del servicio.</h2>
+              <p>Ubica primero la decisión que tienes abierta. Cada entrada conduce a un programa o servicio ya gobernado; esta página no crea un catálogo paralelo.</p>
+            </div>
+            <div className={styles.journeyGrid}>
+              {landing.decisions.map((decision, index) => (
+                <article className={styles.journeyCard} key={decision.situation}>
+                  <span className={styles.journeyNumber}>{String(index + 1).padStart(2, "0")}</span>
+                  <small>Si estás aquí</small>
+                  <h3>{decision.situation}</h3>
+                  <p>{decision.copy}</p>
+                  <div className={styles.journeyLinks}>
+                    <Link href={decision.href}>{decision.startWith} →</Link>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={programStyles.programs} id="programas">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <span className={`${styles.eyebrow} ${programStyles.eyebrow}`}>Programas de entrada más relevantes</span>
+              <h2>Programas para ordenar el inicio antes de desplegar servicios.</h2>
+              <p>Los programas empaquetan una primera etapa de trabajo. El alcance contractual y los servicios técnicos relacionados permanecen gobernados por sus fichas específicas.</p>
+            </div>
+            <div className={programStyles.programGrid}>
+              {programs.map((program) => program ? (
+                <article className={programStyles.programCard} key={program.slug}>
+                  <span>{program.audience}</span>
+                  <h3>{program.name}</h3>
+                  <strong>{program.headline}</strong>
+                  <p>{program.summary}</p>
+                  <div className={programStyles.outputFlow}>{program.outputs.map((output) => <span key={output}>{output}</span>)}</div>
+                  <Link href={`/soluciones/programas/${program.slug}`}>Conocer {program.name} →</Link>
+                </article>
+              ) : null)}
+            </div>
+          </div>
+        </section>
+
+        <section className={moduleStyles.modules} id="modulos">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Decisiones frecuentes</span>
+              <h2>Módulos para resolver preguntas concretas sin inventar servicios nuevos.</h2>
+              <p>Seleccionamos únicamente los módulos útiles para esta audiencia y los conectamos con los servicios técnicos que realmente los soportan.</p>
+            </div>
+            <div className={moduleStyles.moduleGrid}>
+              {modules.map((commercialModule) => {
+                if (!commercialModule) return null;
+                const relatedServices = commercialModule.relatedServiceSlugs.map((slug) => getService(slug)).filter(Boolean);
+                return (
+                  <article className={moduleStyles.moduleCard} key={commercialModule.id}>
+                    <span>{commercialModule.kicker}</span>
+                    <h3>{commercialModule.title}</h3>
+                    <p>{commercialModule.summary}</p>
+                    <div className={moduleStyles.decision}><small>Decisión que organiza</small><strong>{commercialModule.decision}</strong></div>
+                    <div className={moduleStyles.signals}>{commercialModule.signals.map((signal) => <span key={signal}>{signal}</span>)}</div>
+                    <p className={moduleStyles.guardrail}>{commercialModule.guardrail}</p>
+                    <div className={moduleStyles.moduleLinks}>
+                      <small>Servicios técnicos relacionados</small>
+                      {relatedServices.slice(0, 3).map((service) => service ? (
+                        <Link href={`/soluciones/${service.slug}`} key={service.slug}><span>{service.name}</span><span>→</span></Link>
+                      ) : null)}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.audience} id="etapas">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Ruta por madurez</span>
+              <h2>El siguiente paso depende de la etapa, no de una lista fija de compras.</h2>
+              <p>Los servicios pueden contratarse por fase. La secuencia muestra qué capacidades suelen volverse relevantes a medida que aparece mejor información.</p>
+            </div>
+            <div className={styles.audienceGrid}>
+              {landing.stages.map((stage) => (
+                <article className={styles.audienceCard} key={stage.number}>
+                  <div className={styles.audienceIndex}>{stage.number}</div>
+                  <div>
+                    <span className={styles.eyebrow}>{stage.kicker}</span>
+                    <h3>{stage.title}</h3>
+                    <p>{stage.copy}</p>
+                  </div>
+                  <div className={styles.audienceFacts}>
+                    <strong>{stage.serviceSlugs.length}</strong>
+                    <span>capacidades relacionadas</span>
+                    <small>{stage.serviceSlugs.map((slug) => getService(slug)?.name).filter(Boolean).join(" · ")}</small>
+                  </div>
+                  <Link href={`/soluciones/${stage.serviceSlugs[0]}`}>Abrir primera ficha →</Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.guardrail}>
+          <div className={`${styles.container} ${styles.guardrailGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Siguiente conversación</span>
+              <h2>{landing.ctaTitle}</h2>
+            </div>
+            <div>
+              <p>{landing.ctaCopy}</p>
+              <div className={styles.heroLinks}>
+                <Link href="/contacto">Preparar conversación →</Link>
+                <Link href="/soluciones">Volver al portafolio completo →</Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/data/audience-landings.test.ts
+++ b/src/data/audience-landings.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { audienceLandings, audienceSolutionPaths } from "./audience-landings";
+import { commercialModules } from "./commercial-modules";
+import { services } from "./services";
+import { strategicPrograms } from "./strategic-programs";
+
+const serviceSlugs = new Set(services.map((service) => service.slug));
+const programSlugs = new Set(strategicPrograms.map((program) => program.slug));
+const moduleIds = new Set(commercialModules.map((commercialModule) => commercialModule.id));
+
+describe("audience solution landings", () => {
+  it("defines exactly the two master B2B audience routes", () => {
+    expect(audienceLandings).toHaveLength(2);
+    expect(audienceSolutionPaths).toEqual([
+      "/soluciones/esp-municipios",
+      "/soluciones/empresas-grandes-generadores",
+    ]);
+  });
+
+  it("reuses governed programs, modules and services without creating parallel product truth", () => {
+    for (const landing of audienceLandings) {
+      for (const slug of landing.programSlugs) expect(programSlugs.has(slug)).toBe(true);
+      for (const id of landing.moduleIds) expect(moduleIds.has(id)).toBe(true);
+      for (const stage of landing.stages) {
+        expect(stage.serviceSlugs.length).toBeGreaterThan(0);
+        for (const slug of stage.serviceSlugs) expect(serviceSlugs.has(slug)).toBe(true);
+      }
+    }
+  });
+
+  it("keeps the ESP route centered on ESP READY and the enterprise route centered on PMIRS RED", () => {
+    const esp = audienceLandings.find((landing) => landing.slug === "esp-municipios");
+    const companies = audienceLandings.find((landing) => landing.slug === "empresas-grandes-generadores");
+
+    expect(esp?.programSlugs).toContain("esp-ready");
+    expect(esp?.programSlugs).not.toContain("pmirs-red");
+    expect(companies?.programSlugs).toContain("pmirs-red");
+    expect(companies?.programSlugs).not.toContain("esp-ready");
+  });
+
+  it("routes every decision to an existing governed public destination", () => {
+    const knownPaths = new Set([
+      ...services.map((service) => `/soluciones/${service.slug}`),
+      ...strategicPrograms.map((program) => `/soluciones/programas/${program.slug}`),
+    ]);
+
+    for (const landing of audienceLandings) {
+      expect(landing.decisions).toHaveLength(6);
+      for (const decision of landing.decisions) expect(knownPaths.has(decision.href)).toBe(true);
+    }
+  });
+});

--- a/src/data/audience-landings.ts
+++ b/src/data/audience-landings.ts
@@ -1,0 +1,187 @@
+export type AudienceDecision = {
+  situation: string;
+  startWith: string;
+  copy: string;
+  href: `/${string}`;
+};
+
+export type AudienceStage = {
+  number: string;
+  kicker: string;
+  title: string;
+  copy: string;
+  serviceSlugs: readonly string[];
+};
+
+export type AudienceLanding = {
+  slug: "esp-municipios" | "empresas-grandes-generadores";
+  audience: string;
+  eyebrow: string;
+  title: string;
+  lead: string;
+  proofTitle: string;
+  proofCopy: string;
+  path: readonly string[];
+  decisions: readonly AudienceDecision[];
+  programSlugs: readonly ("esp-ready" | "greenatics-base" | "pmirs-red")[];
+  moduleIds: readonly string[];
+  stages: readonly AudienceStage[];
+  ctaTitle: string;
+  ctaCopy: string;
+};
+
+export const audienceLandings: readonly AudienceLanding[] = [
+  {
+    slug: "esp-municipios",
+    audience: "Municipios y empresas de servicios públicos",
+    eyebrow: "Soluciones Greenatics · Territorio y operación de aseo",
+    title: "De la planeación a una operación preparada para crecer.",
+    lead: "Greenatics ayuda a ordenar decisiones de servicio, rutas, orgánicos, datos e infraestructura sin empezar por una compra o una obra. La ruta cambia según la madurez de la operación y las responsabilidades de cada actor.",
+    proofTitle: "Primero saber qué está listo y qué falta.",
+    proofCopy: "Una ESP que inicia, una operación que amplía cobertura y un municipio que evalúa infraestructura no necesitan el mismo punto de entrada. Organizamos el trabajo por decisión y por etapa.",
+    path: ["Preparar", "Medir", "Operar", "Estabilizar", "Decidir", "Escalar"],
+    decisions: [
+      {
+        situation: "Voy a iniciar, ampliar o reorganizar una operación de aseo",
+        startWith: "ESP READY",
+        copy: "Ordena regulación, clientes, operación, tarifa, facturación, rutas, flota, datos, contingencias e infraestructura futura antes del Día 0 o de una expansión.",
+        href: "/soluciones/programas/esp-ready",
+      },
+      {
+        situation: "Necesito datos reales antes de definir rutas, proyectos o inversiones",
+        startWith: "GREENATICS BASE",
+        copy: "Construye línea base de generación, caracterización, infraestructura, evidencia y lectura operativa sin confundir medición técnica con conclusiones regulatorias.",
+        href: "/soluciones/programas/greenatics-base",
+      },
+      {
+        situation: "Debo formular, actualizar o aterrizar el PGIRS",
+        startWith: "PGIRS",
+        copy: "Conecta el instrumento territorial con programas, metas, actores, logística, tratamiento, valorización, proyectos e indicadores implementables.",
+        href: "/soluciones/pgirs",
+      },
+      {
+        situation: "Rutas, flota o continuidad operativa son hoy el cuello de botella",
+        startWith: "Diseño de rutas selectivas y microrrutas",
+        copy: "Parte de usuarios, toneladas, frecuencias, accesos, tiempos, destino y capacidad efectiva antes de dimensionar vehículos o ampliar recorridos.",
+        href: "/soluciones/rutas-selectivas",
+      },
+      {
+        situation: "Quiero saber cuánto orgánico útil puedo capturar realmente",
+        startWith: "Diagnóstico + piloto de orgánicos",
+        copy: "Separa potencial teórico de captura efectiva, calidad, impropios, logística y materia útil antes de escoger tecnología o planta.",
+        href: "/soluciones/diagnostico-caracterizacion",
+      },
+      {
+        situation: "Estoy evaluando una planta, ampliación o infraestructura existente",
+        startWith: "Prefactibilidad",
+        copy: "Compara alternativas y madura la decisión antes de comprometer ingeniería, obra o tecnología; incluye la opción de esperar, rediseñar o no construir.",
+        href: "/soluciones/prefactibilidad",
+      },
+    ],
+    programSlugs: ["esp-ready", "greenatics-base"],
+    moduleIds: ["dia-cero", "rutas-flota", "organicos-piloto", "prefactibilidad-decision", "screening-predios", "acompanamiento-etapas"],
+    stages: [
+      {
+        number: "01",
+        kicker: "Antes de iniciar o ampliar",
+        title: "Preparar el modelo y cerrar brechas críticas.",
+        copy: "Aclarar responsabilidades, línea base, actividades, usuarios, rutas, datos, contingencias y decisiones que no pueden llegar abiertas al inicio.",
+        serviceSlugs: ["diagnostico-caracterizacion", "pgirs", "rutas-selectivas", "trazabilidad-datos"],
+      },
+      {
+        number: "02",
+        kicker: "Durante la estabilización",
+        title: "Convertir el servicio en una operación repetible.",
+        copy: "Coordinar procesos, equipos, mantenimiento, evidencias, inventarios, indicadores y mejora sin confundir acompañamiento técnico con las obligaciones propias de la persona prestadora.",
+        serviceSlugs: ["direccion-operacion", "operacion-integral", "motocarguero", "trazabilidad-datos"],
+      },
+      {
+        number: "03",
+        kicker: "Antes de invertir",
+        title: "Madurar infraestructura con evidencia suficiente.",
+        copy: "Validar residuos, localización, alternativas, capacidad, costos, operación y permisos aplicables antes de avanzar hacia ingeniería o construcción.",
+        serviceSlugs: ["prefactibilidad", "factibilidad-ingenieria", "rehabilitacion", "plantas-nuevas"],
+      },
+    ],
+    ctaTitle: "Cuéntanos en qué etapa está la operación.",
+    ctaCopy: "Con municipio, área de servicio, actividades actuales, usuarios, rutas, infraestructura y objetivo podemos ubicar el punto de entrada sin forzar una solución predeterminada.",
+  },
+  {
+    slug: "empresas-grandes-generadores",
+    audience: "Empresas, grandes generadores y redes multiunidad",
+    eyebrow: "Soluciones Greenatics · Gestión empresarial de residuos",
+    title: "De cumplimiento aislado a gestión medible y circular.",
+    lead: "Greenatics organiza la información, los planes, la separación, la logística, el tratamiento y la evidencia para que una empresa pueda gestionar sus residuos como un sistema y no como tareas desconectadas.",
+    proofTitle: "Una misma base para decidir, operar y demostrar.",
+    proofCopy: "La gestión mejora cuando generación, corrientes, sedes, responsables, rutas, gestores, tratamiento e indicadores comparten una estructura común de información.",
+    path: ["Conocer", "Ordenar", "Separar", "Gestionar", "Medir", "Mejorar"],
+    decisions: [
+      {
+        situation: "No tengo una línea base confiable de cuánto y qué genero",
+        startWith: "GREENATICS BASE",
+        copy: "Levanta generación, caracterización, infraestructura, evidencias y lectura operativa como base reutilizable para planes y decisiones posteriores.",
+        href: "/soluciones/programas/greenatics-base",
+      },
+      {
+        situation: "Necesito ordenar mi plan interno de gestión de residuos",
+        startWith: "PMIRS y planes internos",
+        copy: "Estructura corrientes, separación, almacenamiento, rutas, responsables, gestores, indicadores y evidencias según el marco aplicable a la organización.",
+        href: "/soluciones/pmirs",
+      },
+      {
+        situation: "Tengo varias sedes, unidades o propiedades y quiero una metodología común",
+        startWith: "PMIRS RED",
+        copy: "Conserva el plan de cada unidad y, al mismo tiempo, consolida información comparable para operar, hacer seguimiento y detectar oportunidades de red.",
+        href: "/soluciones/programas/pmirs-red",
+      },
+      {
+        situation: "Necesito una solución trazable para mis residuos orgánicos",
+        startWith: "Gestión, recolección y tratamiento",
+        copy: "Integra programación, criterios de aceptación, recepción, tratamiento, trazabilidad y evidencia de destino según el alcance definido para la corriente.",
+        href: "/soluciones/recoleccion-tratamiento",
+      },
+      {
+        situation: "Quiero saber si tiene sentido invertir en tratamiento propio o compartido",
+        startWith: "Prefactibilidad",
+        copy: "Compara alternativas antes de comprar equipos o construir: generación, logística, localización, tecnología, salidas, CAPEX/OPEX y modelo operativo.",
+        href: "/soluciones/prefactibilidad",
+      },
+      {
+        situation: "Necesito indicadores y evidencia sin rehacer hojas cada mes",
+        startWith: "Trazabilidad digital y GREENATICS OPS",
+        copy: "Conecta registros operativos, lotes, evidencias, inventarios e indicadores para que el dato nazca donde ocurre la actividad y pueda consolidarse después.",
+        href: "/soluciones/trazabilidad-datos",
+      },
+    ],
+    programSlugs: ["greenatics-base", "pmirs-red"],
+    moduleIds: ["organicos-piloto", "prefactibilidad-decision", "screening-predios", "acompanamiento-etapas"],
+    stages: [
+      {
+        number: "01",
+        kicker: "Antes de diseñar el plan",
+        title: "Construir una línea base que pueda reutilizarse.",
+        copy: "Medir y caracterizar corrientes, entender infraestructura y prácticas actuales, identificar responsables y organizar evidencia antes de llenar formatos o definir metas.",
+        serviceSlugs: ["diagnostico-caracterizacion", "pmirs", "trazabilidad-datos"],
+      },
+      {
+        number: "02",
+        kicker: "Durante la implementación",
+        title: "Conectar separación, logística y destino.",
+        copy: "Traducir el plan en procedimientos, rutas, frecuencias, criterios de entrega, tratamiento y seguimiento para que la gestión pueda ejecutarse y verificarse.",
+        serviceSlugs: ["rutas-selectivas", "recoleccion-tratamiento", "motocarguero", "trazabilidad-datos"],
+      },
+      {
+        number: "03",
+        kicker: "Cuando aparece escala suficiente",
+        title: "Evaluar infraestructura sin asumir que construir es la respuesta.",
+        copy: "Comparar alternativas propias, compartidas o tercerizadas y avanzar a ingeniería solo cuando la generación, logística, localización y modelo operativo lo justifiquen.",
+        serviceSlugs: ["prefactibilidad", "factibilidad-ingenieria", "plantas-nuevas", "rehabilitacion"],
+      },
+    ],
+    ctaTitle: "Cuéntanos dónde se generan los residuos y qué quieres resolver.",
+    ctaCopy: "Con tipo de corriente, volumen aproximado, frecuencia, ubicación, separación actual y principal dificultad podemos proponer el primer bloque de trabajo sin sobredimensionar el proyecto.",
+  },
+] as const;
+
+export const audienceSolutionPaths = audienceLandings.map((landing) => `/soluciones/${landing.slug}` as const);
+export const getAudienceLanding = (slug: string) => audienceLandings.find((landing) => landing.slug === slug);

--- a/src/data/public-indexing.test.ts
+++ b/src/data/public-indexing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import sitemap from "../app/sitemap";
 import robots from "../app/robots";
 import { protectedOpsRoutePrefixes } from "../lib/ops-access-policy";
+import { audienceSolutionPaths } from "./audience-landings";
 import { publicNav, publicReservedRoutes, publicSite, publicStaticRoutes } from "./public-site";
 import { services } from "./services";
 import { strategicPrograms } from "./strategic-programs";
@@ -19,9 +20,11 @@ describe("public navigation and indexing contract", () => {
   it("builds a sitemap from governed indexed public data only", () => {
     const entries = sitemap();
     const urls = entries.map((item) => item.url);
-    const expectedCount = publicStaticRoutes.length + strategicPrograms.length + services.length + publicProjects.length + wondergreenCrops.length + wondergreenReferences.length;
+    const expectedCount = publicStaticRoutes.length + audienceSolutionPaths.length + strategicPrograms.length + services.length + publicProjects.length + wondergreenCrops.length + wondergreenReferences.length;
 
     expect(entries).toHaveLength(expectedCount);
+    expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/esp-municipios`);
+    expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/empresas-grandes-generadores`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/esp-ready`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/greenatics-base`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/pmirs-red`);


### PR DESCRIPTION
## Objetivo
Convertir la arquitectura B2B ya gobernada en dos landings maestras de conversión: ESP/municipios y empresas/grandes generadores.

## Cambios
- crea `/soluciones/esp-municipios`;
- crea `/soluciones/empresas-grandes-generadores`;
- añade una plantilla compartida de audiencia, sin duplicar Product/Service Truth;
- cada landing organiza seis situaciones reales y dirige a programas o servicios existentes;
- filtra programas estratégicos y módulos comerciales según audiencia;
- añade una ruta por etapas de madurez con servicios técnicos gobernados;
- conecta las dos landings desde `/soluciones`;
- incorpora ambas rutas al sitemap público;
- añade contratos unitarios y E2E para arquitectura, canonical, breadcrumbs, shell y sitemap.

## Guardrails
- cero servicios nuevos;
- cero cambios a los 13 slugs o sus alcances;
- cero cambios a ESP READY, GREENATICS BASE o PMIRS RED;
- cero cambios OPS/Auth/Supabase/RLS/migraciones;
- cero cambios Wondergreen, Casa y Jardín, precios o Product Truth;
- `main` no se toca.