### PR TITLE
feat(casa): estructurar Product Truth B2C y catálogo navegable

### DIFF
--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -22,6 +22,36 @@ test("Casa Jardín and Vivero exposes stage system without price or checkout", a
   await expect(page.getByRole("link", { name: /comprar/i })).toHaveCount(0);
   await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
   await expect(page.getByRole("heading", { name: "Kit Trasplanta & Arranca", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: /Ver etapa y formatos propuestos/i }).first()).toBeVisible();
+  await expect(page.getByRole("link", { name: /Ver composición y ruta/i }).first()).toBeVisible();
+});
+
+test("Casa product detail exposes proposed household formats without making them commercial SKUs", async ({ page }) => {
+  await page.goto("/casa-jardin/productos/crece");
+
+  await expect(page.getByRole("heading", { name: "CRECE", exact: true })).toBeVisible();
+  for (const variant of ["500 g", "1 kg", "2 kg", "5 kg"]) {
+    await expect(page.getByRole("heading", { name: variant, exact: true })).toBeVisible();
+  }
+  await expect(page.getByText(/Sin precio público, cobertura ni dosis/i).first()).toBeVisible();
+  await expect(page.getByText(/La presentación pequeña no se presume habilitada/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Ver Product Truth técnico" })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
+  await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
+});
+
+test("Casa kit detail preserves exact sourced composition without checkout or savings claims", async ({ page }) => {
+  await page.goto("/casa-jardin/kits/mi-huerta");
+
+  await expect(page.getByRole("heading", { name: "Kit Mi Huerta", exact: true })).toBeVisible();
+  for (const component of ["COMPOST · 2 kg", "CRECE · 500 g", "FLORECE · 500 g", "FRUCTIFICA · 500 g"]) {
+    await expect(page.getByRole("heading", { name: component, exact: true })).toBeVisible();
+  }
+  await expect(page.getByText(/hipótesis comercial de precios/i)).toBeVisible();
+  await expect(page.getByText(/no se anuncia ahorro/i)).toBeVisible();
+  await expect(page.getByRole("button", { name: /comprar/i })).toHaveCount(0);
+  await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
 });
 
 test("Casa diagnostic stops fertilizer-first response on safety conditions", async ({ page }) => {
@@ -36,17 +66,29 @@ test("Casa diagnostic stops fertilizer-first response on safety conditions", asy
   await expect(page.getByText(/Calculadora de dosis: deshabilitada/i)).toBeVisible();
 });
 
-test("Casa diagnostic routes a healthy growing plant to CRECE without calculating dose", async ({ page }) => {
+test("Casa diagnostic captures pot size but routes a healthy growing plant without calculating dose", async ({ page }) => {
   await page.goto("/casa-jardin/diagnostico");
 
   await page.getByLabel("Tipo de planta").selectOption("green");
   await page.getByLabel("Etapa de la planta").selectOption("growing");
   await page.getByLabel("Condición de la planta").selectOption("healthy");
   await page.getByLabel("Cantidad de plantas").selectOption("6-10");
+  await page.getByLabel("Matera M").check();
+  await page.getByLabel("Matera L").check();
 
   await expect(page.getByText("CRECE · 15-3-3", { exact: true })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Abrir siguiente paso →" })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
+  await expect(page.getByRole("link", { name: "Abrir siguiente paso →" })).toHaveAttribute("href", "/casa-jardin/productos/crece");
+  await expect(page.getByText(/Aún no tiene equivalencia pública a volumen ni gramos/i)).toBeVisible();
   await expect(page.getByText(/No calcula dosis ni cobertura todavía/i)).toBeVisible();
+});
+
+test("extremely dry substrate stays in review instead of recommending fertilizer", async ({ page }) => {
+  await page.goto("/casa-jardin/diagnostico");
+  await page.getByLabel("Tipo de planta").selectOption("green");
+  await page.getByLabel("Etapa de la planta").selectOption("growing");
+  await page.getByLabel("Condición de la planta").selectOption("extremely-dry");
+  await expect(page.getByText("Primero recupera una humedad adecuada.", { exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Abrir siguiente paso →" })).toHaveCount(0);
 });
 
 test("Casa guide library exposes handoff sources without broken download links", async ({ page }) => {

--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -48,7 +48,7 @@ test("Casa kit detail preserves exact sourced composition without checkout or sa
     await expect(page.getByRole("heading", { name: component, exact: true })).toBeVisible();
   }
   await expect(page.getByText(/hipótesis comercial de precios/i)).toBeVisible();
-  await expect(page.getByText(/no se anuncia ahorro/i)).toBeVisible();
+  await expect(page.getByText(/Tampoco se anuncia ahorro/i)).toBeVisible();
   await expect(page.getByRole("button", { name: /comprar/i })).toHaveCount(0);
   await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);

--- a/src/app/casa-jardin/diagnostico/home-garden-diagnostic.tsx
+++ b/src/app/casa-jardin/diagnostico/home-garden-diagnostic.tsx
@@ -6,15 +6,16 @@ import { homeGardenDiagnostic, homeGardenProducts, visibleHomeGardenKits } from 
 import styles from "../casa-jardin.module.css";
 
 type StageKey = keyof typeof homeGardenDiagnostic.stages | "";
-type ConditionKey = "healthy" | "stressed" | "very-wilted" | "waterlogged" | "pest-damage" | "root-problem" | "unknown" | "";
-
+type ConditionKey = "healthy" | "stressed" | "very-wilted" | "waterlogged" | "extremely-dry" | "pest-damage" | "root-problem" | "unknown" | "";
 type PlantType = "green" | "flower" | "garden" | "fruit" | "mixed" | "new-transplant" | "unsure" | "";
+type PotSize = (typeof homeGardenDiagnostic.potSizes)[number];
 
 const conditionOptions: readonly [ConditionKey, string][] = [
   ["healthy", "Activa / aparentemente sana"],
   ["stressed", "Estresada, pero sin daño severo evidente"],
   ["very-wilted", "Muy marchita"],
   ["waterlogged", "Encharcada o con exceso de agua"],
+  ["extremely-dry", "Sustrato extremadamente seco"],
   ["pest-damage", "Con manchas, plaga o daño sanitario"],
   ["root-problem", "Con señales de problema radicular"],
   ["unknown", "No estoy seguro"],
@@ -34,6 +35,7 @@ export function HomeGardenDiagnostic() {
   const [stage, setStage] = useState<StageKey>("");
   const [condition, setCondition] = useState<ConditionKey>("");
   const [plantCount, setPlantCount] = useState("");
+  const [potSizes, setPotSizes] = useState<PotSize[]>([]);
 
   const result = useMemo(() => {
     if (!condition || !stage) return null;
@@ -43,13 +45,16 @@ export function HomeGardenDiagnostic() {
     if (plantType === "new-transplant") {
       return { type: "safety" as const, title: "Trasplante reciente: estabiliza antes de decidir nutrición.", copy: "Revisa drenaje, raíces, humedad y establecimiento. Cuando la planta retome actividad, vuelve a identificar su etapa." };
     }
+    if (condition === "extremely-dry") {
+      return { type: "review" as const, title: "Primero recupera una humedad adecuada.", copy: "El sustrato extremadamente seco queda en semáforo amarillo: corrige la condición y vuelve a observar antes de decidir una aplicación." };
+    }
 
     const destination = homeGardenDiagnostic.stages[stage as keyof typeof homeGardenDiagnostic.stages];
     if (!destination) return { type: "review" as const, title: "Todavía falta contexto.", copy: "No identificamos una etapa con suficiente claridad. Usa el semáforo, revisa agua, drenaje, raíces y sanidad, o solicita orientación antes de aplicar." };
 
     if (destination === "casa-completa") {
       const kit = visibleHomeGardenKits.find((item) => item.id === "casa-completa");
-      return { type: "kit" as const, title: kit?.name ?? "Casa Completa", copy: "Tienes varias plantas en etapas distintas. La lógica es identificar cada planta y usar una sola etapa por necesidad, no aplicar todo simultáneamente.", href: "/casa-jardin#kits" };
+      return { type: "kit" as const, title: kit?.name ?? "Casa Completa", copy: "Tienes varias plantas en etapas distintas. La lógica es identificar cada planta y usar una sola etapa por necesidad, no aplicar todo simultáneamente.", href: "/casa-jardin/kits/casa-completa" };
     }
 
     const product = homeGardenProducts.find((item) => item.id === destination);
@@ -58,9 +63,13 @@ export function HomeGardenDiagnostic() {
       type: "stage" as const,
       title: `${product.consumerName} · ${product.formula ?? "Compost"}`,
       copy: `${product.role} ${product.householdFormatStatus}`,
-      href: `/wondergreen/productos/${product.technicalSlug}`,
+      href: `/casa-jardin/productos/${product.id}`,
     };
   }, [condition, plantType, stage]);
+
+  function togglePotSize(size: PotSize) {
+    setPotSizes((current) => current.includes(size) ? current.filter((item) => item !== size) : [...current, size]);
+  }
 
   return (
     <div>
@@ -111,6 +120,20 @@ export function HomeGardenDiagnostic() {
           </select>
           <p>Este dato prepara una futura recomendación de tamaño. <strong>No calcula dosis ni cobertura todavía.</strong></p>
         </label>
+
+        <fieldset className={styles.decisionCard}>
+          <span className={styles.eyebrow}>05 · Materas</span>
+          <h3>¿Qué tamaños tienes?</h3>
+          <div>
+            {homeGardenDiagnostic.potSizes.map((size) => (
+              <label key={size} style={{ display: "inline-flex", gap: ".45rem", marginRight: "1rem", alignItems: "center" }}>
+                <input type="checkbox" checked={potSizes.includes(size)} onChange={() => togglePotSize(size)} aria-label={`Matera ${size}`} />
+                {size}
+              </label>
+            ))}
+          </div>
+          <p>S/M/L/XL proviene del flujo del handoff. <strong>Aún no tiene equivalencia pública a volumen ni gramos.</strong></p>
+        </fieldset>
       </div>
 
       <div className={styles.guardrail} aria-live="polite">
@@ -128,7 +151,7 @@ export function HomeGardenDiagnostic() {
 
       <div className={styles.guardrail}>
         <strong>Calculadora de dosis: deshabilitada.</strong>
-        <p>El handoff exige validar dosis domésticas por formulación y calibrar el dosificador antes de convertir este diagnóstico en gramos, medidas, frecuencia o cobertura.</p>
+        <p>El handoff exige validar dosis domésticas por formulación, tamaño/volumen de sustrato y calibrar el dosificador antes de convertir este diagnóstico en gramos, medidas, frecuencia o cobertura.</p>
       </div>
     </div>
   );

--- a/src/app/casa-jardin/kits/[slug]/page.tsx
+++ b/src/app/casa-jardin/kits/[slug]/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getHomeGardenKit,
+  getHomeGardenProduct,
+  homeGardenKits,
+  homeGardenRelease,
+} from "@/data/home-garden";
+import styles from "../../casa-jardin.module.css";
+
+export function generateStaticParams() {
+  return homeGardenKits.filter((kit) => kit.availability === "prelaunch").map((kit) => ({ slug: kit.id }));
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  const kit = getHomeGardenKit(slug);
+  if (!kit || kit.availability === "blocked") return { title: "Kit Casa & Jardín | Wondergreen" };
+  return {
+    title: `${kit.name} | Wondergreen Casa, Jardín y Vivero`,
+    description: `${kit.promise} Composición de pre-lanzamiento; compra y precio aún no habilitados.`,
+    alternates: { canonical: `/casa-jardin/kits/${kit.id}` },
+    robots: { index: false, follow: true },
+  };
+}
+
+export default async function HomeGardenKitPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const kit = getHomeGardenKit(slug);
+  if (!kit || kit.availability === "blocked") notFound();
+
+  return (
+    <div className={styles.page}>
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin#kits">← Volver a kits</Link>
+              <span className={styles.eyebrow}>Wondergreen Casa & Jardín · kit de pre-lanzamiento</span>
+              <h1>{kit.name}</h1>
+              <p className={styles.lead}>{kit.audience}. <strong>{kit.promise}</strong></p>
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Confirmar si encaja contigo</Link>
+              </div>
+            </div>
+            <aside className={styles.heroVisual}>
+              <p className={styles.heroNote}>COMPOSICIÓN V1 · SIN CHECKOUT</p>
+              <strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>Un sistema por etapas, no una mezcla para aplicar de una vez.</strong>
+            </aside>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Qué incluye la propuesta V1</span><h2>Composición recuperada del handoff.</h2></div>
+              <p>{kit.guardrail}</p>
+            </div>
+            <div className={styles.decisionGrid}>
+              {kit.contents.map((content, index) => (
+                <article className={styles.decisionCard} key={content}>
+                  <span className={styles.eyebrow}>{String(index + 1).padStart(2, "0")}</span>
+                  <h3>{content}</h3>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Ruta del kit</span><h2>Cada etapa se usa cuando corresponde.</h2></div>
+              <p>El kit agrupa posibilidades para distintas etapas. No implica aplicación simultánea ni reemplaza la lectura de condición de cada planta.</p>
+            </div>
+            <div className={styles.flow}>
+              {kit.pathway.map((stage, index) => {
+                const product = getHomeGardenProduct(stage);
+                return (
+                  <article key={stage}>
+                    <strong>{String(index + 1).padStart(2, "0")} · {product?.consumerName ?? stage}</strong>
+                    <p>{product?.role}</p>
+                    {product ? <Link href={`/casa-jardin/productos/${product.id}`}>Ver etapa →</Link> : null}
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.dark}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Lo que todavía falta</span><h2>El kit no es comprable hasta cerrar sus dependencias.</h2></div>
+              <p>El handoff contiene una hipótesis comercial de precios, pero no se publica porque aún falta validar costos reales y márgenes. Tampoco se anuncia ahorro sin una comparación verificable de componentes y accesorios.</p>
+            </div>
+            <div className={styles.flow}>
+              {homeGardenRelease.blockedReasons.map((reason, index) => <article key={reason}><strong>{String(index + 1).padStart(2, "0")}</strong><p>{reason}</p></article>)}
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/casa-jardin/page.tsx
+++ b/src/app/casa-jardin/page.tsx
@@ -60,7 +60,7 @@ export default function CasaJardinPage() {
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>4 etapas + suelo</span><h2>No necesita más. Necesita lo correcto.</h2></div>
-              <p>CRECE, EQUILIBRA, FLORECE y FRUCTIFICA son nombres de uso doméstico para referencias sólidas Wondergreen ya existentes. COMPOST prepara y acondiciona el sistema de suelo. Las presentaciones B2C siguen en cierre y no se muestran como SKUs comprables todavía.</p>
+              <p>CRECE, EQUILIBRA, FLORECE y FRUCTIFICA son nombres de uso doméstico para referencias sólidas Wondergreen ya existentes. COMPOST prepara y acondiciona el sistema de suelo. Los formatos B2C del handoff se muestran como propuestas, no como inventario comprable.</p>
             </div>
             <div className={styles.productGrid}>
               {homeGardenProducts.map((product) => (
@@ -71,7 +71,7 @@ export default function CasaJardinPage() {
                   <span className={styles.formula}>{product.formula ?? "Compost"}</span>
                   <p>{product.role}</p>
                   <p><strong>{product.prompt}</strong></p>
-                  <Link href={`/wondergreen/productos/${product.technicalSlug}`}>Ver Product Truth técnico →</Link>
+                  <Link href={`/casa-jardin/productos/${product.id}`}>Ver etapa y formatos propuestos →</Link>
                 </article>
               ))}
             </div>
@@ -105,7 +105,7 @@ export default function CasaJardinPage() {
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>Kits Casa & Jardín · pre-lanzamiento</span><h2>Compra la lógica del sistema, no una mezcla de productos.</h2></div>
-              <p>Los cinco kits visibles provienen del handoff comercial validado como arquitectura. Aún no tienen checkout ni PVP público: faltan cerrar formatos domésticos, dosificador, empaque, etiquetas, stock y logística.</p>
+              <p>Los cinco kits visibles conservan la composición V1 del handoff. Aún no tienen checkout ni PVP público: faltan cerrar dosificador, empaque, etiquetas, stock, logística y condición regulatoria de las presentaciones domésticas.</p>
             </div>
             <div className={styles.kitGrid}>
               {visibleHomeGardenKits.map((kit) => (
@@ -115,6 +115,7 @@ export default function CasaJardinPage() {
                   <p><strong>{kit.promise}</strong></p>
                   <ul>{kit.contents.map((content) => <li key={content}>{content}</li>)}</ul>
                   <p>{kit.guardrail}</p>
+                  <Link href={`/casa-jardin/kits/${kit.id}`}>Ver composición y ruta →</Link>
                   <div className={styles.status}>Pre-lanzamiento · compra deshabilitada</div>
                 </article>
               ))}
@@ -173,7 +174,7 @@ export default function CasaJardinPage() {
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>Diagnóstico orientativo</span><h2>Deja de fertilizar a ciegas.</h2></div>
-              <p>El diagnóstico pregunta tipo de planta, etapa y condición. Si detecta una señal de seguridad, detiene la recomendación. Si el contexto es claro, orienta hacia una etapa o kit sin calcular gramos todavía.</p>
+              <p>El diagnóstico pregunta tipo de planta, etapa, condición, cantidad y tamaños de matera. Si detecta una señal de seguridad, detiene la recomendación. El tamaño se captura para una futura recomendación de formato, pero todavía no se convierte en dosis.</p>
             </div>
             <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Iniciar diagnóstico</Link></div>
           </div>
@@ -191,7 +192,7 @@ export default function CasaJardinPage() {
 
         <section className={`${styles.section} ${styles.release}`}>
           <div className={`${styles.container} ${styles.releaseGrid}`}>
-            <div><span className={styles.eyebrow}>Estado de lanzamiento</span><h2>La experiencia ya puede construirse. La tienda todavía no.</h2><p className={styles.lead}>Este primer release queda deliberadamente sin indexar y sin checkout. La arquitectura, el contenido y el diagnóstico sí se prueban dentro de la web; compra y precios se habilitan únicamente cuando sus dependencias estén reconciliadas.</p></div>
+            <div><span className={styles.eyebrow}>Estado de lanzamiento</span><h2>El catálogo puede recorrerse. La tienda todavía no.</h2><p className={styles.lead}>Productos, formatos propuestos, kits, diagnóstico y guías ya tienen arquitectura navegable. La compra y los precios se habilitan únicamente cuando sus dependencias estén reconciliadas.</p></div>
             <div>
               <strong>Bloqueos antes de activar ecommerce</strong>
               <ul>{homeGardenRelease.blockedReasons.map((reason) => <li key={reason}>{reason}</li>)}</ul>

--- a/src/app/casa-jardin/productos/[slug]/page.tsx
+++ b/src/app/casa-jardin/productos/[slug]/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getHomeGardenProduct,
+  homeGardenProducts,
+  homeGardenRegulatoryGate,
+  homeGardenRelease,
+} from "@/data/home-garden";
+import styles from "../../casa-jardin.module.css";
+
+export function generateStaticParams() {
+  return homeGardenProducts.map((product) => ({ slug: product.id }));
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  const product = getHomeGardenProduct(slug);
+  if (!product) return { title: "Producto Casa & Jardín | Wondergreen" };
+  return {
+    title: `${product.consumerName} | Wondergreen Casa, Jardín y Vivero`,
+    description: `${product.role} Presentaciones domésticas en validación; compra y precio aún no habilitados.`,
+    alternates: { canonical: `/casa-jardin/productos/${product.id}` },
+    robots: { index: false, follow: true },
+  };
+}
+
+export default async function HomeGardenProductPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const product = getHomeGardenProduct(slug);
+  if (!product) notFound();
+
+  return (
+    <div className={styles.page}>
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin#etapas">← Volver al sistema</Link>
+              <span className={styles.eyebrow}>Wondergreen Casa & Jardín · {product.id === "prepara" ? "suelo" : "etapa"}</span>
+              <h1>{product.consumerName}</h1>
+              <p className={styles.lead}>{product.role}</p>
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Confirmar si es tu etapa</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href={`/wondergreen/productos/${product.technicalSlug}`}>Ver Product Truth técnico</Link>
+              </div>
+            </div>
+            <aside className={styles.heroVisual}>
+              <p className={styles.heroNote}>PRESENTACIÓN DOMÉSTICA EN VALIDACIÓN</p>
+              <strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3.2rem", lineHeight: 1 }}>{product.technicalName}</strong>
+              <p style={{ color: "#d5e2dc", maxWidth: "26rem" }}>{product.formula ? `Fórmula técnica: ${product.formula}` : "Base orgánica para el sistema de suelo."}</p>
+            </aside>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Formatos del handoff B2C</span><h2>Propuestos, todavía no vendidos como SKU.</h2></div>
+              <p>{product.householdFormatStatus}</p>
+            </div>
+            <div className={styles.decisionGrid}>
+              {product.plannedHouseholdVariants.map((variant) => (
+                <article className={styles.decisionCard} key={variant}>
+                  <span className={styles.eyebrow}>Formato propuesto</span>
+                  <h3>{variant}</h3>
+                  <p>Sin precio público, cobertura ni dosis hasta completar validación técnica, comercial y regulatoria.</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Cómo decidir</span><h2>{product.prompt}</h2></div>
+              <p>La etapa orienta la selección, pero no reemplaza la revisión de agua, drenaje, raíces, sanidad, luz y condición general. Si la planta está severamente estresada, el siguiente paso puede ser no fertilizar.</p>
+            </div>
+            <div className={styles.guardrail}>
+              <strong>Dosis y cobertura todavía no se calculan.</strong>
+              <p>Tamaño de matera, volumen de sustrato, formulación y equivalencia real del dosificador deben validarse antes de publicar gramos, medidas o frecuencia.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.dark}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Gate regulatorio</span><h2>La presentación pequeña no se presume habilitada.</h2></div>
+              <p>{homeGardenRegulatoryGate.rule}</p>
+            </div>
+            <div className={styles.flow}>
+              {homeGardenRegulatoryGate.sourceNotes.map((note, index) => <article key={note}><strong>{String(index + 1).padStart(2, "0")}</strong><p>{note}</p></article>)}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.release}`}>
+          <div className={`${styles.container} ${styles.releaseGrid}`}>
+            <div><span className={styles.eyebrow}>Estado B2C</span><h2>Producto definido. Variante doméstica todavía en cierre.</h2></div>
+            <div><ul>{homeGardenRelease.blockedReasons.map((reason) => <li key={reason}>{reason}</li>)}</ul></div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/data/home-garden-assets.test.ts
+++ b/src/data/home-garden-assets.test.ts
@@ -2,19 +2,21 @@ import { describe, expect, it } from "vitest";
 import { blockedHomeGardenAssets, homeGardenAssets, publishableHomeGardenAssets } from "./home-garden-assets";
 
 describe("Casa and Garden handoff asset governance", () => {
-  it("blocks the conflicting hero, transplant kit and unfinished QR card", () => {
+  it("blocks every asset with unresolved truth or functional conflicts", () => {
     expect(blockedHomeGardenAssets.map((asset) => asset.id)).toEqual([
       "hero-source",
+      "kit-mi-huerta",
       "kit-transplant-source",
       "kit-card-qr",
     ]);
+    expect(blockedHomeGardenAssets.find((asset) => asset.id === "kit-mi-huerta")?.guardrail).toMatch(/COMPOST 2 kg.*COMPOST 1 kg/i);
   });
 
-  it("keeps five packshots and five kit concepts as prelaunch candidates only", () => {
+  it("keeps five packshots and only truth-aligned kit concepts as prelaunch candidates", () => {
     expect(homeGardenAssets.filter((asset) => asset.kind === "packshot" && asset.status === "candidate-web")).toHaveLength(5);
-    expect(homeGardenAssets.filter((asset) => asset.kind === "kit" && asset.status === "candidate-web")).toHaveLength(5);
+    expect(homeGardenAssets.filter((asset) => asset.kind === "kit" && asset.status === "candidate-web")).toHaveLength(4);
     for (const asset of publishableHomeGardenAssets.filter((item) => item.kind === "packshot" || item.kind === "kit")) {
-      expect(asset.guardrail).toMatch(/prelaunch|pre-lanzamiento|reconciled|reconciliado|price|precio/i);
+      expect(asset.guardrail).toMatch(/prelaunch|pre-lanzamiento|reconciled|reconciliado|price|precio|visible weights/i);
     }
   });
 

--- a/src/data/home-garden-assets.ts
+++ b/src/data/home-garden-assets.ts
@@ -26,7 +26,7 @@ export const homeGardenAssets: readonly HomeGardenAsset[] = [
     ["packshot-equilibra", "packshot_equilibra.png", "EQUILIBRA / 2Balance 7-7-7"],
     ["packshot-florece", "packshot_florece.png", "FLORECE / 2Bloom 3-8-3"],
     ["packshot-fructifica", "packshot_fructifica.png", "FRUCTIFICA / 2Fruit 3-3-8"],
-    ["packshot-compost", "packshot_compost.png", "COMPOST"],
+    ["packshot-compost", "packshot_compost.png", "COMPOST 2 kg"],
   ].map(([id, sourceFile, use]) => ({
     id,
     sourceFile,
@@ -38,7 +38,6 @@ export const homeGardenAssets: readonly HomeGardenAsset[] = [
   ...[
     ["kit-plantas-verdes", "kit_plantas_verdes.png", "Kit Plantas Verdes"],
     ["kit-plantas-flor", "kit_plantas_con_flor.png", "Kit Plantas con Flor"],
-    ["kit-mi-huerta", "kit_mi_huerta.png", "Kit Mi Huerta"],
     ["kit-casa-completa", "kit_casa_completa.png", "Kit Casa Completa"],
     ["kit-casa-completa-xl", "kit_casa_completa_xl.png", "Casa Completa XL"],
   ].map(([id, sourceFile, use]) => ({
@@ -47,8 +46,16 @@ export const homeGardenAssets: readonly HomeGardenAsset[] = [
     kind: "kit" as const,
     status: "candidate-web" as const,
     use,
-    guardrail: "Concept/prelaunch visual only. Do not infer price, exact household net content, savings, stock or checkout availability from the image.",
+    guardrail: "Concept/prelaunch visual only. Visible weights were checked against the structured V1 composition, but the artwork is not a final commercial label. Do not infer price, savings, stock or checkout availability.",
   })),
+  {
+    id: "kit-mi-huerta",
+    sourceFile: "kit_mi_huerta.png",
+    kind: "kit",
+    status: "blocked",
+    use: "Aesthetic reference pending regeneration.",
+    guardrail: "Structured Kit Mi Huerta V1 requires COMPOST 2 kg, while this artwork visibly shows COMPOST 1 kg. Product Truth wins: do not publish this image until corrected.",
+  },
   {
     id: "education-pot-size",
     sourceFile: "C5_tamanos_matera.png",
@@ -76,7 +83,7 @@ export const homeGardenAssets: readonly HomeGardenAsset[] = [
     kind: "pdf" as const,
     status: "source-guide" as const,
     use,
-    guardrail: "Web content and structured Product Truth override generated-image text. Remove/replace any nonfunctional QR before public binary deployment.",
+    guardrail: "Web content and structured Product Truth override generated-image text. Remove/replace any nonfunctional QR and reconcile visible weights before public binary deployment.",
   })),
   {
     id: "kit-transplant-source",

--- a/src/data/home-garden.test.ts
+++ b/src/data/home-garden.test.ts
@@ -3,6 +3,7 @@ import {
   homeGardenDiagnostic,
   homeGardenKits,
   homeGardenProducts,
+  homeGardenRegulatoryGate,
   homeGardenRelease,
   visibleHomeGardenKits,
 } from "./home-garden";
@@ -27,24 +28,48 @@ describe("Casa, Jardín y Vivero governed offer", () => {
     }
   });
 
-  it("publishes five prelaunch kit concepts while keeping transplant kit blocked", () => {
+  it("keeps household variants as sourced proposals rather than reconciled SKUs", () => {
+    expect(homeGardenProducts.find((product) => product.id === "prepara")?.plannedHouseholdVariants).toEqual(["2 kg", "5 kg"]);
+    for (const id of ["crece", "equilibra", "florece", "fructifica"]) {
+      expect(homeGardenProducts.find((product) => product.id === id)?.plannedHouseholdVariants).toEqual(["500 g", "1 kg", "2 kg", "5 kg"]);
+    }
+    expect(homeGardenRelease.householdVariantsReconciled).toBe(false);
+  });
+
+  it("keeps the exact V1 kit compositions while transplant remains blocked", () => {
     expect(visibleHomeGardenKits).toHaveLength(5);
-    expect(visibleHomeGardenKits.every((kit) => kit.availability === "prelaunch")).toBe(true);
+    expect(homeGardenKits.find((kit) => kit.id === "plantas-verdes")?.contents).toEqual([
+      "CRECE · 500 g",
+      "EQUILIBRA · 500 g",
+      "Dosificador · calibración pendiente",
+      "Guía de uso · QR pendiente",
+    ]);
+    expect(homeGardenKits.find((kit) => kit.id === "mi-huerta")?.contents).toContain("COMPOST · 2 kg");
+    expect(homeGardenKits.find((kit) => kit.id === "casa-completa-xl")?.contents.slice(0, 4)).toEqual([
+      "CRECE · 1 kg",
+      "EQUILIBRA · 1 kg",
+      "FLORECE · 1 kg",
+      "FRUCTIFICA · 1 kg",
+    ]);
 
     const transplant = homeGardenKits.find((kit) => kit.id === "trasplanta-arranca");
     expect(transplant?.availability).toBe("blocked");
     expect(transplant?.guardrail).toMatch(/no se publica como SKU/i);
   });
 
-  it("keeps prices, checkout, B2C variants and dose calculator disabled", () => {
+  it("keeps prices, checkout and dose calculator disabled", () => {
     expect(homeGardenRelease).toMatchObject({
       indexable: false,
       checkoutEnabled: false,
       priceEnabled: false,
       householdDoseCalculatorEnabled: false,
-      householdVariantsReconciled: false,
     });
     expect(homeGardenDiagnostic.calculatorEnabled).toBe(false);
+  });
+
+  it("captures S M L XL for future sizing without assigning dose", () => {
+    expect(homeGardenDiagnostic.potSizes).toEqual(["S", "M", "L", "XL"]);
+    expect(homeGardenRelease.householdDoseCalculatorEnabled).toBe(false);
   });
 
   it("stops fertilizer-first recommendations when a safety trigger is present", () => {
@@ -65,5 +90,13 @@ describe("Casa, Jardín y Vivero governed offer", () => {
       fruiting: "fructifica",
       mixed: "casa-completa",
     });
+  });
+
+  it("requires regulatory verification before household presentations become sellable", () => {
+    expect(homeGardenRegulatoryGate.status).toBe("pending-verification");
+    expect(homeGardenRegulatoryGate.authority).toBe("ICA");
+    expect(homeGardenRegulatoryGate.rule).toMatch(/registro de venta/i);
+    expect(homeGardenRegulatoryGate.rule).toMatch(/etiquetado/i);
+    expect(homeGardenRegulatoryGate.rule).toMatch(/envasador\/empacador/i);
   });
 });

--- a/src/data/home-garden.ts
+++ b/src/data/home-garden.ts
@@ -11,6 +11,7 @@ export type HomeGardenProduct = {
   accent: "earth" | "orange" | "violet" | "blue" | "coral";
   technicalSlug: string;
   availability: HomeGardenAvailability;
+  plannedHouseholdVariants: readonly string[];
   householdFormatStatus: string;
 };
 
@@ -35,23 +36,144 @@ export type HomeGardenGuide = {
 };
 
 export const homeGardenProducts: readonly HomeGardenProduct[] = [
-  { id: "prepara", consumerName: "COMPOST", technicalName: "Wondergreen Compost", role: "Materia orgánica y acondicionamiento del sustrato antes de pensar en la siguiente etapa de nutrición.", prompt: "Empieza por el suelo.", accent: "earth", technicalSlug: "compost", availability: "technical-truth", householdFormatStatus: "Las presentaciones domésticas siguen en cierre; la referencia técnica/comercial vigente conserva su Product Truth propio." },
-  { id: "crece", consumerName: "CRECE", technicalName: "2Grow Sólido", formula: "15-3-3", role: "Crecimiento, brotación y recuperación vegetativa dentro del sistema Wondergreen.", prompt: "Cuando la planta está creciendo, cambia lo que necesita.", accent: "orange", technicalSlug: "2grow-solido-15-3-3", availability: "technical-truth", householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra." },
-  { id: "equilibra", consumerName: "EQUILIBRA", technicalName: "2Balance Sólido", formula: "7-7-7", role: "Mantenimiento y nutrición balanceada cuando la planta se encuentra estable.", prompt: "No siempre necesita empuje. A veces necesita equilibrio.", accent: "violet", technicalSlug: "2balance-solido-7-7-7", availability: "technical-truth", householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra." },
-  { id: "florece", consumerName: "FLORECE", technicalName: "2Bloom Sólido", formula: "3-8-3", role: "Etapas de transición reproductiva, prefloración y floración, sin convertir nutrición en una promesa de floración.", prompt: "Si cambia a floración, cambia su nutrición.", accent: "blue", technicalSlug: "2bloom-solido-3-8-3", availability: "technical-truth", householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra." },
-  { id: "fructifica", consumerName: "FRUCTIFICA", technicalName: "2Fruit Sólido", formula: "3-3-8", role: "Etapas productivas, cuajado, desarrollo y llenado, sin prometer rendimiento, calibre o cosecha.", prompt: "La etapa productiva tiene otra lógica nutricional.", accent: "coral", technicalSlug: "2fruit-solido-3-3-8", availability: "technical-truth", householdFormatStatus: "El formato doméstico propuesto requiere cierre de empaque, etiqueta, stock y dosificación antes de habilitar compra." },
+  {
+    id: "prepara",
+    consumerName: "COMPOST",
+    technicalName: "Wondergreen Compost",
+    role: "Materia orgánica y acondicionamiento del sustrato antes de pensar en la siguiente etapa de nutrición.",
+    prompt: "Empieza por el suelo.",
+    accent: "earth",
+    technicalSlug: "compost",
+    availability: "technical-truth",
+    plannedHouseholdVariants: ["2 kg", "5 kg"],
+    householdFormatStatus: "2 kg y 5 kg provienen del handoff B2C como presentaciones propuestas. No equivalen a SKUs comerciales reconciliados ni sustituyen la presentación técnica vigente.",
+  },
+  {
+    id: "crece",
+    consumerName: "CRECE",
+    technicalName: "2Grow Sólido",
+    formula: "15-3-3",
+    role: "Crecimiento, brotación y recuperación vegetativa dentro del sistema Wondergreen.",
+    prompt: "Cuando la planta está creciendo, cambia lo que necesita.",
+    accent: "orange",
+    technicalSlug: "2grow-solido-15-3-3",
+    availability: "technical-truth",
+    plannedHouseholdVariants: ["500 g", "1 kg", "2 kg", "5 kg"],
+    householdFormatStatus: "Los cuatro formatos provienen del handoff B2C y siguen sujetos a cierre de empaque, etiqueta, stock, dosificación y condición regulatoria antes de habilitar compra.",
+  },
+  {
+    id: "equilibra",
+    consumerName: "EQUILIBRA",
+    technicalName: "2Balance Sólido",
+    formula: "7-7-7",
+    role: "Mantenimiento y nutrición balanceada cuando la planta se encuentra estable.",
+    prompt: "No siempre necesita empuje. A veces necesita equilibrio.",
+    accent: "violet",
+    technicalSlug: "2balance-solido-7-7-7",
+    availability: "technical-truth",
+    plannedHouseholdVariants: ["500 g", "1 kg", "2 kg", "5 kg"],
+    householdFormatStatus: "Los cuatro formatos provienen del handoff B2C y siguen sujetos a cierre de empaque, etiqueta, stock, dosificación y condición regulatoria antes de habilitar compra.",
+  },
+  {
+    id: "florece",
+    consumerName: "FLORECE",
+    technicalName: "2Bloom Sólido",
+    formula: "3-8-3",
+    role: "Etapas de transición reproductiva, prefloración y floración, sin convertir nutrición en una promesa de floración.",
+    prompt: "Si cambia a floración, cambia su nutrición.",
+    accent: "blue",
+    technicalSlug: "2bloom-solido-3-8-3",
+    availability: "technical-truth",
+    plannedHouseholdVariants: ["500 g", "1 kg", "2 kg", "5 kg"],
+    householdFormatStatus: "Los cuatro formatos provienen del handoff B2C y siguen sujetos a cierre de empaque, etiqueta, stock, dosificación y condición regulatoria antes de habilitar compra.",
+  },
+  {
+    id: "fructifica",
+    consumerName: "FRUCTIFICA",
+    technicalName: "2Fruit Sólido",
+    formula: "3-3-8",
+    role: "Etapas productivas, cuajado, desarrollo y llenado, sin prometer rendimiento, calibre o cosecha.",
+    prompt: "La etapa productiva tiene otra lógica nutricional.",
+    accent: "coral",
+    technicalSlug: "2fruit-solido-3-3-8",
+    availability: "technical-truth",
+    plannedHouseholdVariants: ["500 g", "1 kg", "2 kg", "5 kg"],
+    householdFormatStatus: "Los cuatro formatos provienen del handoff B2C y siguen sujetos a cierre de empaque, etiqueta, stock, dosificación y condición regulatoria antes de habilitar compra.",
+  },
 ] as const;
+
+export function getHomeGardenProduct(id: string) {
+  return homeGardenProducts.find((product) => product.id === id);
+}
 
 export const homeGardenMethod = ["OBSERVA", "IDENTIFICA", "ELIGE", "APLICA", "REVISA"] as const;
 
 export const homeGardenKits: readonly HomeGardenKit[] = [
-  { id: "plantas-verdes", name: "Kit Plantas Verdes", audience: "Plantas de follaje, interior y exterior", promise: "Crece cuando lo necesita. Equilibra cuando está estable.", pathway: ["crece", "equilibra"], contents: ["CRECE", "EQUILIBRA", "dosificador pendiente de calibración final", "guía de uso"], availability: "prelaunch", guardrail: "Concepto de kit validado para la arquitectura web. Precio, formatos domésticos, dosificador y checkout permanecen bloqueados hasta cierre comercial y técnico." },
-  { id: "plantas-con-flor", name: "Kit Plantas con Flor", audience: "Plantas ornamentales con transición a floración", promise: "Si cambia a floración, cambia su nutrición.", pathway: ["equilibra", "florece"], contents: ["EQUILIBRA", "FLORECE", "dosificador pendiente de calibración final", "guía de uso"], availability: "prelaunch", guardrail: "El kit no promete inducir floración. Es una lógica de nutrición por etapa y no sustituye la evaluación de luz, agua, edad, especie o sanidad." },
-  { id: "mi-huerta", name: "Kit Mi Huerta", audience: "Huertas domésticas, aromáticas y plantas productivas", promise: "Del sustrato al fruto.", pathway: ["prepara", "crece", "florece", "fructifica"], contents: ["COMPOST", "CRECE", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía Mi Huerta"], availability: "prelaunch", guardrail: "La secuencia representa etapas; no significa aplicar todos los productos simultáneamente ni garantiza floración, cuajado o cosecha." },
-  { id: "casa-completa", name: "Kit Casa Completa", audience: "Hogares con plantas en distintas etapas", promise: "4 etapas. 1 sistema. Cero adivinanzas.", pathway: ["crece", "equilibra", "florece", "fructifica"], contents: ["CRECE", "EQUILIBRA", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía + diagnóstico"], availability: "prelaunch", guardrail: "Tener las cuatro etapas no significa usarlas juntas. Cada planta entra al sistema según su etapa y condición." },
-  { id: "casa-completa-xl", name: "Casa Completa XL", audience: "Colecciones más amplias, jardines y viveros pequeños", promise: "Muchas plantas. Una sola lógica.", pathway: ["crece", "equilibra", "florece", "fructifica"], contents: ["CRECE", "EQUILIBRA", "FLORECE", "FRUCTIFICA", "dosificador pendiente de calibración final", "guía de uso"], availability: "prelaunch", guardrail: "El tamaño XL es una propuesta B2C/B2B liviana en cierre; cobertura, presentaciones y PVP no se publican hasta reconciliar dosificación, empaque, stock y logística." },
-  { id: "trasplanta-arranca", name: "Kit Trasplanta & Arranca", audience: "Trasplantes y establecimiento", promise: "Primero raíz, drenaje y estabilidad; después nutrición por etapa.", pathway: ["prepara"], contents: ["componente radicular por validar", "guía de trasplante"], availability: "blocked", guardrail: "No se publica como SKU ni se habilita compra mientras el componente radicular/bioinsumo no tenga Product Truth técnico, regulatorio y comercial reconciliado." },
+  {
+    id: "plantas-verdes",
+    name: "Kit Plantas Verdes",
+    audience: "Plantas de follaje, interior y exterior",
+    promise: "Crece cuando lo necesita. Equilibra cuando está estable.",
+    pathway: ["crece", "equilibra"],
+    contents: ["CRECE · 500 g", "EQUILIBRA · 500 g", "Dosificador · calibración pendiente", "Guía de uso · QR pendiente"],
+    availability: "prelaunch",
+    guardrail: "Composición propuesta V1 del handoff. Precio, formatos, dosificador, QR y checkout permanecen bloqueados hasta cierre comercial, técnico y regulatorio.",
+  },
+  {
+    id: "plantas-con-flor",
+    name: "Kit Plantas con Flor",
+    audience: "Plantas ornamentales con transición a floración",
+    promise: "Si cambia a floración, cambia su nutrición.",
+    pathway: ["equilibra", "florece"],
+    contents: ["EQUILIBRA · 500 g", "FLORECE · 500 g", "Dosificador · calibración pendiente", "Guía de uso · QR pendiente"],
+    availability: "prelaunch",
+    guardrail: "Composición propuesta V1. El kit no promete inducir floración y no sustituye la evaluación de luz, agua, edad, especie o sanidad.",
+  },
+  {
+    id: "mi-huerta",
+    name: "Kit Mi Huerta",
+    audience: "Huertas domésticas, aromáticas y plantas productivas",
+    promise: "Del sustrato al fruto.",
+    pathway: ["prepara", "crece", "florece", "fructifica"],
+    contents: ["COMPOST · 2 kg", "CRECE · 500 g", "FLORECE · 500 g", "FRUCTIFICA · 500 g", "Dosificador · calibración pendiente", "Guía Mi Huerta · QR pendiente"],
+    availability: "prelaunch",
+    guardrail: "Composición propuesta V1. La secuencia representa etapas; no significa aplicar todos los productos simultáneamente ni garantiza floración, cuajado o cosecha.",
+  },
+  {
+    id: "casa-completa",
+    name: "Kit Casa Completa",
+    audience: "Hogares con plantas en distintas etapas",
+    promise: "4 etapas. 1 sistema. Cero adivinanzas.",
+    pathway: ["crece", "equilibra", "florece", "fructifica"],
+    contents: ["CRECE · 500 g", "EQUILIBRA · 500 g", "FLORECE · 500 g", "FRUCTIFICA · 500 g", "Dosificador · calibración pendiente", "Guía + diagnóstico · QR pendiente"],
+    availability: "prelaunch",
+    guardrail: "Composición propuesta V1. Tener las cuatro etapas no significa usarlas juntas. Cada planta entra al sistema según su etapa y condición.",
+  },
+  {
+    id: "casa-completa-xl",
+    name: "Casa Completa XL",
+    audience: "Colecciones más amplias, jardines y viveros pequeños",
+    promise: "Muchas plantas. Una sola lógica.",
+    pathway: ["crece", "equilibra", "florece", "fructifica"],
+    contents: ["CRECE · 1 kg", "EQUILIBRA · 1 kg", "FLORECE · 1 kg", "FRUCTIFICA · 1 kg", "Dosificador · calibración pendiente", "Guía de uso · QR pendiente"],
+    availability: "prelaunch",
+    guardrail: "Composición propuesta V1. Cobertura, PVP, stock, empaque y logística siguen en cierre antes de convertirlo en SKU comercial.",
+  },
+  {
+    id: "trasplanta-arranca",
+    name: "Kit Trasplanta & Arranca",
+    audience: "Trasplantes y establecimiento",
+    promise: "Primero raíz, drenaje y estabilidad; después nutrición por etapa.",
+    pathway: ["prepara"],
+    contents: ["COMPOST · 2 kg", "CRECE · 500 g", "Componente radicular · por validar", "Dosificador · por calibrar", "Guía de trasplante"],
+    availability: "blocked",
+    guardrail: "No se publica como SKU ni se habilita compra mientras el componente radicular/bioinsumo no tenga Product Truth técnico, regulatorio y comercial reconciliado.",
+  },
 ] as const;
+
+export function getHomeGardenKit(id: string) {
+  return homeGardenKits.find((kit) => kit.id === id);
+}
 
 export const visibleHomeGardenKits = homeGardenKits.filter((kit) => kit.availability === "prelaunch");
 
@@ -72,7 +194,20 @@ export const homeGardenDiagnostic = {
   calculatorEnabled: false,
   safetyTriggers: ["very-wilted", "waterlogged", "pest-damage", "root-problem"] as const,
   safetyMessage: "NO EMPIECES FERTILIZANDO. Revisa primero agua, drenaje, raíces y sanidad.",
+  potSizes: ["S", "M", "L", "XL"] as const,
   stages: { growing: "crece", stable: "equilibra", flowering: "florece", fruiting: "fructifica", mixed: "casa-completa" } as const,
+} as const;
+
+export const homeGardenRegulatoryGate = {
+  status: "pending-verification",
+  checkedAt: "2026-08-19",
+  authority: "ICA",
+  rule: "No presumir que una nueva presentación B2C queda habilitada por existir la referencia técnica/comercial de mayor tamaño. Antes de comercializar debe confirmarse que registro de venta, etiquetado aprobado y condición de fabricante/formulador/envasador/empacador aplicables cubren la presentación que se pretende vender.",
+  sourceNotes: [
+    "El ICA exige registro de venta previo a la comercialización de fertilizantes y acondicionadores de suelo.",
+    "El trámite contempla proyecto de etiquetado y permite solicitar modificaciones o adiciones al registro de venta.",
+    "La actividad de envasar o empacar fertilizantes para comercialización está sujeta al registro empresarial correspondiente ante ICA.",
+  ],
 } as const;
 
 export const homeGardenGuides: readonly HomeGardenGuide[] = [
@@ -104,7 +239,7 @@ export const homeGardenRelease = {
   blockedReasons: [
     "Cerrar dosis domésticas por formulación y tamaño de planta/contenedor.",
     "Calibrar equivalencias reales del dosificador por producto.",
-    "Cerrar etiquetas, textos legales y presentaciones B2C.",
+    "Confirmar que registro de venta, etiquetado y condición de envasado/empacado cubran cada presentación B2C.",
     "Reconciliar costos, PVP, márgenes, stock, empaque, armado y logística de envío.",
   ],
 } as const;


### PR DESCRIPTION
## Objetivo
Avanzar Casa, Jardín y Vivero desde el pre-lanzamiento general hacia un Product Truth B2C gobernado, sin activar ecommerce ni inventar dosis/márgenes.

## Fuente
- handoff MKTG Studio `WONDERGREEN_CASA_JARDIN_WEB_HANDOFF_V1_2026-08-19`;
- Product Truth / Price Truth V9 vigentes;
- trabajo previo de Casa & Jardín sobre tamaños y cobertura usado solo como hipótesis de validación;
- verificación oficial ICA sobre registro de venta, etiquetado y actividad de envasado/empacado.

## Cambios
- formatos domésticos propuestos por etapa:
  - CRECE / EQUILIBRA / FLORECE / FRUCTIFICA: 500 g, 1 kg, 2 kg, 5 kg;
  - COMPOST: 2 kg, 5 kg;
- composiciones V1 exactas de los 5 kits visibles;
- `Trasplanta & Arranca` continúa `blocked`;
- páginas noindex individuales para las 5 etapas y 5 kits de pre-lanzamiento;
- hub enlaza a detalle B2C y conserva enlace desde cada etapa al Product Truth técnico;
- diagnóstico captura materas S/M/L/XL sin asignar volumen/dosis;
- condición `sustrato extremadamente seco` queda en revisión/amarillo, no recomienda fertilización;
- gate regulatorio que impide presumir habilitada una nueva presentación B2C sin verificar registro/etiquetado/envasado aplicable;
- pruebas unitarias y E2E para formatos, composiciones, noindex, ausencia de precio/checkout y seguridad diagnóstica.

## QA adicional de activos
El manifiesto visual se endureció contra Product Truth:
- `hero-source` permanece bloqueado por conflicto de peso de Compost;
- `kit-mi-huerta` queda ahora **bloqueado**: el arte visible muestra `COMPOST 1 kg`, mientras la composición V1 estructurada exige `COMPOST 2 kg`;
- `kit-transplant-source` permanece bloqueado por componente radicular no reconciliado;
- `kit-card-qr` permanece bloqueada por QR/dosificador no final;
- quedan 5 packshots y 4 visuales de kits como candidatos de pre-lanzamiento, sujetos a QA y sin convertir el arte en SKU/etiqueta final.

## Deliberadamente NO incluido
- precios propuestos del handoff en código/web;
- margen calculado: faltan costos reales de empaque, fique, dosificador, ensamble, caja, pasarela, flete y costos industriales;
- dosis, frecuencia o cobertura pública;
- equivalencia S/M/L/XL a gramos;
- packshots como prueba de SKU comercial;
- Product Schema / indexación / checkout.

## Motivo comercial
Los PVP del handoff son hipótesis B2C y no simples conversiones del precio de 40 kg. Sin costeo all-in no existe base para afirmar margen, ahorro o descuento verificable.

## CI final
Cabeza validada: `ebf66f921c383cefcd1d7a0fcead3da3c5b04218`.

Run #683 ✅
- quality ✅
- database / fresh migrations / RLS / pgTAP / lint ✅
- desktop Chromium ✅
- mobile Chromium ✅

La rama está 10 commits adelante y 0 detrás de `develop`, sin review threads abiertos.