### PR TITLE
feat(public): crear landings por reto específico

### DIFF
--- a/e2e/public-intent-solutions.spec.ts
+++ b/e2e/public-intent-solutions.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+
+async function jsonLdByType(page: import("@playwright/test").Page, type: string) {
+  const payloads = await page.locator('script[type="application/ld+json"]').allTextContents();
+  return payloads
+    .map((payload) => JSON.parse(payload) as Record<string, unknown>)
+    .filter((payload) => payload["@type"] === type);
+}
+
+test("solutions hub exposes three governed intent routes", async ({ page }) => {
+  await page.goto("/soluciones");
+
+  await expect(page.getByRole("heading", { name: "Tres problemas que suelen atravesar varias líneas de servicio." })).toBeVisible();
+  await expect(page.locator('a[href="/soluciones/residuos-organicos"]')).toBeVisible();
+  await expect(page.locator('a[href="/soluciones/infraestructura-plantas"]')).toBeVisible();
+  await expect(page.locator('a[href="/soluciones/propiedad-horizontal-redes"]')).toBeVisible();
+});
+
+test("organic waste route moves from real capture to treatment and prefactibility", async ({ page }) => {
+  await page.goto("/soluciones/residuos-organicos");
+
+  await expect(page.getByRole("heading", { name: "Del potencial orgánico a una corriente útil y trazable." })).toBeVisible();
+  await expect(page.getByText(/Orgánico potencial no es lo mismo que orgánico útil/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: "GREENATICS BASE →", exact: true })).toHaveAttribute("href", "/soluciones/programas/greenatics-base");
+  await expect(page.getByRole("link", { name: "Diagnóstico y caracterización →", exact: true })).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
+  await expect(page.getByRole("link", { name: "Gestión, recolección y tratamiento →", exact: true })).toHaveAttribute("href", "/soluciones/recoleccion-tratamiento");
+  await expect(page.getByRole("link", { name: "Prefactibilidad →", exact: true })).toHaveAttribute("href", "/soluciones/prefactibilidad");
+  await expect(page.getByText(/El módulo no presupone una planta ni una tecnología/i)).toBeVisible();
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", "https://greenatics.com.co/soluciones/residuos-organicos");
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/residuos-organicos");
+});
+
+test("infrastructure route keeps prefactibility before engineering and construction", async ({ page }) => {
+  await page.goto("/soluciones/infraestructura-plantas");
+
+  await expect(page.getByRole("heading", { name: "La primera decisión no es construir. Es saber si vale la pena avanzar." })).toBeVisible();
+  await expect(page.getByText(/Seguir, esperar, rediseñar o descartar también son resultados útiles/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Prefactibilidad →", exact: true })).toHaveAttribute("href", "/soluciones/prefactibilidad");
+  await expect(page.getByRole("link", { name: "Factibilidad e ingeniería →", exact: true })).toHaveAttribute("href", "/soluciones/factibilidad-ingenieria");
+  await expect(page.getByRole("link", { name: "Diseño, construcción e implementación →", exact: true })).toHaveAttribute("href", "/soluciones/plantas-nuevas");
+  await expect(page.getByRole("link", { name: "Diagnóstico y rehabilitación →", exact: true })).toHaveAttribute("href", "/soluciones/rehabilitacion");
+  await expect(page.getByText(/La prefactibilidad orienta la decisión/i)).toBeVisible();
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", "https://greenatics.com.co/soluciones/infraestructura-plantas");
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/infraestructura-plantas");
+});
+
+test("multiunit property route standardizes method without importing ESP READY", async ({ page }) => {
+  await page.goto("/soluciones/propiedad-horizontal-redes");
+
+  await expect(page.getByRole("heading", { name: "Cada unidad conserva su realidad. La red puede compartir método y datos." })).toBeVisible();
+  await expect(page.getByText(/La escala aparece cuando la información puede compararse/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: "GREENATICS BASE →", exact: true })).toHaveAttribute("href", "/soluciones/programas/greenatics-base");
+  await expect(page.getByRole("link", { name: "PMIRS y planes internos →", exact: true })).toHaveAttribute("href", "/soluciones/pmirs");
+  await expect(page.getByRole("link", { name: "PMIRS RED →", exact: true })).toHaveAttribute("href", "/soluciones/programas/pmirs-red");
+  await expect(page.getByRole("link", { name: "Trazabilidad digital y GREENATICS OPS →", exact: true })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
+  await expect(page.getByText("ESP READY", { exact: true })).toHaveCount(0);
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", "https://greenatics.com.co/soluciones/propiedad-horizontal-redes");
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/propiedad-horizontal-redes");
+});

--- a/e2e/public-shell-seo.spec.ts
+++ b/e2e/public-shell-seo.spec.ts
@@ -9,6 +9,9 @@ const shellRoutes = [
   "/soluciones",
   "/soluciones/esp-municipios",
   "/soluciones/empresas-grandes-generadores",
+  "/soluciones/residuos-organicos",
+  "/soluciones/infraestructura-plantas",
+  "/soluciones/propiedad-horizontal-redes",
   "/soluciones/diagnostico-caracterizacion",
   "/proyectos",
   "/proyectos/yarumal",
@@ -69,6 +72,9 @@ test("sitemap exposes public routes and robots blocks OPS", async ({ request }) 
   const sitemapText = await sitemap.text();
   expect(sitemapText).toContain("https://greenatics.com.co/soluciones/esp-municipios");
   expect(sitemapText).toContain("https://greenatics.com.co/soluciones/empresas-grandes-generadores");
+  expect(sitemapText).toContain("https://greenatics.com.co/soluciones/residuos-organicos");
+  expect(sitemapText).toContain("https://greenatics.com.co/soluciones/infraestructura-plantas");
+  expect(sitemapText).toContain("https://greenatics.com.co/soluciones/propiedad-horizontal-redes");
   expect(sitemapText).toContain("https://greenatics.com.co/soluciones/diagnostico-caracterizacion");
   expect(sitemapText).toContain("https://greenatics.com.co/proyectos/yarumal");
   expect(sitemapText).toContain("https://greenatics.com.co/wondergreen/cultivos/cafe");

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { audienceSolutionPaths } from "@/data/audience-landings";
+import { intentSolutionPaths } from "@/data/intent-landings";
 import { publicProjects } from "@/data/projects-public";
 import { publicSite, publicStaticRoutes } from "@/data/public-site";
 import { services } from "@/data/services";
@@ -30,6 +31,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     entry(path, 0.82, "monthly"),
   );
 
+  const intentEntries = intentSolutionPaths.map((path) =>
+    entry(path, 0.8, "monthly"),
+  );
+
   const strategicProgramEntries = strategicPrograms.map((program) =>
     entry(`/soluciones/programas/${program.slug}`, 0.78, "monthly"),
   );
@@ -50,5 +55,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
     entry(`/wondergreen/productos/${reference.slug}`, reference.truthStatus === "commercial-reconciled" ? 0.76 : 0.64, "monthly"),
   );
 
-  return [...staticEntries, ...audienceEntries, ...strategicProgramEntries, ...serviceEntries, ...projectEntries, ...cropEntries, ...productEntries];
+  return [...staticEntries, ...audienceEntries, ...intentEntries, ...strategicProgramEntries, ...serviceEntries, ...projectEntries, ...cropEntries, ...productEntries];
 }

--- a/src/app/soluciones/infraestructura-plantas/page.tsx
+++ b/src/app/soluciones/infraestructura-plantas/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
+import { getIntentLanding } from "@/data/intent-landings";
+
+const landing = getIntentLanding("infraestructura-plantas");
+
+export const metadata: Metadata = {
+  title: "Infraestructura y plantas de residuos | Greenatics",
+  description: "Prefactibilidad, evaluación técnica, factibilidad, ingeniería, construcción, rehabilitación y operación de plantas de tratamiento y valorización.",
+  alternates: { canonical: "/soluciones/infraestructura-plantas" },
+};
+
+export default function InfraestructuraPlantasPage() {
+  if (!landing) return null;
+  return <AudienceSolutionLanding landing={landing} />;
+}

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { commercialModules } from "@/data/commercial-modules";
+import { intentLandings } from "@/data/intent-landings";
 import { serviceJourneys } from "@/data/service-journeys";
 import { getPrimaryProjectMedia } from "@/data/public-media";
 import { companyServices, getService, municipalServices, serviceCategories, services, type ServiceCategory } from "@/data/services";
@@ -43,7 +44,7 @@ export default function SolutionsPage() {
               <div className={styles.heroLinks}>
                 <a href="#programas">Ver programas de entrada →</a>
                 <a href="#modulos">Resolver una decisión concreta →</a>
-                <a href="#recorridos">Explorar líneas de solución →</a>
+                <a href="#retos">Explorar por reto específico →</a>
                 <Link href="/soluciones/esp-municipios">Municipios y ESP →</Link>
                 <Link href="/soluciones/empresas-grandes-generadores">Empresas →</Link>
               </div>
@@ -168,6 +169,26 @@ export default function SolutionsPage() {
                 <div className={styles.audienceFacts}><strong>{companyServices.length}</strong><span>servicios aplicables</span><small>Información una vez · gestión y seguimiento sobre la misma base.</small></div>
                 <Link href="/soluciones/empresas-grandes-generadores">Ver ruta para empresas →</Link>
               </article>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.audience} id="retos">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Explora por reto específico</span>
+              <h2>Tres problemas que suelen atravesar varias líneas de servicio.</h2>
+              <p>Estas rutas no agregan servicios al catálogo. Reordenan capacidades existentes alrededor de una intención concreta para que sea más fácil encontrar el punto de entrada correcto.</p>
+            </div>
+            <div className={styles.audienceGrid}>
+              {intentLandings.map((landing, index) => (
+                <article className={styles.audienceCard} key={landing.slug}>
+                  <div className={styles.audienceIndex}>{String(index + 1).padStart(2, "0")}</div>
+                  <div><span className={styles.eyebrow}>{landing.audience}</span><h3>{landing.title}</h3><p>{landing.lead}</p></div>
+                  <div className={styles.audienceFacts}><strong>{landing.decisions.length}</strong><span>puntos de entrada</span><small>{landing.path.join(" · ")}</small></div>
+                  <Link href={`/soluciones/${landing.slug}`}>Explorar este reto →</Link>
+                </article>
+              ))}
             </div>
           </div>
         </section>

--- a/src/app/soluciones/propiedad-horizontal-redes/page.tsx
+++ b/src/app/soluciones/propiedad-horizontal-redes/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
+import { getIntentLanding } from "@/data/intent-landings";
+
+const landing = getIntentLanding("propiedad-horizontal-redes");
+
+export const metadata: Metadata = {
+  title: "Residuos para propiedad horizontal y redes | Greenatics",
+  description: "Línea base, planes internos, PMIRS RED, rutas, orgánicos y trazabilidad para propiedad horizontal, constructoras y redes multiunidad.",
+  alternates: { canonical: "/soluciones/propiedad-horizontal-redes" },
+};
+
+export default function PropiedadHorizontalRedesPage() {
+  if (!landing) return null;
+  return <AudienceSolutionLanding landing={landing} />;
+}

--- a/src/app/soluciones/residuos-organicos/page.tsx
+++ b/src/app/soluciones/residuos-organicos/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
+import { getIntentLanding } from "@/data/intent-landings";
+
+const landing = getIntentLanding("residuos-organicos");
+
+export const metadata: Metadata = {
+  title: "Gestión de residuos orgánicos | Greenatics",
+  description: "Diagnóstico, separación, rutas, captura, recolección, tratamiento, trazabilidad y prefactibilidad para residuos orgánicos.",
+  alternates: { canonical: "/soluciones/residuos-organicos" },
+};
+
+export default function ResiduosOrganicosPage() {
+  if (!landing) return null;
+  return <AudienceSolutionLanding landing={landing} />;
+}

--- a/src/components/audience-solution-landing.tsx
+++ b/src/components/audience-solution-landing.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
 import type { AudienceLanding } from "@/data/audience-landings";
 import { commercialModules } from "@/data/commercial-modules";
+import type { IntentLanding } from "@/data/intent-landings";
 import { getService } from "@/data/services";
 import { strategicPrograms } from "@/data/strategic-programs";
 import styles from "@/app/soluciones/solutions.module.css";
@@ -9,7 +10,9 @@ import refresh from "@/app/soluciones/solutions-refresh.module.css";
 import programStyles from "@/app/soluciones/strategic-programs.module.css";
 import moduleStyles from "@/app/soluciones/commercial-modules.module.css";
 
-export function AudienceSolutionLanding({ landing }: { landing: AudienceLanding }) {
+type GuidedSolutionLanding = AudienceLanding | IntentLanding;
+
+export function AudienceSolutionLanding({ landing }: { landing: GuidedSolutionLanding }) {
   const programs = landing.programSlugs
     .map((slug) => strategicPrograms.find((program) => program.slug === slug))
     .filter(Boolean);
@@ -105,7 +108,7 @@ export function AudienceSolutionLanding({ landing }: { landing: AudienceLanding 
             <div className={styles.sectionHead}>
               <span className={styles.eyebrow}>Decisiones frecuentes</span>
               <h2>Módulos para resolver preguntas concretas sin inventar servicios nuevos.</h2>
-              <p>Seleccionamos únicamente los módulos útiles para esta audiencia y los conectamos con los servicios técnicos que realmente los soportan.</p>
+              <p>Seleccionamos únicamente los módulos útiles para este contexto y los conectamos con los servicios técnicos que realmente los soportan.</p>
             </div>
             <div className={moduleStyles.moduleGrid}>
               {modules.map((commercialModule) => {

--- a/src/data/intent-landings.test.ts
+++ b/src/data/intent-landings.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { commercialModules } from "./commercial-modules";
+import { intentLandings, intentSolutionPaths } from "./intent-landings";
+import { services } from "./services";
+import { strategicPrograms } from "./strategic-programs";
+
+describe("intent solution landings", () => {
+  const servicePaths = new Set(services.map((service) => `/soluciones/${service.slug}`));
+  const programPaths = new Set(strategicPrograms.map((program) => `/soluciones/programas/${program.slug}`));
+  const moduleIds = new Set(commercialModules.map((commercialModule) => commercialModule.id));
+
+  it("keeps exactly three distinct intent routes", () => {
+    expect(intentLandings).toHaveLength(3);
+    expect(intentSolutionPaths).toEqual([
+      "/soluciones/residuos-organicos",
+      "/soluciones/infraestructura-plantas",
+      "/soluciones/propiedad-horizontal-redes",
+    ]);
+    expect(new Set(intentSolutionPaths).size).toBe(intentSolutionPaths.length);
+  });
+
+  it("routes every decision, stage, program and module to governed truth", () => {
+    for (const landing of intentLandings) {
+      expect(landing.decisions).toHaveLength(6);
+      expect(landing.path).toHaveLength(6);
+      expect(landing.stages).toHaveLength(3);
+
+      for (const decision of landing.decisions) {
+        expect(servicePaths.has(decision.href) || programPaths.has(decision.href)).toBe(true);
+      }
+      for (const programSlug of landing.programSlugs) {
+        expect(strategicPrograms.some((program) => program.slug === programSlug)).toBe(true);
+      }
+      for (const moduleId of landing.moduleIds) expect(moduleIds.has(moduleId)).toBe(true);
+      for (const stage of landing.stages) {
+        expect(stage.serviceSlugs.length).toBeGreaterThan(0);
+        for (const slug of stage.serviceSlugs) expect(services.some((service) => service.slug === slug)).toBe(true);
+      }
+    }
+  });
+
+  it("keeps organic capture distinct from theoretical potential and infrastructure from automatic construction", () => {
+    const organics = intentLandings.find((landing) => landing.slug === "residuos-organicos");
+    const infrastructure = intentLandings.find((landing) => landing.slug === "infraestructura-plantas");
+
+    expect(`${organics?.proofTitle} ${organics?.proofCopy}`.toLowerCase()).toContain("potencial");
+    expect(`${organics?.proofTitle} ${organics?.proofCopy}`.toLowerCase()).toContain("útil");
+    expect(infrastructure?.title.toLowerCase()).toContain("no es construir");
+    expect(infrastructure?.decisions.some((decision) => decision.href === "/soluciones/prefactibilidad")).toBe(true);
+  });
+
+  it("keeps multiunit property on GREENATICS BASE and PMIRS RED without importing ESP READY", () => {
+    const network = intentLandings.find((landing) => landing.slug === "propiedad-horizontal-redes");
+    expect(network?.programSlugs).toContain("greenatics-base");
+    expect(network?.programSlugs).toContain("pmirs-red");
+    expect(network?.programSlugs).not.toContain("esp-ready");
+  });
+});

--- a/src/data/intent-landings.ts
+++ b/src/data/intent-landings.ts
@@ -1,0 +1,236 @@
+import type { AudienceLanding } from "./audience-landings";
+
+export type IntentLanding = Omit<AudienceLanding, "slug"> & {
+  slug: "residuos-organicos" | "infraestructura-plantas" | "propiedad-horizontal-redes";
+};
+
+export const intentLandings: readonly IntentLanding[] = [
+  {
+    slug: "residuos-organicos",
+    audience: "Residuos orgánicos",
+    eyebrow: "Soluciones Greenatics · Separación, captura, logística y tratamiento",
+    title: "Del potencial orgánico a una corriente útil y trazable.",
+    lead: "Greenatics ayuda a medir, separar, capturar, transportar y tratar residuos orgánicos con evidencia suficiente para mejorar la operación o decidir si tiene sentido escalar hacia nueva infraestructura.",
+    proofTitle: "Orgánico potencial no es lo mismo que orgánico útil.",
+    proofCopy: "Antes de dimensionar rutas, equipos o plantas distinguimos generación potencial, separación real, captura efectiva, calidad, impropios y materia que realmente puede llegar a tratamiento.",
+    path: ["Medir", "Separar", "Capturar", "Transportar", "Tratar", "Escalar"],
+    decisions: [
+      {
+        situation: "No sé cuánto orgánico genero ni con qué calidad",
+        startWith: "GREENATICS BASE",
+        copy: "Construye una línea base de generación, caracterización, puntos de origen, infraestructura y evidencia antes de definir metas, frecuencias o inversión.",
+        href: "/soluciones/programas/greenatics-base",
+      },
+      {
+        situation: "La separación es irregular o tengo demasiados impropios",
+        startWith: "Diagnóstico y caracterización",
+        copy: "Identifica cantidad, composición, frecuencia, puntos críticos y condiciones de separación para saber qué parte de la corriente puede gestionarse con mayor calidad.",
+        href: "/soluciones/diagnostico-caracterizacion",
+      },
+      {
+        situation: "Necesito validar la logística antes de ampliar una ruta",
+        startWith: "Diseño de rutas selectivas",
+        copy: "Ordena generadores, frecuencias, ventanas, secuencias, destino y captura de datos; cuando aplica, un piloto permite probar tiempos y volúmenes antes de escalar.",
+        href: "/soluciones/rutas-selectivas",
+      },
+      {
+        situation: "Necesito una gestión continua con evidencia de tratamiento",
+        startWith: "Gestión, recolección y tratamiento",
+        copy: "Integra programación, criterios de aceptación, recepción, tratamiento y trazabilidad para que la gestión no termine en una simple recolección sin evidencia de destino.",
+        href: "/soluciones/recoleccion-tratamiento",
+      },
+      {
+        situation: "Necesito saber qué pasó con cada entrega o tonelada",
+        startWith: "Trazabilidad digital y GREENATICS OPS",
+        copy: "Conecta origen, ruta, recepción, proceso, producto, inventario y destino para reducir reprocesos y sostener indicadores sobre registros operativos.",
+        href: "/soluciones/trazabilidad-datos",
+      },
+      {
+        situation: "Estoy pensando en tratamiento propio, compartido o nueva infraestructura",
+        startWith: "Prefactibilidad",
+        copy: "Compara suministro, logística, localización, alternativas de proceso, salidas, CAPEX/OPEX preliminar y modelo operativo antes de comprar tecnología o construir.",
+        href: "/soluciones/prefactibilidad",
+      },
+    ],
+    programSlugs: ["greenatics-base"],
+    moduleIds: ["organicos-piloto", "rutas-flota", "prefactibilidad-decision", "acompanamiento-etapas"],
+    stages: [
+      {
+        number: "01",
+        kicker: "Antes de prometer captura",
+        title: "Medir cuánto existe y cuánto puede separarse bien.",
+        copy: "Caracterizar generación, calidad, impropios, puntos de origen y condiciones de entrega para separar potencial teórico de captura efectiva.",
+        serviceSlugs: ["diagnostico-caracterizacion", "rutas-selectivas", "motocarguero"],
+      },
+      {
+        number: "02",
+        kicker: "Durante la operación",
+        title: "Conectar logística, recepción, tratamiento y evidencia.",
+        copy: "Estabilizar frecuencias, criterios de aceptación, registros y seguimiento para que la corriente conserve trazabilidad desde el generador hasta su tratamiento.",
+        serviceSlugs: ["recoleccion-tratamiento", "trazabilidad-datos", "direccion-operacion"],
+      },
+      {
+        number: "03",
+        kicker: "Cuando aparece escala",
+        title: "Evaluar infraestructura sin asumir que construir es la respuesta.",
+        copy: "Comparar alternativas propias, compartidas o tercerizadas y avanzar a ingeniería solo cuando cantidad, calidad, continuidad, logística y modelo operativo lo justifiquen.",
+        serviceSlugs: ["prefactibilidad", "factibilidad-ingenieria", "plantas-nuevas", "rehabilitacion"],
+      },
+    ],
+    ctaTitle: "Cuéntanos cómo nace y dónde termina hoy la corriente orgánica.",
+    ctaCopy: "Con tipo y origen del residuo, volumen aproximado, frecuencia, ubicación, separación actual y destino podemos ubicar el primer bloque de trabajo sin presuponer una ruta, tecnología o planta.",
+  },
+  {
+    slug: "infraestructura-plantas",
+    audience: "Infraestructura, plantas y proyectos",
+    eyebrow: "Soluciones Greenatics · Prefactibilidad, ingeniería, rehabilitación y operación",
+    title: "La primera decisión no es construir. Es saber si vale la pena avanzar.",
+    lead: "Greenatics madura proyectos de tratamiento y valorización por etapas: línea base, prefactibilidad, revisión de localización, ingeniería, implementación, rehabilitación y operación según la evidencia disponible.",
+    proofTitle: "Seguir, esperar, rediseñar o descartar también son resultados útiles.",
+    proofCopy: "La infraestructura se evalúa alrededor del residuo, la logística, el predio, el proceso, las salidas y la capacidad real de operar; no alrededor de una tecnología elegida de antemano.",
+    path: ["Línea base", "Prefactibilidad", "Predio", "Ingeniería", "Implementación", "Operación"],
+    decisions: [
+      {
+        situation: "Tengo una idea de planta pero todavía no sé si se justifica",
+        startWith: "Prefactibilidad",
+        copy: "Compara demanda y oferta de residuos, alternativas de proceso, dimensionamiento preliminar, implantación, CAPEX/OPEX y riesgos antes de comprometer ingeniería.",
+        href: "/soluciones/prefactibilidad",
+      },
+      {
+        situation: "Tengo un predio y necesito saber si merece estudios más profundos",
+        startWith: "Prefactibilidad + screening técnico",
+        copy: "Revisa de manera preliminar accesos, distancias, entorno, servicios, riesgos, restricciones, expansión y compatibilidad operativa antes de asumir que el predio es apto.",
+        href: "/soluciones/prefactibilidad",
+      },
+      {
+        situation: "La alternativa ya maduró y necesito bases técnicas para contratar o construir",
+        startWith: "Factibilidad e ingeniería",
+        copy: "Desarrolla balances, proceso, equipos, implantación, cantidades, APU, servicios auxiliares y criterios de operación según el alcance contratado.",
+        href: "/soluciones/factibilidad-ingenieria",
+      },
+      {
+        situation: "Necesito diseñar e implementar una planta nueva",
+        startWith: "Diseño, construcción e implementación",
+        copy: "Integra recepción, tratamiento biológico, servicios auxiliares, manejo de productos, instrumentación y puesta en marcha alrededor del residuo y la operación real.",
+        href: "/soluciones/plantas-nuevas",
+      },
+      {
+        situation: "Ya existe infraestructura pero está subutilizada o presenta fallas",
+        startWith: "Diagnóstico y rehabilitación",
+        copy: "Separa fallas de infraestructura, proceso, suministro, personal y gestión antes de decidir qué adecuar, recuperar o reemplazar.",
+        href: "/soluciones/rehabilitacion",
+      },
+      {
+        situation: "La planta existe y el reto es sostener una operación disciplinada",
+        startWith: "Dirección técnica y coordinación",
+        copy: "Conecta proceso, personas, mantenimiento, calidad, inventarios, productos, reportes y mejora continua bajo responsabilidades contractuales explícitas.",
+        href: "/soluciones/direccion-operacion",
+      },
+    ],
+    programSlugs: ["greenatics-base"],
+    moduleIds: ["prefactibilidad-decision", "screening-predios", "acompanamiento-etapas"],
+    stages: [
+      {
+        number: "01",
+        kicker: "Antes de comprometer inversión",
+        title: "Construir evidencia para decidir si el proyecto debe avanzar.",
+        copy: "Validar residuos, escala, logística, localización, alternativas, salidas y modelo operativo antes de convertir una idea en ingeniería.",
+        serviceSlugs: ["diagnostico-caracterizacion", "prefactibilidad"],
+      },
+      {
+        number: "02",
+        kicker: "Cuando la alternativa está madura",
+        title: "Pasar de concepto a proyecto implementable.",
+        copy: "Definir proceso, capacidades, equipos, implantación, cantidades, costos y criterios de arranque con el nivel de detalle acordado para contratación o construcción.",
+        serviceSlugs: ["factibilidad-ingenieria", "plantas-nuevas"],
+      },
+      {
+        number: "03",
+        kicker: "Con infraestructura existente",
+        title: "Recuperar o estabilizar antes de volver a invertir.",
+        copy: "Diagnosticar activos y proceso, priorizar adecuaciones y fortalecer la operación antes de recomendar reemplazos o nuevas ampliaciones.",
+        serviceSlugs: ["rehabilitacion", "direccion-operacion", "operacion-integral", "trazabilidad-datos"],
+      },
+    ],
+    ctaTitle: "Cuéntanos qué infraestructura existe y qué decisión está abierta.",
+    ctaCopy: "Con ubicación, corriente prevista, capacidad objetivo, infraestructura disponible, etapa del proyecto y restricciones conocidas podemos ubicar el nivel de estudio correcto sin saltar prematuramente a obra o tecnología.",
+  },
+  {
+    slug: "propiedad-horizontal-redes",
+    audience: "Propiedad horizontal, constructoras y redes multiunidad",
+    eyebrow: "Soluciones Greenatics · Línea base, planes internos y arquitectura común de información",
+    title: "Cada unidad conserva su realidad. La red puede compartir método y datos.",
+    lead: "Greenatics estructura diagnósticos, planes internos, separación, rutas, orgánicos e indicadores para conjuntos residenciales, constructoras y redes de múltiples unidades sin convertir cada sede en un proyecto aislado.",
+    proofTitle: "La escala aparece cuando la información puede compararse.",
+    proofCopy: "Una metodología común permite que cada unidad tenga su propio diagnóstico o plan y que la red consolide generación, composición, accesos, horarios, orgánicos, rutas, indicadores y oportunidades.",
+    path: ["Levantar", "Estandarizar", "Implementar", "Consolidar", "Optimizar", "Escalar"],
+    decisions: [
+      {
+        situation: "No tengo una línea base comparable entre unidades",
+        startWith: "GREENATICS BASE",
+        copy: "Estandariza generación, caracterización, infraestructura, evidencias y lectura operativa para que las sedes puedan analizarse bajo una misma estructura.",
+        href: "/soluciones/programas/greenatics-base",
+      },
+      {
+        situation: "Necesito ordenar la gestión interna de una unidad",
+        startWith: "PMIRS y planes internos",
+        copy: "Organiza corrientes, separación, almacenamiento, rutas, responsables, gestores, indicadores y evidencias según la aplicabilidad y alcance de cada organización.",
+        href: "/soluciones/pmirs",
+      },
+      {
+        situation: "Tengo varias propiedades y quiero un estándar común",
+        startWith: "PMIRS RED",
+        copy: "Permite conservar el plan o diagnóstico de cada unidad y, al mismo tiempo, consolidar información comparable para seguimiento y decisiones de red.",
+        href: "/soluciones/programas/pmirs-red",
+      },
+      {
+        situation: "Las rutas, accesos u horarios cambian mucho entre unidades",
+        startWith: "Diseño de rutas selectivas",
+        copy: "Conecta generadores, accesos, frecuencias, ventanas, secuencias y destino para diseñar logística sobre condiciones reales y no sobre promedios de la red.",
+        href: "/soluciones/rutas-selectivas",
+      },
+      {
+        situation: "Quiero separar y gestionar orgánicos de forma trazable",
+        startWith: "Gestión, recolección y tratamiento",
+        copy: "Integra criterios de separación, programación, recepción, tratamiento y evidencia según el esquema definido para cada corriente y unidad.",
+        href: "/soluciones/recoleccion-tratamiento",
+      },
+      {
+        situation: "Necesito indicadores consolidados sin rehacer la información cada mes",
+        startWith: "Trazabilidad digital y GREENATICS OPS",
+        copy: "Estructura registros y evidencia para que cada unidad produzca datos comparables y la red pueda consolidarlos sin perder el origen de cada actividad.",
+        href: "/soluciones/trazabilidad-datos",
+      },
+    ],
+    programSlugs: ["greenatics-base", "pmirs-red"],
+    moduleIds: ["rutas-flota", "organicos-piloto", "acompanamiento-etapas"],
+    stages: [
+      {
+        number: "01",
+        kicker: "Unidad por unidad",
+        title: "Levantar una base consistente antes de estandarizar.",
+        copy: "Entender generación, corrientes, infraestructura, responsables y prácticas reales para que el estándar común no borre las diferencias entre propiedades.",
+        serviceSlugs: ["diagnostico-caracterizacion", "pmirs", "trazabilidad-datos"],
+      },
+      {
+        number: "02",
+        kicker: "Durante la implementación",
+        title: "Traducir planes en separación, logística y destino.",
+        copy: "Conectar procedimientos, accesos, rutas, frecuencias, criterios de entrega y tratamiento para que la gestión pueda ejecutarse y verificarse en cada unidad.",
+        serviceSlugs: ["rutas-selectivas", "recoleccion-tratamiento", "motocarguero"],
+      },
+      {
+        number: "03",
+        kicker: "A escala de red",
+        title: "Consolidar información y detectar decisiones que sí merecen escala.",
+        copy: "Comparar generación, desempeño y oportunidades antes de decidir logística compartida, pilotos de orgánicos o infraestructura común.",
+        serviceSlugs: ["trazabilidad-datos", "prefactibilidad", "factibilidad-ingenieria"],
+      },
+    ],
+    ctaTitle: "Cuéntanos cuántas unidades componen la red y qué información ya existe.",
+    ctaCopy: "Con número de sedes o propiedades, ubicación, tipo de generación, información disponible, prácticas actuales y principal decisión pendiente podemos definir si conviene empezar por línea base, plan interno, PMIRS RED o una fase operacional.",
+  },
+] as const;
+
+export const intentSolutionPaths = intentLandings.map((landing) => `/soluciones/${landing.slug}` as const);
+export const getIntentLanding = (slug: string) => intentLandings.find((landing) => landing.slug === slug);

--- a/src/data/public-indexing.test.ts
+++ b/src/data/public-indexing.test.ts
@@ -3,6 +3,7 @@ import sitemap from "../app/sitemap";
 import robots from "../app/robots";
 import { protectedOpsRoutePrefixes } from "../lib/ops-access-policy";
 import { audienceSolutionPaths } from "./audience-landings";
+import { intentSolutionPaths } from "./intent-landings";
 import { publicNav, publicReservedRoutes, publicSite, publicStaticRoutes } from "./public-site";
 import { services } from "./services";
 import { strategicPrograms } from "./strategic-programs";
@@ -20,11 +21,14 @@ describe("public navigation and indexing contract", () => {
   it("builds a sitemap from governed indexed public data only", () => {
     const entries = sitemap();
     const urls = entries.map((item) => item.url);
-    const expectedCount = publicStaticRoutes.length + audienceSolutionPaths.length + strategicPrograms.length + services.length + publicProjects.length + wondergreenCrops.length + wondergreenReferences.length;
+    const expectedCount = publicStaticRoutes.length + audienceSolutionPaths.length + intentSolutionPaths.length + strategicPrograms.length + services.length + publicProjects.length + wondergreenCrops.length + wondergreenReferences.length;
 
     expect(entries).toHaveLength(expectedCount);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/esp-municipios`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/empresas-grandes-generadores`);
+    expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/residuos-organicos`);
+    expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/infraestructura-plantas`);
+    expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/propiedad-horizontal-redes`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/esp-ready`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/greenatics-base`);
     expect(urls).toContain(`${publicSite.publicDomainTarget}/soluciones/programas/pmirs-red`);


### PR DESCRIPTION
## Objetivo
Crear una segunda capa de landings públicas por intención comercial y SEO, reutilizando exclusivamente la arquitectura B2B ya gobernada.

## Nuevas rutas
- `/soluciones/residuos-organicos`
- `/soluciones/infraestructura-plantas`
- `/soluciones/propiedad-horizontal-redes`

## Arquitectura
- las tres rutas reutilizan la plantilla certificada de landings guiadas;
- cada una organiza 6 situaciones de entrada, programas aplicables, módulos comerciales y 3 etapas de madurez;
- `/soluciones` incorpora una sección “Explora por reto específico”;
- las rutas se derivan desde `intent-landings.ts` y entran al sitemap con canonical y breadcrumbs propios.

## Guardrails
- cero servicios nuevos;
- cero cambios a `services.ts` y a los 13 alcances técnicos;
- cero cambios a ESP READY, GREENATICS BASE, PMIRS RED o módulos comerciales;
- orgánicos distingue potencial, captura efectiva, calidad y materia útil antes de infraestructura;
- infraestructura mantiene prefactibilidad antes de ingeniería/construcción y admite seguir/esperar/rediseñar/descartar;
- propiedad horizontal no presume PMIRS universal y usa GREENATICS BASE + PMIRS RED sin importar ESP READY;
- cero cambios OPS/Auth/Supabase/RLS/migraciones;
- cero cambios Wondergreen, Casa y Jardín, precios o Product Truth;
- `main` no se toca.

## QA añadido
- contrato unitario de las 3 landings y sus destinos gobernados;
- E2E de hub, decisiones, canonical y BreadcrumbList;
- shell público y sitemap ampliados a las 3 rutas.