### PR TITLE
feat(casa): construir Casa Jardín y Vivero desde handoff MKTG

### DIFF
--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -21,7 +21,7 @@ test("Casa Jardín and Vivero exposes stage system without price or checkout", a
   await expect(page.getByRole("button", { name: /comprar/i })).toHaveCount(0);
   await expect(page.getByRole("link", { name: /comprar/i })).toHaveCount(0);
   await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
-  await expect(page.getByText(/Kit Trasplanta & Arranca no aparece como kit disponible/i)).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Kit Trasplanta & Arranca", exact: true })).toHaveCount(0);
 });
 
 test("Casa diagnostic stops fertilizer-first response on safety conditions", async ({ page }) => {

--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+
+test("Casa Jardín and Vivero exposes stage system without price or checkout", async ({ page }) => {
+  await page.goto("/casa-jardin");
+
+  for (const [name, formula] of [
+    ["CRECE", "15-3-3"],
+    ["EQUILIBRA", "7-7-7"],
+    ["FLORECE", "3-8-3"],
+    ["FRUCTIFICA", "3-3-8"],
+  ] as const) {
+    await expect(page.getByText(name, { exact: true }).first()).toBeVisible();
+    await expect(page.getByText(formula, { exact: true }).first()).toBeVisible();
+  }
+  await expect(page.getByText("COMPOST", { exact: true }).first()).toBeVisible();
+
+  for (const kit of ["Kit Plantas Verdes", "Kit Plantas con Flor", "Kit Mi Huerta", "Kit Casa Completa", "Casa Completa XL"]) {
+    await expect(page.getByRole("heading", { name: kit, exact: true })).toBeVisible();
+  }
+
+  await expect(page.getByRole("button", { name: /comprar/i })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: /comprar/i })).toHaveCount(0);
+  await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
+  await expect(page.getByText(/Kit Trasplanta & Arranca no aparece como kit disponible/i)).toBeVisible();
+});
+
+test("Casa diagnostic stops fertilizer-first response on safety conditions", async ({ page }) => {
+  await page.goto("/casa-jardin/diagnostico");
+
+  await page.getByLabel("Tipo de planta").selectOption("green");
+  await page.getByLabel("Etapa de la planta").selectOption("growing");
+  await page.getByLabel("Condición de la planta").selectOption("waterlogged");
+
+  await expect(page.getByText("Primero corrige la condición de la planta.", { exact: true })).toBeVisible();
+  await expect(page.getByText(/NO EMPIECES FERTILIZANDO/i)).toBeVisible();
+  await expect(page.getByText(/Calculadora de dosis: deshabilitada/i)).toBeVisible();
+});
+
+test("Casa diagnostic routes a healthy growing plant to CRECE without calculating dose", async ({ page }) => {
+  await page.goto("/casa-jardin/diagnostico");
+
+  await page.getByLabel("Tipo de planta").selectOption("green");
+  await page.getByLabel("Etapa de la planta").selectOption("growing");
+  await page.getByLabel("Condición de la planta").selectOption("healthy");
+  await page.getByLabel("Cantidad de plantas").selectOption("6-10");
+
+  await expect(page.getByText("CRECE · 15-3-3", { exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Abrir siguiente paso →" })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
+  await expect(page.getByText(/No calcula dosis ni cobertura todavía/i)).toBeVisible();
+});
+
+test("Casa guide library exposes handoff sources without broken download links", async ({ page }) => {
+  await page.goto("/casa-jardin/guias");
+
+  for (const guide of ["Guía Wondergreen Casa & Jardín", "Guía Mi Huerta", "Guía rápida de etapas", "Guía de trasplante"]) {
+    await expect(page.getByRole("heading", { name: guide, exact: true })).toBeVisible();
+  }
+  await expect(page.getByRole("link", { name: /Descargar PDF/i })).toHaveCount(0);
+  await expect(page.getByText(/PDF fuente validado en el handoff/i).first()).toBeVisible();
+});

--- a/e2e/public-shell-seo.spec.ts
+++ b/e2e/public-shell-seo.spec.ts
@@ -1,30 +1,16 @@
 import { test, expect } from "@playwright/test";
 
 const shellRoutes = [
-  "/",
-  "/wondergreen",
-  "/wondergreen/cultivos",
-  "/wondergreen/cultivos/cafe",
-  "/casa-jardin",
-  "/soluciones",
-  "/soluciones/esp-municipios",
-  "/soluciones/empresas-grandes-generadores",
-  "/soluciones/residuos-organicos",
-  "/soluciones/infraestructura-plantas",
-  "/soluciones/propiedad-horizontal-redes",
-  "/soluciones/diagnostico-caracterizacion",
-  "/proyectos",
-  "/proyectos/yarumal",
-  "/impacto",
-  "/biblioteca",
-  "/biblioteca/guia-deficiencias",
-  "/nosotros",
-  "/contacto",
+  "/", "/wondergreen", "/wondergreen/cultivos", "/wondergreen/cultivos/cafe",
+  "/casa-jardin", "/casa-jardin/diagnostico", "/casa-jardin/guias",
+  "/soluciones", "/soluciones/esp-municipios", "/soluciones/empresas-grandes-generadores",
+  "/soluciones/residuos-organicos", "/soluciones/infraestructura-plantas", "/soluciones/propiedad-horizontal-redes",
+  "/soluciones/diagnostico-caracterizacion", "/proyectos", "/proyectos/yarumal", "/impacto",
+  "/biblioteca", "/biblioteca/guia-deficiencias", "/nosotros", "/contacto",
 ];
 
 test("public home uses the shared navigation and real routes", async ({ page }) => {
   await page.goto("/");
-
   const header = page.getByRole("banner");
   const nav = header.getByRole("navigation", { name: "Navegación pública" });
   await expect(nav).toBeVisible();
@@ -37,17 +23,18 @@ test("public home uses the shared navigation and real routes", async ({ page }) 
   await expect(header.getByRole("link", { name: "Acceder a Greenatics" })).toHaveAttribute("href", "/app");
 });
 
-test("Casa y Jardín stays a real but non-indexed placeholder until its catalog is defined", async ({ page }) => {
+test("Casa y Jardín is functional but remains non-indexed until B2C validation closes", async ({ page }) => {
   await page.goto("/casa-jardin");
-
-  await expect(page.getByRole("heading", { name: "Casa y Jardín." })).toBeVisible();
-  await expect(page.getByText("Próximamente", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Nutrición por etapas para tus plantas." })).toBeVisible();
+  await expect(page.getByText("CRECE", { exact: true }).first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Kit Casa Completa" })).toBeVisible();
+  await expect(page.getByText(/compra deshabilitada/i).first()).toBeVisible();
+  await expect(page.getByText(/Trasplanta & Arranca no aparece como kit disponible/i)).toBeVisible();
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
 });
 
 test("nested public routes inherit the same shell", async ({ page }) => {
   await page.goto("/soluciones/diagnostico-caracterizacion");
-
   const header = page.getByRole("banner");
   const footer = page.getByRole("contentinfo");
   await expect(header.getByRole("navigation", { name: "Navegación pública" })).toBeVisible();
@@ -66,7 +53,7 @@ test("every governed public route renders exactly one shared shell", async ({ pa
   }
 });
 
-test("sitemap exposes public routes and robots blocks OPS", async ({ request }) => {
+test("sitemap exposes indexed routes while Casa and Jardín remains reserved", async ({ request }) => {
   const sitemap = await request.get("/sitemap.xml");
   expect(sitemap.ok()).toBe(true);
   const sitemapText = await sitemap.text();
@@ -84,11 +71,6 @@ test("sitemap exposes public routes and robots blocks OPS", async ({ request }) 
   const robots = await request.get("/robots.txt");
   expect(robots.ok()).toBe(true);
   const robotsText = await robots.text();
-  expect(robotsText).toContain("Disallow: /app");
-  expect(robotsText).toContain("Disallow: /dashboard");
-  expect(robotsText).toContain("Disallow: /login");
-  expect(robotsText).toContain("Disallow: /receptions");
-  expect(robotsText).toContain("Disallow: /sales");
-  expect(robotsText).toContain("Disallow: /supplies");
+  for (const path of ["/app", "/dashboard", "/login", "/receptions", "/sales", "/supplies"]) expect(robotsText).toContain(`Disallow: ${path}`);
   expect(robotsText).toContain("Sitemap: https://greenatics.com.co/sitemap.xml");
 });

--- a/src/app/casa-jardin/casa-jardin.module.css
+++ b/src/app/casa-jardin/casa-jardin.module.css
@@ -1,0 +1,116 @@
+.page {
+  --forest: #063d2c;
+  --green: #2f7d32;
+  --lime: #7db43c;
+  --pale: #eaf4e4;
+  --paper: #f7faf8;
+  --ink: #17382d;
+  --muted: #5c7168;
+  --line: rgba(6, 61, 44, .15);
+  --sun: #f4d944;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.container { width: min(1180px, calc(100% - 40px)); margin: 0 auto; }
+.hero { position: relative; overflow: hidden; padding: 104px 0 88px; background: #f6f3e9; border-bottom: 1px solid var(--line); }
+.hero::after { content: ""; position: absolute; width: 420px; height: 420px; right: -120px; top: -170px; border: 1px solid rgba(47,125,50,.18); border-radius: 50%; }
+.heroGrid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(320px, .7fr); gap: 68px; align-items: center; }
+.eyebrow { display: inline-block; color: var(--green); font-size: .72rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.hero h1, .section h2, .card h3, .guideCard h3, .kitCard h3 { font-family: var(--display); font-weight: 600; }
+.hero h1 { max-width: 760px; margin: 18px 0 22px; font-size: clamp(3.6rem, 7vw, 6.7rem); line-height: .92; letter-spacing: -.045em; }
+.lead { max-width: 700px; color: var(--muted); font-size: 1.13rem; line-height: 1.75; }
+.actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 34px; }
+.button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; padding: 0 18px; border: 1px solid var(--forest); font-weight: 800; text-decoration: none; }
+.primary { background: var(--forest); color: #fff; }
+.ghost { color: var(--forest); background: transparent; }
+.heroVisual { position: relative; min-height: 430px; display: grid; place-items: center; padding: 42px; background: var(--forest); overflow: hidden; }
+.heroVisual::before { content: "4 ETAPAS. 1 SISTEMA."; position: absolute; inset: auto 28px 26px; color: #dceac0; font-size: .72rem; font-weight: 900; letter-spacing: .12em; }
+.heroVisual img { width: min(100%, 360px); height: auto; object-fit: contain; filter: drop-shadow(0 16px 26px rgba(0,0,0,.22)); }
+.heroNote { position: absolute; top: 25px; left: 26px; right: 26px; color: #d5e2dc; line-height: 1.55; font-size: .82rem; }
+
+.path { background: var(--forest); color: #fff; }
+.pathGrid { display: grid; grid-template-columns: repeat(5, 1fr); border-left: 1px solid rgba(255,255,255,.16); }
+.pathGrid div { min-height: 92px; display: flex; flex-direction: column; justify-content: center; gap: 7px; padding: 18px 22px; border-right: 1px solid rgba(255,255,255,.16); }
+.pathGrid span { color: #cfe396; font-size: .66rem; font-weight: 800; }
+.pathGrid strong { font-size: .85rem; letter-spacing: .05em; }
+
+.section { padding: 102px 0; border-bottom: 1px solid var(--line); }
+.soft { background: #eef5ec; }
+.dark { background: var(--forest); color: #fff; }
+.dark p { color: #bdd0c7; }
+.sectionHead { display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, .6fr); gap: 48px; align-items: end; margin-bottom: 42px; }
+.sectionHead h2 { max-width: 780px; margin: 12px 0 0; font-size: clamp(2.5rem, 4.6vw, 4.8rem); line-height: 1; letter-spacing: -.035em; }
+.sectionHead p { margin: 0; color: var(--muted); line-height: 1.7; }
+
+.productGrid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
+.card { min-height: 360px; display: flex; flex-direction: column; padding: 26px 22px; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: #fff; }
+.stageBar { height: 7px; margin: -26px -22px 24px; background: var(--stage); }
+.card small { color: var(--muted); font-weight: 800; text-transform: uppercase; letter-spacing: .08em; }
+.card h3 { margin: 12px 0 4px; font-size: 2rem; }
+.formula { color: var(--green); font-size: .9rem; font-weight: 900; }
+.card p { color: var(--muted); line-height: 1.62; }
+.card a { margin-top: auto; color: var(--forest); font-weight: 800; }
+.earth { --stage: #8b6d46; }
+.orange { --stage: #f28c28; }
+.violet { --stage: #7452a3; }
+.blue { --stage: #3b77b9; }
+.coral { --stage: #d95b50; }
+
+.decisionGrid, .kitGrid, .trafficGrid, .guideGrid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
+.decisionCard, .kitCard, .trafficCard, .guideCard { padding: 28px; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: #fff; }
+.decisionCard h3, .kitCard h3, .trafficCard h3, .guideCard h3 { margin: 10px 0; font-size: 1.65rem; }
+.decisionCard p, .kitCard p, .trafficCard p, .guideCard p { color: var(--muted); line-height: 1.65; }
+.kitCard { min-height: 420px; display: flex; flex-direction: column; }
+.kitCard ul { padding-left: 18px; color: var(--muted); line-height: 1.7; }
+.kitCard .status { margin-top: auto; padding-top: 18px; border-top: 1px solid var(--line); color: var(--green); font-size: .75rem; font-weight: 900; text-transform: uppercase; letter-spacing: .08em; }
+
+.flow { display: grid; grid-template-columns: repeat(4, 1fr); border-top: 1px solid rgba(255,255,255,.18); border-left: 1px solid rgba(255,255,255,.18); }
+.flow article { padding: 28px; border-right: 1px solid rgba(255,255,255,.18); border-bottom: 1px solid rgba(255,255,255,.18); }
+.flow strong { display: block; color: #d9ed9e; margin-bottom: 10px; }
+.flow p { margin: 0; line-height: 1.65; }
+
+.trafficCard:first-child { border-top: 7px solid #57953e; }
+.trafficCard:nth-child(2) { border-top: 7px solid #e4ba35; }
+.trafficCard:nth-child(3) { border-top: 7px solid #bc4b45; }
+.level { font-size: .72rem; font-weight: 900; letter-spacing: .12em; }
+
+.guardrail { padding: 28px; margin-top: 34px; border-left: 6px solid var(--sun); background: #fff; }
+.guardrail strong { display: block; margin-bottom: 8px; }
+.guardrail p { margin: 0; color: var(--muted); line-height: 1.7; }
+
+.guideCard { min-height: 270px; display: flex; flex-direction: column; }
+.guideCard span { color: var(--green); font-size: .72rem; font-weight: 900; text-transform: uppercase; letter-spacing: .08em; }
+.guideCard a { margin-top: auto; color: var(--forest); font-weight: 800; }
+
+.faq { display: grid; border-top: 1px solid var(--line); }
+.faq details { padding: 22px 0; border-bottom: 1px solid var(--line); }
+.faq summary { cursor: pointer; font-weight: 800; }
+.faq p { max-width: 840px; color: var(--muted); line-height: 1.7; }
+
+.release { background: #f0eeda; }
+.releaseGrid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(320px, .72fr); gap: 60px; align-items: start; }
+.release ul { color: var(--muted); line-height: 1.8; }
+
+@media (max-width: 1100px) {
+  .productGrid { grid-template-columns: repeat(3, 1fr); }
+  .decisionGrid, .kitGrid, .trafficGrid, .guideGrid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 820px) {
+  .heroGrid, .sectionHead, .releaseGrid { grid-template-columns: 1fr; }
+  .heroVisual { min-height: 330px; }
+  .pathGrid { grid-template-columns: repeat(2, 1fr); }
+  .productGrid, .decisionGrid, .kitGrid, .trafficGrid, .guideGrid, .flow { grid-template-columns: 1fr; }
+  .card, .kitCard { min-height: auto; }
+}
+
+@media (max-width: 560px) {
+  .container { width: min(100% - 28px, 1180px); }
+  .hero { padding: 78px 0 62px; }
+  .hero h1 { font-size: clamp(3rem, 16vw, 4.5rem); }
+  .section { padding: 72px 0; }
+  .pathGrid { grid-template-columns: 1fr; }
+  .actions { flex-direction: column; }
+  .button { width: 100%; }
+}

--- a/src/app/casa-jardin/diagnostico/home-garden-diagnostic.tsx
+++ b/src/app/casa-jardin/diagnostico/home-garden-diagnostic.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { homeGardenDiagnostic, homeGardenProducts, visibleHomeGardenKits } from "@/data/home-garden";
+import styles from "../casa-jardin.module.css";
+
+type StageKey = keyof typeof homeGardenDiagnostic.stages | "";
+type ConditionKey = "healthy" | "stressed" | "very-wilted" | "waterlogged" | "pest-damage" | "root-problem" | "unknown" | "";
+
+type PlantType = "green" | "flower" | "garden" | "fruit" | "mixed" | "new-transplant" | "unsure" | "";
+
+const conditionOptions: readonly [ConditionKey, string][] = [
+  ["healthy", "Activa / aparentemente sana"],
+  ["stressed", "Estresada, pero sin daño severo evidente"],
+  ["very-wilted", "Muy marchita"],
+  ["waterlogged", "Encharcada o con exceso de agua"],
+  ["pest-damage", "Con manchas, plaga o daño sanitario"],
+  ["root-problem", "Con señales de problema radicular"],
+  ["unknown", "No estoy seguro"],
+];
+
+const stageOptions: readonly [StageKey, string][] = [
+  ["growing", "Sacando hojas o brotes nuevos"],
+  ["stable", "Estable / mantenimiento"],
+  ["flowering", "Formando botones o flores"],
+  ["fruiting", "Con fruto o en etapa productiva"],
+  ["mixed", "Tengo varias plantas en etapas distintas"],
+  ["", "No sé identificar la etapa"],
+];
+
+export function HomeGardenDiagnostic() {
+  const [plantType, setPlantType] = useState<PlantType>("");
+  const [stage, setStage] = useState<StageKey>("");
+  const [condition, setCondition] = useState<ConditionKey>("");
+  const [plantCount, setPlantCount] = useState("");
+
+  const result = useMemo(() => {
+    if (!condition || !stage) return null;
+    if ((homeGardenDiagnostic.safetyTriggers as readonly string[]).includes(condition)) {
+      return { type: "safety" as const, title: "Primero corrige la condición de la planta.", copy: homeGardenDiagnostic.safetyMessage };
+    }
+    if (plantType === "new-transplant") {
+      return { type: "safety" as const, title: "Trasplante reciente: estabiliza antes de decidir nutrición.", copy: "Revisa drenaje, raíces, humedad y establecimiento. Cuando la planta retome actividad, vuelve a identificar su etapa." };
+    }
+
+    const destination = homeGardenDiagnostic.stages[stage as keyof typeof homeGardenDiagnostic.stages];
+    if (!destination) return { type: "review" as const, title: "Todavía falta contexto.", copy: "No identificamos una etapa con suficiente claridad. Usa el semáforo, revisa agua, drenaje, raíces y sanidad, o solicita orientación antes de aplicar." };
+
+    if (destination === "casa-completa") {
+      const kit = visibleHomeGardenKits.find((item) => item.id === "casa-completa");
+      return { type: "kit" as const, title: kit?.name ?? "Casa Completa", copy: "Tienes varias plantas en etapas distintas. La lógica es identificar cada planta y usar una sola etapa por necesidad, no aplicar todo simultáneamente.", href: "/casa-jardin#kits" };
+    }
+
+    const product = homeGardenProducts.find((item) => item.id === destination);
+    if (!product) return null;
+    return {
+      type: "stage" as const,
+      title: `${product.consumerName} · ${product.formula ?? "Compost"}`,
+      copy: `${product.role} ${product.householdFormatStatus}`,
+      href: `/wondergreen/productos/${product.technicalSlug}`,
+    };
+  }, [condition, plantType, stage]);
+
+  return (
+    <div>
+      <div className={styles.decisionGrid}>
+        <label className={styles.decisionCard}>
+          <span className={styles.eyebrow}>01 · Tipo de planta</span>
+          <h3>¿Qué estás cuidando?</h3>
+          <select value={plantType} onChange={(event) => setPlantType(event.target.value as PlantType)} aria-label="Tipo de planta">
+            <option value="">Selecciona una opción</option>
+            <option value="green">Planta verde / follaje</option>
+            <option value="flower">Planta con flor</option>
+            <option value="garden">Huerta / aromáticas</option>
+            <option value="fruit">Planta productiva / fruto</option>
+            <option value="mixed">Colección mixta</option>
+            <option value="new-transplant">Recién trasplantada</option>
+            <option value="unsure">No estoy seguro</option>
+          </select>
+        </label>
+
+        <label className={styles.decisionCard}>
+          <span className={styles.eyebrow}>02 · Etapa</span>
+          <h3>¿Qué está haciendo?</h3>
+          <select value={stage} onChange={(event) => setStage(event.target.value as StageKey)} aria-label="Etapa de la planta">
+            <option value="">Selecciona una opción</option>
+            {stageOptions.filter(([value]) => value).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+          </select>
+        </label>
+
+        <label className={styles.decisionCard}>
+          <span className={styles.eyebrow}>03 · Condición</span>
+          <h3>¿Cómo se ve hoy?</h3>
+          <select value={condition} onChange={(event) => setCondition(event.target.value as ConditionKey)} aria-label="Condición de la planta">
+            <option value="">Selecciona una opción</option>
+            {conditionOptions.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+          </select>
+        </label>
+
+        <label className={styles.decisionCard}>
+          <span className={styles.eyebrow}>04 · Escala</span>
+          <h3>¿Cuántas plantas tienes?</h3>
+          <select value={plantCount} onChange={(event) => setPlantCount(event.target.value)} aria-label="Cantidad de plantas">
+            <option value="">Selecciona una opción</option>
+            <option value="1-5">1–5</option>
+            <option value="6-10">6–10</option>
+            <option value="11-20">11–20</option>
+            <option value="21-40">21–40</option>
+            <option value="40+">Más de 40</option>
+          </select>
+          <p>Este dato prepara una futura recomendación de tamaño. <strong>No calcula dosis ni cobertura todavía.</strong></p>
+        </label>
+      </div>
+
+      <div className={styles.guardrail} aria-live="polite">
+        {!result ? (
+          <><strong>Completa etapa y condición.</strong><p>El diagnóstico no entregará una recomendación hasta tener esas dos señales mínimas.</p></>
+        ) : (
+          <>
+            <span className={styles.eyebrow}>{result.type === "safety" ? "Detener y revisar" : "Punto de partida orientativo"}</span>
+            <strong>{result.title}</strong>
+            <p>{result.copy}</p>
+            {"href" in result && result.href ? <Link href={result.href}>Abrir siguiente paso →</Link> : null}
+          </>
+        )}
+      </div>
+
+      <div className={styles.guardrail}>
+        <strong>Calculadora de dosis: deshabilitada.</strong>
+        <p>El handoff exige validar dosis domésticas por formulación y calibrar el dosificador antes de convertir este diagnóstico en gramos, medidas, frecuencia o cobertura.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/casa-jardin/diagnostico/page.tsx
+++ b/src/app/casa-jardin/diagnostico/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { HomeGardenDiagnostic } from "./home-garden-diagnostic";
+import styles from "../casa-jardin.module.css";
+
+export const metadata: Metadata = {
+  title: "Diagnóstico orientativo | Casa, Jardín y Vivero",
+  description: "Identifica etapa y condición antes de elegir una línea Wondergreen. El diagnóstico detiene la recomendación si encuentra señales de estrés, exceso de agua, raíces o sanidad.",
+  alternates: { canonical: "/casa-jardin/diagnostico" },
+  robots: { index: false, follow: true },
+};
+
+export default function CasaJardinDiagnosticoPage() {
+  return (
+    <div className={styles.page}>
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Wondergreen Casa & Jardín · diagnóstico</span>
+              <h1>Deja de fertilizar a ciegas.</h1>
+              <p className={styles.lead}>Este flujo no intenta diagnosticar una planta por una sola señal. Primero identifica etapa y condición; si hay un factor de riesgo, la recomendación es detener la fertilización y revisar la causa.</p>
+              <div className={styles.actions}><Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin">← Volver a Casa, Jardín y Vivero</Link></div>
+            </div>
+            <aside className={styles.heroVisual}>
+              <p className={styles.heroNote}>NO NECESITA MÁS. NECESITA LO CORRECTO.</p>
+              <strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>Observa antes de aplicar.</strong>
+            </aside>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Flujo orientativo</span><h2>Etapa + condición antes de producto.</h2></div>
+              <p>La cantidad de plantas se captura únicamente para preparar una futura recomendación de formato. No se traduce todavía en gramos, cucharadas, cobertura ni frecuencia.</p>
+            </div>
+            <HomeGardenDiagnostic />
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/casa-jardin/guias/page.tsx
+++ b/src/app/casa-jardin/guias/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { homeGardenGuides } from "@/data/home-garden";
+import styles from "../casa-jardin.module.css";
+
+export const metadata: Metadata = {
+  title: "Guías | Casa, Jardín y Vivero",
+  description: "Guías Wondergreen Casa & Jardín sobre etapas, huerta y trasplante, acompañadas por contenido navegable y guardrails de uso.",
+  alternates: { canonical: "/casa-jardin/guias" },
+  robots: { index: false, follow: true },
+};
+
+const guideContent = {
+  "casa-jardin": [
+    "Identifica primero la etapa: suelo, crecimiento, mantenimiento, floración o producción.",
+    "Usa el método OBSERVA → IDENTIFICA → ELIGE → APLICA → REVISA.",
+    "No conviertas un síntoma aislado en una receta nutricional.",
+    "Trabaja con humedad adecuada y no acumules pellets contra el tallo.",
+    "Detén la fertilización si hay encharcamiento, pudrición, raíces comprometidas o marchitez severa.",
+  ],
+  "mi-huerta": [
+    "PREPARA: materia orgánica y condición del sustrato antes de exigir producción.",
+    "CRECE: etapa vegetativa y desarrollo de hojas/brotes.",
+    "FLORECE: cambia de lógica cuando aparecen botones y flores.",
+    "FRUCTIFICA: acompaña la etapa productiva sin prometer rendimiento o cosecha.",
+    "La secuencia es por etapas; no significa aplicar todos los productos al mismo tiempo.",
+  ],
+  "etapas": [
+    "CRECE = 2Grow Sólido 15-3-3.",
+    "EQUILIBRA = 2Balance Sólido 7-7-7.",
+    "FLORECE = 2Bloom Sólido 3-8-3.",
+    "FRUCTIFICA = 2Fruit Sólido 3-3-8.",
+    "COMPOST = materia orgánica y acondicionamiento del sustrato.",
+  ],
+  "trasplante": [
+    "Prioriza drenaje y estructura del sustrato.",
+    "Manipula raíces con cuidado y evita sobrecompactar.",
+    "Mantén humedad adecuada sin encharcar.",
+    "Espera señales de estabilidad y nueva actividad antes de escoger una etapa nutricional.",
+    "La guía de trasplante es educativa; no habilita el Kit Trasplanta & Arranca bloqueado.",
+  ],
+} as const;
+
+export default function CasaJardinGuiasPage() {
+  return (
+    <div className={styles.page}>
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Wondergreen Casa & Jardín · biblioteca</span>
+              <h1>Guías para observar antes de aplicar.</h1>
+              <p className={styles.lead}>El handoff de MKTG Studio incluye cuatro guías útiles para la primera versión web. Su contenido se vuelve navegable aquí y los PDFs se conservan como material descargable de apoyo.</p>
+              <div className={styles.actions}><Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin">← Volver a Casa, Jardín y Vivero</Link></div>
+            </div>
+            <aside className={styles.heroVisual}>
+              <p className={styles.heroNote}>DEL PDF A CONTENIDO NAVEGABLE</p>
+              <strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>Conocimiento que acompaña la decisión.</strong>
+            </aside>
+          </div>
+        </section>
+
+        {homeGardenGuides.map((guide, index) => (
+          <section className={`${styles.section} ${index % 2 ? styles.soft : ""}`} id={guide.id} key={guide.id}>
+            <div className={styles.container}>
+              <div className={styles.sectionHead}>
+                <div><span className={styles.eyebrow}>Guía {String(index + 1).padStart(2, "0")}</span><h2>{guide.title}</h2></div>
+                <p>{guide.summary}</p>
+              </div>
+              <div className={styles.decisionGrid}>
+                {guideContent[guide.id as keyof typeof guideContent].map((item, itemIndex) => (
+                  <article className={styles.decisionCard} key={item}>
+                    <span className={styles.eyebrow}>{String(itemIndex + 1).padStart(2, "0")}</span>
+                    <p><strong>{item}</strong></p>
+                  </article>
+                ))}
+              </div>
+              <div className={styles.actions}>
+                <a className={`${styles.button} ${styles.primary}`} href={guide.file}>Descargar PDF optimizado</a>
+              </div>
+            </div>
+          </section>
+        ))}
+
+        <section className={`${styles.section} ${styles.release}`}>
+          <div className={styles.container}>
+            <div className={styles.guardrail}>
+              <strong>Las guías no reemplazan diagnóstico ni Product Truth.</strong>
+              <p>Dosis domésticas, frecuencia, equivalencias del dosificador, presentaciones B2C y claims finales siguen subordinados a la validación técnica y comercial. Ante estrés severo, exceso de agua, daño sanitario o problemas radiculares, no empieces fertilizando.</p>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/casa-jardin/guias/page.tsx
+++ b/src/app/casa-jardin/guias/page.tsx
@@ -11,34 +11,10 @@ export const metadata: Metadata = {
 };
 
 const guideContent = {
-  "casa-jardin": [
-    "Identifica primero la etapa: suelo, crecimiento, mantenimiento, floración o producción.",
-    "Usa el método OBSERVA → IDENTIFICA → ELIGE → APLICA → REVISA.",
-    "No conviertas un síntoma aislado en una receta nutricional.",
-    "Trabaja con humedad adecuada y no acumules pellets contra el tallo.",
-    "Detén la fertilización si hay encharcamiento, pudrición, raíces comprometidas o marchitez severa.",
-  ],
-  "mi-huerta": [
-    "PREPARA: materia orgánica y condición del sustrato antes de exigir producción.",
-    "CRECE: etapa vegetativa y desarrollo de hojas/brotes.",
-    "FLORECE: cambia de lógica cuando aparecen botones y flores.",
-    "FRUCTIFICA: acompaña la etapa productiva sin prometer rendimiento o cosecha.",
-    "La secuencia es por etapas; no significa aplicar todos los productos al mismo tiempo.",
-  ],
-  "etapas": [
-    "CRECE = 2Grow Sólido 15-3-3.",
-    "EQUILIBRA = 2Balance Sólido 7-7-7.",
-    "FLORECE = 2Bloom Sólido 3-8-3.",
-    "FRUCTIFICA = 2Fruit Sólido 3-3-8.",
-    "COMPOST = materia orgánica y acondicionamiento del sustrato.",
-  ],
-  "trasplante": [
-    "Prioriza drenaje y estructura del sustrato.",
-    "Manipula raíces con cuidado y evita sobrecompactar.",
-    "Mantén humedad adecuada sin encharcar.",
-    "Espera señales de estabilidad y nueva actividad antes de escoger una etapa nutricional.",
-    "La guía de trasplante es educativa; no habilita el Kit Trasplanta & Arranca bloqueado.",
-  ],
+  "casa-jardin": ["Identifica primero la etapa: suelo, crecimiento, mantenimiento, floración o producción.", "Usa OBSERVA → IDENTIFICA → ELIGE → APLICA → REVISA.", "No conviertas un síntoma aislado en una receta nutricional.", "Trabaja con humedad adecuada y no acumules pellets contra el tallo.", "Detén la fertilización si hay encharcamiento, raíces comprometidas o marchitez severa."],
+  "mi-huerta": ["PREPARA: condición del sustrato antes de exigir producción.", "CRECE: etapa vegetativa.", "FLORECE: cambia de lógica cuando aparecen botones y flores.", "FRUCTIFICA: acompaña la etapa productiva sin prometer rendimiento.", "La secuencia es por etapas; no significa aplicar todo al mismo tiempo."],
+  etapas: ["CRECE = 2Grow Sólido 15-3-3.", "EQUILIBRA = 2Balance Sólido 7-7-7.", "FLORECE = 2Bloom Sólido 3-8-3.", "FRUCTIFICA = 2Fruit Sólido 3-3-8.", "COMPOST = materia orgánica y acondicionamiento del sustrato."],
+  trasplante: ["Prioriza drenaje y estructura del sustrato.", "Manipula raíces con cuidado y evita sobrecompactar.", "Mantén humedad adecuada sin encharcar.", "Espera estabilidad antes de escoger una etapa nutricional.", "La guía es educativa; no habilita el Kit Trasplanta & Arranca bloqueado."],
 } as const;
 
 export default function CasaJardinGuiasPage() {
@@ -50,13 +26,10 @@ export default function CasaJardinGuiasPage() {
             <div>
               <span className={styles.eyebrow}>Wondergreen Casa & Jardín · biblioteca</span>
               <h1>Guías para observar antes de aplicar.</h1>
-              <p className={styles.lead}>El handoff de MKTG Studio incluye cuatro guías útiles para la primera versión web. Su contenido se vuelve navegable aquí y los PDFs se conservan como material descargable de apoyo.</p>
+              <p className={styles.lead}>El handoff de MKTG Studio incluye cuatro guías útiles para esta primera versión. Su conocimiento ya vive de forma navegable aquí; los binarios PDF se mantienen separados hasta completar su incorporación técnica al repositorio.</p>
               <div className={styles.actions}><Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin">← Volver a Casa, Jardín y Vivero</Link></div>
             </div>
-            <aside className={styles.heroVisual}>
-              <p className={styles.heroNote}>DEL PDF A CONTENIDO NAVEGABLE</p>
-              <strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>Conocimiento que acompaña la decisión.</strong>
-            </aside>
+            <aside className={styles.heroVisual}><p className={styles.heroNote}>DEL PDF A CONTENIDO NAVEGABLE</p><strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>Conocimiento que acompaña la decisión.</strong></aside>
           </div>
         </section>
 
@@ -68,28 +41,17 @@ export default function CasaJardinGuiasPage() {
                 <p>{guide.summary}</p>
               </div>
               <div className={styles.decisionGrid}>
-                {guideContent[guide.id as keyof typeof guideContent].map((item, itemIndex) => (
-                  <article className={styles.decisionCard} key={item}>
-                    <span className={styles.eyebrow}>{String(itemIndex + 1).padStart(2, "0")}</span>
-                    <p><strong>{item}</strong></p>
-                  </article>
-                ))}
+                {guideContent[guide.id as keyof typeof guideContent].map((item, itemIndex) => <article className={styles.decisionCard} key={item}><span className={styles.eyebrow}>{String(itemIndex + 1).padStart(2, "0")}</span><p><strong>{item}</strong></p></article>)}
               </div>
-              <div className={styles.actions}>
-                <a className={`${styles.button} ${styles.primary}`} href={guide.file}>Descargar PDF optimizado</a>
+              <div className={styles.guardrail}>
+                <strong>PDF fuente validado en el handoff.</strong>
+                <p>{guide.sourceFile} · El archivo optimizado ya fue extraído y revisado, pero la descarga web permanece deshabilitada hasta que el binario quede incorporado y verificado dentro del deploy.</p>
               </div>
             </div>
           </section>
         ))}
 
-        <section className={`${styles.section} ${styles.release}`}>
-          <div className={styles.container}>
-            <div className={styles.guardrail}>
-              <strong>Las guías no reemplazan diagnóstico ni Product Truth.</strong>
-              <p>Dosis domésticas, frecuencia, equivalencias del dosificador, presentaciones B2C y claims finales siguen subordinados a la validación técnica y comercial. Ante estrés severo, exceso de agua, daño sanitario o problemas radiculares, no empieces fertilizando.</p>
-            </div>
-          </div>
-        </section>
+        <section className={`${styles.section} ${styles.release}`}><div className={styles.container}><div className={styles.guardrail}><strong>Las guías no reemplazan diagnóstico ni Product Truth.</strong><p>Dosis domésticas, frecuencia, equivalencias del dosificador, presentaciones B2C y claims finales siguen subordinados a validación técnica y comercial.</p></div></div></section>
       </main>
     </div>
   );

--- a/src/app/casa-jardin/page.tsx
+++ b/src/app/casa-jardin/page.tsx
@@ -1,40 +1,201 @@
+import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
-import styles from "../company-public.module.css";
-import refresh from "../company-public-v9.module.css";
+import {
+  homeGardenApplication,
+  homeGardenFaq,
+  homeGardenGuides,
+  homeGardenMethod,
+  homeGardenProducts,
+  homeGardenRelease,
+  homeGardenTrafficLight,
+  visibleHomeGardenKits,
+} from "@/data/home-garden";
+import styles from "./casa-jardin.module.css";
+
+export const metadata: Metadata = {
+  title: "Casa, Jardín y Vivero | Wondergreen · Greenatics",
+  description: "Nutrición por etapas para plantas, jardín, huerta y vivero: observa, identifica, elige, aplica y revisa con el sistema Wondergreen Casa & Jardín.",
+  alternates: { canonical: "/casa-jardin" },
+  robots: { index: false, follow: true },
+};
+
+const plantQuestions = [
+  ["Está creciendo o sacando brotes", "CRECE", "2Grow Sólido 15-3-3"],
+  ["Está estable y quieres mantenerla", "EQUILIBRA", "2Balance Sólido 7-7-7"],
+  ["Está formando botones o flores", "FLORECE", "2Bloom Sólido 3-8-3"],
+  ["Está en fruto o etapa productiva", "FRUCTIFICA", "2Fruit Sólido 3-3-8"],
+  ["Vas a preparar o recuperar sustrato", "COMPOST", "Materia orgánica + acondicionamiento"],
+] as const;
 
 export default function CasaJardinPage() {
   return (
-    <div className={`${styles.page} ${refresh.page}`}>
+    <div className={styles.page}>
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Greenatics · próxima línea</span>
-              <h1>Casa y Jardín.</h1>
-              <p className={styles.lead}>
-                Estamos preparando un espacio para soluciones Greenatics y Wondergreen pensadas para plantas, huertas, jardín y autocultivo en casa.
-              </p>
+              <span className={styles.eyebrow}>Wondergreen · Casa, jardín y vivero</span>
+              <h1>Nutrición por etapas para tus plantas.</h1>
+              <p className={styles.lead}>Tu planta cambia. Su nutrición también. Observa qué está haciendo, identifica su condición y elige solo la etapa que necesita. La propuesta Casa & Jardín lleva la lógica Wondergreen a hogares, huertas, jardines y viveros sin convertir la fertilización en una receta automática.</p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen">Conocer Wondergreen</Link>
-                <Link className={`${styles.button} ${styles.ghost}`} href="/biblioteca">Explorar conocimiento</Link>
+                <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Encontrar un punto de partida</Link>
+                <a className={`${styles.button} ${styles.ghost}`} href="#kits">Explorar kits</a>
               </div>
             </div>
-            <aside className={styles.officeCard}>
-              <span>Próximamente</span>
-              <strong>Este espacio ya hace parte de la arquitectura pública.</strong>
-              <span>Los kits, presentaciones, coberturas, precios y contenidos se publicarán únicamente cuando queden definidos y validados.</span>
+            <aside className={styles.heroVisual}>
+              <p className={styles.heroNote}>No apliques todo. Aplica lo que necesita. La identidad técnica sigue en Wondergreen; Greenatics aporta el sistema circular, el conocimiento y el soporte.</p>
+              <Image src="/brand/wondergreen-nutrients.webp" width={720} height={310} alt="Logotipo oficial de Wondergreen Nutrients" priority />
             </aside>
+          </div>
+        </section>
+
+        <section className={styles.path} aria-label="Método Wondergreen Casa y Jardín">
+          <div className={`${styles.container} ${styles.pathGrid}`}>
+            {homeGardenMethod.map((step, index) => <div key={step}><span>{String(index + 1).padStart(2, "0")}</span><strong>{step}</strong></div>)}
+          </div>
+        </section>
+
+        <section className={styles.section} id="etapas">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>4 etapas + suelo</span><h2>No necesita más. Necesita lo correcto.</h2></div>
+              <p>CRECE, EQUILIBRA, FLORECE y FRUCTIFICA son nombres de uso doméstico para referencias sólidas Wondergreen ya existentes. COMPOST prepara y acondiciona el sistema de suelo. Las presentaciones B2C siguen en cierre y no se muestran como SKUs comprables todavía.</p>
+            </div>
+            <div className={styles.productGrid}>
+              {homeGardenProducts.map((product) => (
+                <article className={`${styles.card} ${styles[product.accent]}`} key={product.id}>
+                  <div className={styles.stageBar} aria-hidden="true" />
+                  <small>{product.id === "prepara" ? "Base del sistema" : "Etapa nutricional"}</small>
+                  <h3>{product.consumerName}</h3>
+                  <span className={styles.formula}>{product.formula ?? "Compost"}</span>
+                  <p>{product.role}</p>
+                  <p><strong>{product.prompt}</strong></p>
+                  <Link href={`/wondergreen/productos/${product.technicalSlug}`}>Ver Product Truth técnico →</Link>
+                </article>
+              ))}
+            </div>
           </div>
         </section>
 
         <section className={`${styles.section} ${styles.soft}`}>
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <span className={styles.eyebrow}>Espacio reservado</span>
-              <h2>Primero consolidamos la oferta. Luego abrimos la tienda.</h2>
-              <p>
-                Por ahora esta sección funciona como puerta de entrada futura. No publicamos productos, promesas, dosis ni precios provisionales.
-              </p>
+              <div><span className={styles.eyebrow}>Antes del producto</span><h2>¿Qué está haciendo tu planta?</h2></div>
+              <p>La entrada correcta no es “qué fertilizante compro”, sino “qué etapa y condición estoy observando”. Si hay estrés severo, exceso de agua, raíces comprometidas o daño sanitario, la respuesta puede ser no fertilizar todavía.</p>
+            </div>
+            <div className={styles.decisionGrid}>
+              {plantQuestions.map(([situation, result, technical]) => (
+                <article className={styles.decisionCard} key={situation}>
+                  <span className={styles.eyebrow}>Si observas</span>
+                  <h3>{situation}</h3>
+                  <p><strong>{result}</strong> · {technical}</p>
+                </article>
+              ))}
+              <article className={styles.decisionCard}>
+                <span className={styles.eyebrow}>Si “se ve mal”</span>
+                <h3>No empieces fertilizando.</h3>
+                <p>Primero revisa agua, drenaje, raíces, luz y sanidad. Una hoja amarilla o una planta marchita no son diagnósticos nutricionales por sí solos.</p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section} id="kits">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Kits Casa & Jardín · pre-lanzamiento</span><h2>Compra la lógica del sistema, no una mezcla de productos.</h2></div>
+              <p>Los cinco kits visibles provienen del handoff comercial validado como arquitectura. Aún no tienen checkout ni PVP público: faltan cerrar formatos domésticos, dosificador, empaque, etiquetas, stock y logística.</p>
+            </div>
+            <div className={styles.kitGrid}>
+              {visibleHomeGardenKits.map((kit) => (
+                <article className={styles.kitCard} key={kit.id}>
+                  <span className={styles.eyebrow}>{kit.audience}</span>
+                  <h3>{kit.name}</h3>
+                  <p><strong>{kit.promise}</strong></p>
+                  <ul>{kit.contents.map((content) => <li key={content}>{content}</li>)}</ul>
+                  <p>{kit.guardrail}</p>
+                  <div className={styles.status}>Pre-lanzamiento · compra deshabilitada</div>
+                </article>
+              ))}
+            </div>
+            <div className={styles.guardrail}>
+              <strong>Trasplanta & Arranca no aparece como kit disponible.</strong>
+              <p>El handoff lo bloquea expresamente hasta validar el componente radicular/bioinsumo. Sí mantenemos la guía educativa de trasplante, porque su lógica es primero drenaje, raíces, estabilidad y observación.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.dark}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Cómo aplicar</span><h2>Ni de más. Ni a ojo.</h2></div>
+              <p>La frecuencia y equivalencia doméstica del dosificador todavía no están reconciliadas. Publicarlas hoy como universales sería convertir una herramienta orientativa en una receta sin validar.</p>
+            </div>
+            <div className={styles.flow}>
+              {homeGardenApplication.map((item, index) => <article key={item.step}><strong>{String(index + 1).padStart(2, "0")} · {item.step}</strong><p>{item.copy}</p></article>)}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Semáforo antes de aplicar</span><h2>A veces, la mejor dosis es no fertilizar todavía.</h2></div>
+              <p>El sistema debe ayudar a detener una mala decisión, no solo recomendar un producto. Este semáforo es la regla de seguridad central del diagnóstico Casa & Jardín.</p>
+            </div>
+            <div className={styles.trafficGrid}>
+              {homeGardenTrafficLight.map((item) => <article className={styles.trafficCard} key={item.level}><span className={styles.level}>{item.level}</span><h3>{item.title}</h3><p>{item.copy}</p></article>)}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`} id="guias">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Conocimiento práctico</span><h2>Guías para mirar mejor antes de decidir.</h2></div>
+              <p>El handoff incluye guías maestras de Casa & Jardín, Mi Huerta, etapas y trasplante. Las llevamos a una biblioteca navegable para que el PDF sea soporte, no el único lugar donde vive el conocimiento.</p>
+            </div>
+            <div className={styles.guideGrid}>
+              {homeGardenGuides.map((guide) => (
+                <article className={styles.guideCard} key={guide.id}>
+                  <span>Guía del handoff</span>
+                  <h3>{guide.title}</h3>
+                  <p>{guide.summary}</p>
+                  <Link href={`/casa-jardin/guias#${guide.id}`}>Abrir guía →</Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Diagnóstico orientativo</span><h2>Deja de fertilizar a ciegas.</h2></div>
+              <p>El diagnóstico pregunta tipo de planta, etapa y condición. Si detecta una señal de seguridad, detiene la recomendación. Si el contexto es claro, orienta hacia una etapa o kit sin calcular gramos todavía.</p>
+            </div>
+            <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Iniciar diagnóstico</Link></div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Preguntas frecuentes</span><h2>Lo que el sistema sí puede —y no puede— decirte.</h2></div>
+              <p>Las respuestas conservan los límites del handoff: nutrición por etapa, sin promesas de floración, rendimiento o diagnósticos automáticos a partir de un solo síntoma.</p>
+            </div>
+            <div className={styles.faq}>{homeGardenFaq.map((item) => <details key={item.q}><summary>{item.q}</summary><p>{item.a}</p></details>)}</div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.release}`}>
+          <div className={`${styles.container} ${styles.releaseGrid}`}>
+            <div><span className={styles.eyebrow}>Estado de lanzamiento</span><h2>La experiencia ya puede construirse. La tienda todavía no.</h2><p className={styles.lead}>Este primer release queda deliberadamente sin indexar y sin checkout. La arquitectura, el contenido y el diagnóstico sí se prueban dentro de la web; compra y precios se habilitan únicamente cuando sus dependencias estén reconciliadas.</p></div>
+            <div>
+              <strong>Bloqueos antes de activar ecommerce</strong>
+              <ul>{homeGardenRelease.blockedReasons.map((reason) => <li key={reason}>{reason}</li>)}</ul>
+              <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/wondergreen">Ver Wondergreen técnico</Link><Link className={`${styles.button} ${styles.ghost}`} href="/contacto">Hablar con Greenatics</Link></div>
             </div>
           </div>
         </section>

--- a/src/data/home-garden-assets.test.ts
+++ b/src/data/home-garden-assets.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { blockedHomeGardenAssets, homeGardenAssets, publishableHomeGardenAssets } from "./home-garden-assets";
+
+describe("Casa and Garden handoff asset governance", () => {
+  it("blocks the conflicting hero, transplant kit and unfinished QR card", () => {
+    expect(blockedHomeGardenAssets.map((asset) => asset.id)).toEqual([
+      "hero-source",
+      "kit-transplant-source",
+      "kit-card-qr",
+    ]);
+  });
+
+  it("keeps five packshots and five kit concepts as prelaunch candidates only", () => {
+    expect(homeGardenAssets.filter((asset) => asset.kind === "packshot" && asset.status === "candidate-web")).toHaveLength(5);
+    expect(homeGardenAssets.filter((asset) => asset.kind === "kit" && asset.status === "candidate-web")).toHaveLength(5);
+    for (const asset of publishableHomeGardenAssets.filter((item) => item.kind === "packshot" || item.kind === "kit")) {
+      expect(asset.guardrail).toMatch(/prelaunch|pre-lanzamiento|reconciled|reconciliado|price|precio/i);
+    }
+  });
+
+  it("keeps four validated source guides without treating image text as Product Truth", () => {
+    const guides = homeGardenAssets.filter((asset) => asset.kind === "pdf" && asset.status === "source-guide");
+    expect(guides).toHaveLength(4);
+    for (const guide of guides) expect(guide.guardrail).toMatch(/Product Truth override/i);
+  });
+});

--- a/src/data/home-garden-assets.ts
+++ b/src/data/home-garden-assets.ts
@@ -1,0 +1,100 @@
+export type HomeGardenAssetStatus = "candidate-web" | "source-guide" | "blocked";
+
+export type HomeGardenAsset = {
+  id: string;
+  sourceFile: string;
+  kind: "hero" | "packshot" | "kit" | "education" | "pdf" | "draft";
+  status: HomeGardenAssetStatus;
+  use: string;
+  guardrail: string;
+};
+
+// Inventory extracted from WONDERGREEN_CASA_JARDIN_WEB_HANDOFF_V1_2026-08-19.
+// This manifest governs whether a source asset may enter the public web. It does not assert
+// that the binary is already deployed, nor does artwork override Product Truth.
+export const homeGardenAssets: readonly HomeGardenAsset[] = [
+  {
+    id: "hero-source",
+    sourceFile: "hero_casa_y_jardin.png",
+    kind: "hero",
+    status: "blocked",
+    use: "Aesthetic reference only until packaging text is reconciled.",
+    guardrail: "The artwork shows a Compost household weight that conflicts with current/proposed structured product data. Do not publish as-is.",
+  },
+  ...[
+    ["packshot-crece", "packshot_crece.png", "CRECE / 2Grow 15-3-3"],
+    ["packshot-equilibra", "packshot_equilibra.png", "EQUILIBRA / 2Balance 7-7-7"],
+    ["packshot-florece", "packshot_florece.png", "FLORECE / 2Bloom 3-8-3"],
+    ["packshot-fructifica", "packshot_fructifica.png", "FRUCTIFICA / 2Fruit 3-3-8"],
+    ["packshot-compost", "packshot_compost.png", "COMPOST"],
+  ].map(([id, sourceFile, use]) => ({
+    id,
+    sourceFile,
+    kind: "packshot" as const,
+    status: "candidate-web" as const,
+    use,
+    guardrail: "Use only as a prelaunch visual after checking visible formula/weight. It does not make a household pack a reconciled commercial SKU or final print label.",
+  })),
+  ...[
+    ["kit-plantas-verdes", "kit_plantas_verdes.png", "Kit Plantas Verdes"],
+    ["kit-plantas-flor", "kit_plantas_con_flor.png", "Kit Plantas con Flor"],
+    ["kit-mi-huerta", "kit_mi_huerta.png", "Kit Mi Huerta"],
+    ["kit-casa-completa", "kit_casa_completa.png", "Kit Casa Completa"],
+    ["kit-casa-completa-xl", "kit_casa_completa_xl.png", "Casa Completa XL"],
+  ].map(([id, sourceFile, use]) => ({
+    id,
+    sourceFile,
+    kind: "kit" as const,
+    status: "candidate-web" as const,
+    use,
+    guardrail: "Concept/prelaunch visual only. Do not infer price, exact household net content, savings, stock or checkout availability from the image.",
+  })),
+  {
+    id: "education-pot-size",
+    sourceFile: "C5_tamanos_matera.png",
+    kind: "education",
+    status: "candidate-web",
+    use: "Explain pot-size classification for future diagnosis/sizing.",
+    guardrail: "Do not convert S/M/L/XL into grams or dose until the household dose table is validated.",
+  },
+  {
+    id: "education-stress",
+    sourceFile: "C6_no_todo_estres.png",
+    kind: "education",
+    status: "candidate-web",
+    use: "Safety education: symptoms are not automatically fertilizer deficiencies.",
+    guardrail: "Use structured diagnostic copy as the source of truth if image text differs.",
+  },
+  ...[
+    ["guide-master", "GUIA_WONDERGREEN_CASA_Y_JARDIN_IMAGEGEN_V1.pdf", "Master Casa & Jardín guide"],
+    ["guide-huerta", "Guia_Mi_Huerta_Wondergreen_V1_optimizada.pdf", "Mi Huerta guide"],
+    ["guide-etapas", "GUIA_RAPIDA_ETAPAS_WONDERGREEN_IMAGEGEN_V1.pdf", "Stage quick guide"],
+    ["guide-trasplante", "GUIA_TRASPLANTE_WONDERGREEN_IMAGEGEN_V1.pdf", "Transplant education guide"],
+  ].map(([id, sourceFile, use]) => ({
+    id,
+    sourceFile,
+    kind: "pdf" as const,
+    status: "source-guide" as const,
+    use,
+    guardrail: "Web content and structured Product Truth override generated-image text. Remove/replace any nonfunctional QR before public binary deployment.",
+  })),
+  {
+    id: "kit-transplant-source",
+    sourceFile: "kit_trasplanta_arranca.png",
+    kind: "draft",
+    status: "blocked",
+    use: "Reference only.",
+    guardrail: "Do not publish or sell until the root/bioinput component has reconciled technical, regulatory and commercial truth.",
+  },
+  {
+    id: "kit-card-qr",
+    sourceFile: "TARJETA_KIT_WONDERGREEN_DOBLE_CARA_IMAGEGEN_V1.pdf",
+    kind: "draft",
+    status: "blocked",
+    use: "Future physical kit card.",
+    guardrail: "Contains/depends on QR and dosifier details that are not final. Do not publish as a functional asset.",
+  },
+] as const;
+
+export const publishableHomeGardenAssets = homeGardenAssets.filter((asset) => asset.status !== "blocked");
+export const blockedHomeGardenAssets = homeGardenAssets.filter((asset) => asset.status === "blocked");

--- a/src/data/home-garden.test.ts
+++ b/src/data/home-garden.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  homeGardenDiagnostic,
+  homeGardenKits,
+  homeGardenProducts,
+  homeGardenRelease,
+  visibleHomeGardenKits,
+} from "./home-garden";
+import { getWondergreenReference } from "./wondergreen-public";
+
+describe("Casa, Jardín y Vivero governed offer", () => {
+  it("maps the five household stages to existing Wondergreen technical truth", () => {
+    expect(homeGardenProducts).toHaveLength(5);
+    expect(homeGardenProducts.map((product) => [product.consumerName, product.formula])).toEqual([
+      ["COMPOST", undefined],
+      ["CRECE", "15-3-3"],
+      ["EQUILIBRA", "7-7-7"],
+      ["FLORECE", "3-8-3"],
+      ["FRUCTIFICA", "3-3-8"],
+    ]);
+
+    for (const product of homeGardenProducts) {
+      const technicalReference = getWondergreenReference(product.technicalSlug);
+      expect(technicalReference, product.technicalSlug).toBeDefined();
+      expect(technicalReference?.truthStatus).toBe("commercial-reconciled");
+      if (product.formula) expect(technicalReference?.formula).toBe(product.formula);
+    }
+  });
+
+  it("publishes five prelaunch kit concepts while keeping transplant kit blocked", () => {
+    expect(visibleHomeGardenKits).toHaveLength(5);
+    expect(visibleHomeGardenKits.every((kit) => kit.availability === "prelaunch")).toBe(true);
+
+    const transplant = homeGardenKits.find((kit) => kit.id === "trasplanta-arranca");
+    expect(transplant?.availability).toBe("blocked");
+    expect(transplant?.guardrail).toMatch(/no se publica como SKU/i);
+  });
+
+  it("keeps prices, checkout, B2C variants and dose calculator disabled", () => {
+    expect(homeGardenRelease).toMatchObject({
+      indexable: false,
+      checkoutEnabled: false,
+      priceEnabled: false,
+      householdDoseCalculatorEnabled: false,
+      householdVariantsReconciled: false,
+    });
+    expect(homeGardenDiagnostic.calculatorEnabled).toBe(false);
+  });
+
+  it("stops fertilizer-first recommendations when a safety trigger is present", () => {
+    expect(homeGardenDiagnostic.safetyTriggers).toEqual([
+      "very-wilted",
+      "waterlogged",
+      "pest-damage",
+      "root-problem",
+    ]);
+    expect(homeGardenDiagnostic.safetyMessage).toMatch(/NO EMPIECES FERTILIZANDO/i);
+  });
+
+  it("routes stage logic without turning every symptom into a fertilizer recommendation", () => {
+    expect(homeGardenDiagnostic.stages).toEqual({
+      growing: "crece",
+      stable: "equilibra",
+      flowering: "florece",
+      fruiting: "fructifica",
+      mixed: "casa-completa",
+    });
+  });
+});

--- a/src/data/home-garden.ts
+++ b/src/data/home-garden.ts
@@ -1,0 +1,222 @@
+export type HomeGardenStage = "prepara" | "crece" | "equilibra" | "florece" | "fructifica";
+export type HomeGardenAvailability = "technical-truth" | "prelaunch" | "blocked";
+
+export type HomeGardenProduct = {
+  id: HomeGardenStage;
+  consumerName: string;
+  technicalName: string;
+  formula?: string;
+  role: string;
+  prompt: string;
+  accent: "earth" | "orange" | "violet" | "blue" | "coral";
+  technicalSlug: string;
+  availability: HomeGardenAvailability;
+  householdFormatStatus: string;
+};
+
+export type HomeGardenKit = {
+  id: string;
+  name: string;
+  audience: string;
+  promise: string;
+  pathway: readonly HomeGardenStage[];
+  contents: readonly string[];
+  availability: "prelaunch" | "blocked";
+  guardrail: string;
+};
+
+export type HomeGardenGuide = {
+  id: string;
+  title: string;
+  summary: string;
+  file: string;
+  status: "web-ready";
+};
+
+export const homeGardenProducts: readonly HomeGardenProduct[] = [
+  {
+    id: "prepara",
+    consumerName: "COMPOST",
+    technicalName: "Wondergreen Compost",
+    role: "Materia orgánica y acondicionamiento del sustrato antes de pensar en la siguiente etapa de nutrición.",
+    prompt: "Empieza por el suelo.",
+    accent: "earth",
+    technicalSlug: "compost",
+    availability: "technical-truth",
+    householdFormatStatus: "Las presentaciones domésticas siguen en cierre; la referencia técnica/comercial vigente conserva su Product Truth propio.",
+  },
+  {
+    id: "crece",
+    consumerName: "CRECE",
+    technicalName: "2Grow Sólido",
+    formula: "15-3-3",
+    role: "Crecimiento, brotación y recuperación vegetativa dentro del sistema Wondergreen.",
+    prompt: "Cuando la planta está creciendo, cambia lo que necesita.",
+    accent: "orange",
+    technicalSlug: "2grow-solido-15-3-3",
+    availability: "technical-truth",
+    householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra.",
+  },
+  {
+    id: "equilibra",
+    consumerName: "EQUILIBRA",
+    technicalName: "2Balance Sólido",
+    formula: "7-7-7",
+    role: "Mantenimiento y nutrición balanceada cuando la planta se encuentra estable.",
+    prompt: "No siempre necesita empuje. A veces necesita equilibrio.",
+    accent: "violet",
+    technicalSlug: "2balance-solido-7-7-7",
+    availability: "technical-truth",
+    householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra.",
+  },
+  {
+    id: "florece",
+    consumerName: "FLORECE",
+    technicalName: "2Bloom Sólido",
+    formula: "3-8-3",
+    role: "Etapas de transición reproductiva, prefloración y floración, sin convertir nutrición en una promesa de floración.",
+    prompt: "Si cambia a floración, cambia su nutrición.",
+    accent: "blue",
+    technicalSlug: "2bloom-solido-3-8-3",
+    availability: "technical-truth",
+    householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra.",
+  },
+  {
+    id: "fructifica",
+    consumerName: "FRUCTIFICA",
+    technicalName: "2Fruit Sólido",
+    formula: "3-3-8",
+    role: "Etapas productivas, cuajado, desarrollo y llenado, sin prometer rendimiento, calibre o cosecha.",
+    prompt: "La etapa productiva tiene otra lógica nutricional.",
+    accent: "coral",
+    technicalSlug: "2fruit-solido-3-3-8",
+    availability: "technical-truth",
+    householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra.",
+  },
+] as const;
+
+export const homeGardenMethod = ["OBSERVA", "IDENTIFICA", "ELIGE", "APLICA", "REVISA"] as const;
+
+export const homeGardenKits: readonly HomeGardenKit[] = [
+  {
+    id: "plantas-verdes",
+    name: "Kit Plantas Verdes",
+    audience: "Plantas de follaje, interior y exterior",
+    promise: "Crece cuando lo necesita. Equilibra cuando está estable.",
+    pathway: ["crece", "equilibra"],
+    contents: ["CRECE", "EQUILIBRA", "dosificador pendiente de calibración final", "guía de uso"],
+    availability: "prelaunch",
+    guardrail: "Concepto de kit validado para la arquitectura web. Precio, formatos domésticos, dosificador y checkout permanecen bloqueados hasta cierre comercial y técnico.",
+  },
+  {
+    id: "plantas-con-flor",
+    name: "Kit Plantas con Flor",
+    audience: "Plantas ornamentales con transición a floración",
+    promise: "Si cambia a floración, cambia su nutrición.",
+    pathway: ["equilibra", "florece"],
+    contents: ["EQUILIBRA", "FLORECE", "dosificador pendiente de calibración final", "guía de uso"],
+    availability: "prelaunch",
+    guardrail: "El kit no promete inducir floración. Es una lógica de nutrición por etapa y no sustituye la evaluación de luz, agua, edad, especie o sanidad.",
+  },
+  {
+    id: "mi-huerta",
+    name: "Kit Mi Huerta",
+    audience: "Huertas domésticas, aromáticas y plantas productivas",
+    promise: "Del sustrato al fruto.",
+    pathway: ["prepara", "crece", "florece", "fructifica"],
+    contents: ["COMPOST", "CRECE", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía Mi Huerta"],
+    availability: "prelaunch",
+    guardrail: "La secuencia representa etapas; no significa aplicar todos los productos simultáneamente ni garantiza floración, cuajado o cosecha.",
+  },
+  {
+    id: "casa-completa",
+    name: "Kit Casa Completa",
+    audience: "Hogares con plantas en distintas etapas",
+    promise: "4 etapas. 1 sistema. Cero adivinanzas.",
+    pathway: ["crece", "equilibra", "florece", "fructifica"],
+    contents: ["CRECE", "EQUILIBRA", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía + diagnóstico"],
+    availability: "prelaunch",
+    guardrail: "Tener las cuatro etapas no significa usarlas juntas. Cada planta entra al sistema según su etapa y condición.",
+  },
+  {
+    id: "casa-completa-xl",
+    name: "Casa Completa XL",
+    audience: "Colecciones más amplias, jardines y viveros pequeños",
+    promise: "Muchas plantas. Una sola lógica.",
+    pathway: ["crece", "equilibra", "florece", "fructifica"],
+    contents: ["CRECE", "EQUILIBRA", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía de uso"],
+    availability: "prelaunch",
+    guardrail: "El tamaño XL es una propuesta B2C/B2B liviana en cierre; cobertura, presentaciones y PVP no se publican hasta reconciliar dosificación, empaque, stock y logística.",
+  },
+  {
+    id: "trasplanta-arranca",
+    name: "Kit Trasplanta & Arranca",
+    audience: "Trasplantes y establecimiento",
+    promise: "Primero raíz, drenaje y estabilidad; después nutrición por etapa.",
+    pathway: ["prepara"],
+    contents: ["componente radicular por validar", "guía de trasplante"],
+    availability: "blocked",
+    guardrail: "No se publica como SKU ni se habilita compra mientras el componente radicular/bioinsumo no tenga Product Truth técnico, regulatorio y comercial reconciliado.",
+  },
+] as const;
+
+export const visibleHomeGardenKits = homeGardenKits.filter((kit) => kit.availability === "prelaunch");
+
+export const homeGardenApplication = [
+  { step: "HUMEDECE", copy: "Trabaja con humedad adecuada y buen drenaje; evita fertilizar una planta encharcada o severamente estresada." },
+  { step: "DOSIFICA", copy: "La dosis doméstica final se publicará solo después de calibrar formulación y dosificador. No apliques a ojo." },
+  { step: "DISTRIBUYE", copy: "Distribuye alrededor de la zona radicular. No acumules pellets contra el tallo." },
+  { step: "OBSERVA", copy: "Revisa respuesta, humedad, etapa y condición antes de repetir una aplicación." },
+] as const;
+
+export const homeGardenTrafficLight = [
+  { level: "VERDE", title: "Puedes evaluar nutrición", copy: "Planta activa, drenaje funcional, humedad adecuada y etapa reconocible." },
+  { level: "AMARILLO", title: "Primero confirma la causa", copy: "Trasplante reciente, estrés, sustrato demasiado seco o síntomas que todavía no entiendes." },
+  { level: "ROJO", title: "No empieces fertilizando", copy: "Encharcamiento, pudrición, problema radicular, marchitez severa o daño sanitario evidente." },
+] as const;
+
+export const homeGardenDiagnostic = {
+  calculatorEnabled: false,
+  safetyTriggers: ["very-wilted", "waterlogged", "pest-damage", "root-problem"] as const,
+  safetyMessage: "NO EMPIECES FERTILIZANDO. Revisa primero agua, drenaje, raíces y sanidad.",
+  stages: {
+    growing: "crece",
+    stable: "equilibra",
+    flowering: "florece",
+    fruiting: "fructifica",
+    mixed: "casa-completa",
+  } as const,
+} as const;
+
+export const homeGardenGuides: readonly HomeGardenGuide[] = [
+  { id: "casa-jardin", title: "Guía Wondergreen Casa & Jardín", summary: "Etapas, método de observación, aplicación, semáforo y errores frecuentes.", file: "/casa-jardin/guias/guia-casa-jardin.pdf", status: "web-ready" },
+  { id: "mi-huerta", title: "Guía Mi Huerta", summary: "PREPARA → CRECE → FLORECE → FRUCTIFICA para una huerta doméstica por etapas.", file: "/casa-jardin/guias/guia-mi-huerta.pdf", status: "web-ready" },
+  { id: "etapas", title: "Guía rápida de etapas", summary: "Una referencia visual corta para identificar la etapa antes de elegir producto.", file: "/casa-jardin/guias/guia-rapida-etapas.pdf", status: "web-ready" },
+  { id: "trasplante", title: "Guía de trasplante", summary: "Drenaje, raíces, sustrato, estabilidad y observación antes de decidir nutrición.", file: "/casa-jardin/guias/guia-trasplante.pdf", status: "web-ready" },
+] as const;
+
+export const homeGardenFaq = [
+  { q: "¿Necesito usar CRECE, EQUILIBRA, FLORECE y FRUCTIFICA al mismo tiempo?", a: "No. El sistema existe para elegir según etapa y condición, no para aplicar todo junto." },
+  { q: "¿FLORECE hace que cualquier planta florezca?", a: "No. La floración también depende de especie, edad, luz, temperatura, agua, poda y condición general. La nutrición no es una garantía de floración." },
+  { q: "¿FRUCTIFICA garantiza más frutos o mejor cosecha?", a: "No. Es una línea orientada a etapas productivas; rendimiento, calibre y cosecha dependen de múltiples variables de manejo y ambiente." },
+  { q: "¿El compost reemplaza toda la nutrición?", a: "No. Aporta materia orgánica y acondicionamiento dentro del sistema de suelo, pero no sustituye automáticamente los requerimientos nutricionales de cada etapa." },
+  { q: "¿Cada cuánto debo aplicar?", a: "La frecuencia doméstica final sigue pendiente de validación por formulación, tamaño de planta, contenedor y dosificador. Por ahora no publicamos una frecuencia universal." },
+  { q: "¿Más producto produce mejores resultados?", a: "No. La lógica de Casa & Jardín es precisamente evitar la aplicación por exceso o a ojo." },
+  { q: "¿Debo fertilizar justo después de trasplantar?", a: "No automáticamente. Primero revisa drenaje, raíces, humedad y establecimiento; cuando la planta se estabilice, identifica su etapa." },
+  { q: "¿Una hoja amarilla significa falta de fertilizante?", a: "No necesariamente. Agua, raíces, plagas, enfermedades, luz y otros factores pueden producir síntomas similares." },
+] as const;
+
+export const homeGardenRelease = {
+  route: "/casa-jardin",
+  indexable: false,
+  checkoutEnabled: false,
+  priceEnabled: false,
+  householdDoseCalculatorEnabled: false,
+  householdVariantsReconciled: false,
+  blockedReasons: [
+    "Cerrar dosis domésticas por formulación y tamaño de planta/contenedor.",
+    "Calibrar equivalencias reales del dosificador por producto.",
+    "Cerrar etiquetas, textos legales y presentaciones B2C.",
+    "Reconciliar costos, PVP, márgenes, stock, empaque, armado y logística de envío.",
+  ],
+} as const;

--- a/src/data/home-garden.ts
+++ b/src/data/home-garden.ts
@@ -29,135 +29,28 @@ export type HomeGardenGuide = {
   id: string;
   title: string;
   summary: string;
-  file: string;
-  status: "web-ready";
+  sourceFile: string;
+  sourceStatus: "handoff-validated";
+  deployedDownload?: string;
 };
 
 export const homeGardenProducts: readonly HomeGardenProduct[] = [
-  {
-    id: "prepara",
-    consumerName: "COMPOST",
-    technicalName: "Wondergreen Compost",
-    role: "Materia orgánica y acondicionamiento del sustrato antes de pensar en la siguiente etapa de nutrición.",
-    prompt: "Empieza por el suelo.",
-    accent: "earth",
-    technicalSlug: "compost",
-    availability: "technical-truth",
-    householdFormatStatus: "Las presentaciones domésticas siguen en cierre; la referencia técnica/comercial vigente conserva su Product Truth propio.",
-  },
-  {
-    id: "crece",
-    consumerName: "CRECE",
-    technicalName: "2Grow Sólido",
-    formula: "15-3-3",
-    role: "Crecimiento, brotación y recuperación vegetativa dentro del sistema Wondergreen.",
-    prompt: "Cuando la planta está creciendo, cambia lo que necesita.",
-    accent: "orange",
-    technicalSlug: "2grow-solido-15-3-3",
-    availability: "technical-truth",
-    householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra.",
-  },
-  {
-    id: "equilibra",
-    consumerName: "EQUILIBRA",
-    technicalName: "2Balance Sólido",
-    formula: "7-7-7",
-    role: "Mantenimiento y nutrición balanceada cuando la planta se encuentra estable.",
-    prompt: "No siempre necesita empuje. A veces necesita equilibrio.",
-    accent: "violet",
-    technicalSlug: "2balance-solido-7-7-7",
-    availability: "technical-truth",
-    householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra.",
-  },
-  {
-    id: "florece",
-    consumerName: "FLORECE",
-    technicalName: "2Bloom Sólido",
-    formula: "3-8-3",
-    role: "Etapas de transición reproductiva, prefloración y floración, sin convertir nutrición en una promesa de floración.",
-    prompt: "Si cambia a floración, cambia su nutrición.",
-    accent: "blue",
-    technicalSlug: "2bloom-solido-3-8-3",
-    availability: "technical-truth",
-    householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra.",
-  },
-  {
-    id: "fructifica",
-    consumerName: "FRUCTIFICA",
-    technicalName: "2Fruit Sólido",
-    formula: "3-3-8",
-    role: "Etapas productivas, cuajado, desarrollo y llenado, sin prometer rendimiento, calibre o cosecha.",
-    prompt: "La etapa productiva tiene otra lógica nutricional.",
-    accent: "coral",
-    technicalSlug: "2fruit-solido-3-3-8",
-    availability: "technical-truth",
-    householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra.",
-  },
+  { id: "prepara", consumerName: "COMPOST", technicalName: "Wondergreen Compost", role: "Materia orgánica y acondicionamiento del sustrato antes de pensar en la siguiente etapa de nutrición.", prompt: "Empieza por el suelo.", accent: "earth", technicalSlug: "compost", availability: "technical-truth", householdFormatStatus: "Las presentaciones domésticas siguen en cierre; la referencia técnica/comercial vigente conserva su Product Truth propio." },
+  { id: "crece", consumerName: "CRECE", technicalName: "2Grow Sólido", formula: "15-3-3", role: "Crecimiento, brotación y recuperación vegetativa dentro del sistema Wondergreen.", prompt: "Cuando la planta está creciendo, cambia lo que necesita.", accent: "orange", technicalSlug: "2grow-solido-15-3-3", availability: "technical-truth", householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra." },
+  { id: "equilibra", consumerName: "EQUILIBRA", technicalName: "2Balance Sólido", formula: "7-7-7", role: "Mantenimiento y nutrición balanceada cuando la planta se encuentra estable.", prompt: "No siempre necesita empuje. A veces necesita equilibrio.", accent: "violet", technicalSlug: "2balance-solido-7-7-7", availability: "technical-truth", householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra." },
+  { id: "florece", consumerName: "FLORECE", technicalName: "2Bloom Sólido", formula: "3-8-3", role: "Etapas de transición reproductiva, prefloración y floración, sin convertir nutrición en una promesa de floración.", prompt: "Si cambia a floración, cambia su nutrición.", accent: "blue", technicalSlug: "2bloom-solido-3-8-3", availability: "technical-truth", householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra." },
+  { id: "fructifica", consumerName: "FRUCTIFICA", technicalName: "2Fruit Sólido", formula: "3-3-8", role: "Etapas productivas, cuajado, desarrollo y llenado, sin prometer rendimiento, calibre o cosecha.", prompt: "La etapa productiva tiene otra lógica nutricional.", accent: "coral", technicalSlug: "2fruit-solido-3-3-8", availability: "technical-truth", householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra." },
 ] as const;
 
 export const homeGardenMethod = ["OBSERVA", "IDENTIFICA", "ELIGE", "APLICA", "REVISA"] as const;
 
 export const homeGardenKits: readonly HomeGardenKit[] = [
-  {
-    id: "plantas-verdes",
-    name: "Kit Plantas Verdes",
-    audience: "Plantas de follaje, interior y exterior",
-    promise: "Crece cuando lo necesita. Equilibra cuando está estable.",
-    pathway: ["crece", "equilibra"],
-    contents: ["CRECE", "EQUILIBRA", "dosificador pendiente de calibración final", "guía de uso"],
-    availability: "prelaunch",
-    guardrail: "Concepto de kit validado para la arquitectura web. Precio, formatos domésticos, dosificador y checkout permanecen bloqueados hasta cierre comercial y técnico.",
-  },
-  {
-    id: "plantas-con-flor",
-    name: "Kit Plantas con Flor",
-    audience: "Plantas ornamentales con transición a floración",
-    promise: "Si cambia a floración, cambia su nutrición.",
-    pathway: ["equilibra", "florece"],
-    contents: ["EQUILIBRA", "FLORECE", "dosificador pendiente de calibración final", "guía de uso"],
-    availability: "prelaunch",
-    guardrail: "El kit no promete inducir floración. Es una lógica de nutrición por etapa y no sustituye la evaluación de luz, agua, edad, especie o sanidad.",
-  },
-  {
-    id: "mi-huerta",
-    name: "Kit Mi Huerta",
-    audience: "Huertas domésticas, aromáticas y plantas productivas",
-    promise: "Del sustrato al fruto.",
-    pathway: ["prepara", "crece", "florece", "fructifica"],
-    contents: ["COMPOST", "CRECE", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía Mi Huerta"],
-    availability: "prelaunch",
-    guardrail: "La secuencia representa etapas; no significa aplicar todos los productos simultáneamente ni garantiza floración, cuajado o cosecha.",
-  },
-  {
-    id: "casa-completa",
-    name: "Kit Casa Completa",
-    audience: "Hogares con plantas en distintas etapas",
-    promise: "4 etapas. 1 sistema. Cero adivinanzas.",
-    pathway: ["crece", "equilibra", "florece", "fructifica"],
-    contents: ["CRECE", "EQUILIBRA", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía + diagnóstico"],
-    availability: "prelaunch",
-    guardrail: "Tener las cuatro etapas no significa usarlas juntas. Cada planta entra al sistema según su etapa y condición.",
-  },
-  {
-    id: "casa-completa-xl",
-    name: "Casa Completa XL",
-    audience: "Colecciones más amplias, jardines y viveros pequeños",
-    promise: "Muchas plantas. Una sola lógica.",
-    pathway: ["crece", "equilibra", "florece", "fructifica"],
-    contents: ["CRECE", "EQUILIBRA", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía de uso"],
-    availability: "prelaunch",
-    guardrail: "El tamaño XL es una propuesta B2C/B2B liviana en cierre; cobertura, presentaciones y PVP no se publican hasta reconciliar dosificación, empaque, stock y logística.",
-  },
-  {
-    id: "trasplanta-arranca",
-    name: "Kit Trasplanta & Arranca",
-    audience: "Trasplantes y establecimiento",
-    promise: "Primero raíz, drenaje y estabilidad; después nutrición por etapa.",
-    pathway: ["prepara"],
-    contents: ["componente radicular por validar", "guía de trasplante"],
-    availability: "blocked",
-    guardrail: "No se publica como SKU ni se habilita compra mientras el componente radicular/bioinsumo no tenga Product Truth técnico, regulatorio y comercial reconciliado.",
-  },
+  { id: "plantas-verdes", name: "Kit Plantas Verdes", audience: "Plantas de follaje, interior y exterior", promise: "Crece cuando lo necesita. Equilibra cuando está estable.", pathway: ["crece", "equilibra"], contents: ["CRECE", "EQUILIBRA", "dosificador pendiente de calibración final", "guía de uso"], availability: "prelaunch", guardrail: "Concepto de kit validado para la arquitectura web. Precio, formatos domésticos, dosificador y checkout permanecen bloqueados hasta cierre comercial y técnico." },
+  { id: "plantas-con-flor", name: "Kit Plantas con Flor", audience: "Plantas ornamentales con transición a floración", promise: "Si cambia a floración, cambia su nutrición.", pathway: ["equilibra", "florece"], contents: ["EQUILIBRA", "FLORECE", "dosificador pendiente de calibración final", "guía de uso"], availability: "prelaunch", guardrail: "El kit no promete inducir floración. Es una lógica de nutrición por etapa y no sustituye la evaluación de luz, agua, edad, especie o sanidad." },
+  { id: "mi-huerta", name: "Kit Mi Huerta", audience: "Huertas domésticas, aromáticas y plantas productivas", promise: "Del sustrato al fruto.", pathway: ["prepara", "crece", "florece", "fructifica"], contents: ["COMPOST", "CRECE", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía Mi Huerta"], availability: "prelaunch", guardrail: "La secuencia representa etapas; no significa aplicar todos los productos simultáneamente ni garantiza floración, cuajado o cosecha." },
+  { id: "casa-completa", name: "Kit Casa Completa", audience: "Hogares con plantas en distintas etapas", promise: "4 etapas. 1 sistema. Cero adivinanzas.", pathway: ["crece", "equilibra", "florece", "fructifica"], contents: ["CRECE", "EQUILIBRA", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía + diagnóstico"], availability: "prelaunch", guardrail: "Tener las cuatro etapas no significa usarlas juntas. Cada planta entra al sistema según su etapa y condición." },
+  { id: "casa-completa-xl", name: "Casa Completa XL", audience: "Colecciones más amplias, jardines y viveros pequeños", promise: "Muchas plantas. Una sola lógica.", pathway: ["crece", "equilibra", "florece", "fructifica"], contents: ["CRECE", "EQUILIBRA", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía de uso"], availability: "prelaunch", guardrail: "El tamaño XL es una propuesta B2C/B2B liviana en cierre; cobertura, presentaciones y PVP no se publican hasta reconciliar dosificación, empaque, stock y logística." },
+  { id: "trasplanta-arranca", name: "Kit Trasplanta & Arranca", audience: "Trasplantes y establecimiento", promise: "Primero raíz, drenaje y estabilidad; después nutrición por etapa.", pathway: ["prepara"], contents: ["componente radicular por validar", "guía de trasplante"], availability: "blocked", guardrail: "No se publica como SKU ni se habilita compra mientras el componente radicular/bioinsumo no tenga Product Truth técnico, regulatorio y comercial reconciliado." },
 ] as const;
 
 export const visibleHomeGardenKits = homeGardenKits.filter((kit) => kit.availability === "prelaunch");
@@ -179,20 +72,14 @@ export const homeGardenDiagnostic = {
   calculatorEnabled: false,
   safetyTriggers: ["very-wilted", "waterlogged", "pest-damage", "root-problem"] as const,
   safetyMessage: "NO EMPIECES FERTILIZANDO. Revisa primero agua, drenaje, raíces y sanidad.",
-  stages: {
-    growing: "crece",
-    stable: "equilibra",
-    flowering: "florece",
-    fruiting: "fructifica",
-    mixed: "casa-completa",
-  } as const,
+  stages: { growing: "crece", stable: "equilibra", flowering: "florece", fruiting: "fructifica", mixed: "casa-completa" } as const,
 } as const;
 
 export const homeGardenGuides: readonly HomeGardenGuide[] = [
-  { id: "casa-jardin", title: "Guía Wondergreen Casa & Jardín", summary: "Etapas, método de observación, aplicación, semáforo y errores frecuentes.", file: "/casa-jardin/guias/guia-casa-jardin.pdf", status: "web-ready" },
-  { id: "mi-huerta", title: "Guía Mi Huerta", summary: "PREPARA → CRECE → FLORECE → FRUCTIFICA para una huerta doméstica por etapas.", file: "/casa-jardin/guias/guia-mi-huerta.pdf", status: "web-ready" },
-  { id: "etapas", title: "Guía rápida de etapas", summary: "Una referencia visual corta para identificar la etapa antes de elegir producto.", file: "/casa-jardin/guias/guia-rapida-etapas.pdf", status: "web-ready" },
-  { id: "trasplante", title: "Guía de trasplante", summary: "Drenaje, raíces, sustrato, estabilidad y observación antes de decidir nutrición.", file: "/casa-jardin/guias/guia-trasplante.pdf", status: "web-ready" },
+  { id: "casa-jardin", title: "Guía Wondergreen Casa & Jardín", summary: "Etapas, método de observación, aplicación, semáforo y errores frecuentes.", sourceFile: "GUIA_WONDERGREEN_CASA_Y_JARDIN_IMAGEGEN_V1.pdf", sourceStatus: "handoff-validated" },
+  { id: "mi-huerta", title: "Guía Mi Huerta", summary: "PREPARA → CRECE → FLORECE → FRUCTIFICA para una huerta doméstica por etapas.", sourceFile: "Guia_Mi_Huerta_Wondergreen_V1_optimizada.pdf", sourceStatus: "handoff-validated" },
+  { id: "etapas", title: "Guía rápida de etapas", summary: "Una referencia visual corta para identificar la etapa antes de elegir producto.", sourceFile: "GUIA_RAPIDA_ETAPAS_WONDERGREEN_IMAGEGEN_V1.pdf", sourceStatus: "handoff-validated" },
+  { id: "trasplante", title: "Guía de trasplante", summary: "Drenaje, raíces, sustrato, estabilidad y observación antes de decidir nutrición.", sourceFile: "GUIA_TRASPLANTE_WONDERGREEN_IMAGEGEN_V1.pdf", sourceStatus: "handoff-validated" },
 ] as const;
 
 export const homeGardenFaq = [
@@ -213,6 +100,7 @@ export const homeGardenRelease = {
   priceEnabled: false,
   householdDoseCalculatorEnabled: false,
   householdVariantsReconciled: false,
+  binaryAssetsDeployed: false,
   blockedReasons: [
     "Cerrar dosis domésticas por formulación y tamaño de planta/contenedor.",
     "Calibrar equivalencias reales del dosificador por producto.",


### PR DESCRIPTION
## Objetivo
Reemplazar el placeholder `/casa-jardin` por la primera experiencia gobernada de Wondergreen Casa & Jardín / Casa, Jardín y Vivero, usando el handoff web generado por MKTG Studio y cruzándolo con el Product Truth vigente del repo.

## Implementado
- Truth específico `home-garden.ts` separado del Product Truth técnico;
- 5 etapas/productos: COMPOST, CRECE, EQUILIBRA, FLORECE, FRUCTIFICA, enlazadas a referencias Wondergreen comerciales reconciliadas;
- 5 kits visibles como conceptos de pre-lanzamiento;
- Kit Trasplanta & Arranca modelado como `blocked` y ausente como SKU/tarjeta disponible;
- método OBSERVA → IDENTIFICA → ELIGE → APLICA → REVISA;
- semáforo de seguridad y aplicación;
- diagnóstico interactivo que detiene la recomendación ante marchitez severa, encharcamiento, daño sanitario o problema radicular;
- biblioteca navegable basada en cuatro guías fuente del handoff;
- FAQ y guardrails de claims;
- ruta y subrutas permanecen `noindex`, sin precios ni checkout;
- manifiesto `home-garden-assets.ts` que clasifica activos en candidato web, fuente de guía o bloqueado.

## Activos del handoff
Se auditó y extrajo el ZIP completo. Para esta PR los binarios no se incorporan al deploy deliberadamente: la web usa contenido estructurado y el logo canónico existente. Se generó fuera del repo un paquete curado con 5 packshots, 5 visuales de kits, 2 piezas educativas y 4 PDFs optimizados para revisión/importación posterior.

Activos bloqueados explícitamente:
- hero fuente con conflicto de peso de Compost;
- Kit Trasplanta & Arranca;
- tarjeta/QR no final;
- drafts del handoff.

## Bloqueos antes de ecommerce/indexación
- dosis domésticas finales por formulación y tamaño de planta/contenedor;
- equivalencias reales del dosificador;
- presentaciones B2C como SKUs reconciliados, etiquetas y textos legales;
- PVP, márgenes, stock, empaque, armado y logística;
- QR funcionales;
- componente radicular/bioinsumo de Trasplanta & Arranca.

## Guardrails
- no modifica `wondergreen-public.ts` ni fórmulas técnicas;
- no publica precios propuestos del handoff;
- no activa calculadora de dosis;
- no afirma que empaques 500 g / 1 kg / 2 kg ya sean Product Truth comercial vigente;
- no toca OPS/Auth/Supabase/RLS/migraciones;
- no toca `main`.

## QA final
Run #678 sobre la cabeza final:
- quality ✅
- database / fresh migrations / RLS / pgTAP / lint ✅
- desktop Chromium ✅
- mobile Chromium ✅

La rama queda 0 commits detrás de `develop` y la diff efectiva está limitada a 11 archivos de Casa, Jardín y Vivero + QA.