### PR TITLE
feat(casa): gobernar readiness comercial B2C

### DIFF
--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -18,6 +18,11 @@ test("Casa Jardín and Vivero exposes stage system without price or checkout", a
     await expect(page.getByRole("heading", { name: kit, exact: true })).toBeVisible();
   }
 
+  await expect(page.getByText("Ya está gobernado", { exact: true })).toBeVisible();
+  await expect(page.getByText("Falta cerrar antes de activar ecommerce", { exact: true })).toBeVisible();
+  await expect(page.getByText(/Costo total y PVP gobernado/i)).toBeVisible();
+  await expect(page.getByText(/Kit Trasplanta & Arranca · bloqueado/i)).toBeVisible();
+
   await expect(page.getByRole("button", { name: /comprar/i })).toHaveCount(0);
   await expect(page.getByRole("link", { name: /comprar/i })).toHaveCount(0);
   await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);

--- a/src/app/casa-jardin/page.tsx
+++ b/src/app/casa-jardin/page.tsx
@@ -7,10 +7,14 @@ import {
   homeGardenGuides,
   homeGardenMethod,
   homeGardenProducts,
-  homeGardenRelease,
   homeGardenTrafficLight,
   visibleHomeGardenKits,
 } from "@/data/home-garden";
+import {
+  blockedHomeGardenLaunchItems,
+  pendingHomeGardenLaunchItems,
+  readyHomeGardenLaunchItems,
+} from "@/data/home-garden-readiness";
 import styles from "./casa-jardin.module.css";
 
 export const metadata: Metadata = {
@@ -192,11 +196,29 @@ export default function CasaJardinPage() {
 
         <section className={`${styles.section} ${styles.release}`}>
           <div className={`${styles.container} ${styles.releaseGrid}`}>
-            <div><span className={styles.eyebrow}>Estado de lanzamiento</span><h2>El catálogo puede recorrerse. La tienda todavía no.</h2><p className={styles.lead}>Productos, formatos propuestos, kits, diagnóstico y guías ya tienen arquitectura navegable. La compra y los precios se habilitan únicamente cuando sus dependencias estén reconciliadas.</p></div>
             <div>
-              <strong>Bloqueos antes de activar ecommerce</strong>
-              <ul>{homeGardenRelease.blockedReasons.map((reason) => <li key={reason}>{reason}</li>)}</ul>
-              <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/wondergreen">Ver Wondergreen técnico</Link><Link className={`${styles.button} ${styles.ghost}`} href="/contacto">Hablar con Greenatics</Link></div>
+              <span className={styles.eyebrow}>Estado de lanzamiento</span>
+              <h2>El catálogo puede recorrerse. La tienda todavía no.</h2>
+              <p className={styles.lead}>Productos, formatos propuestos, kits, diagnóstico y guías ya tienen arquitectura navegable. La compra y los precios se habilitan únicamente cuando sus dependencias estén reconciliadas.</p>
+            </div>
+            <div>
+              <strong>Ya está gobernado</strong>
+              <ul>{readyHomeGardenLaunchItems.map((item) => <li key={item.id}><strong>{item.publicLabel}.</strong> {item.publicCopy}</li>)}</ul>
+
+              <strong>Falta cerrar antes de activar ecommerce</strong>
+              <ul>{pendingHomeGardenLaunchItems.map((item) => <li key={item.id}><strong>{item.publicLabel}.</strong> {item.publicCopy}</li>)}</ul>
+
+              {blockedHomeGardenLaunchItems.map((item) => (
+                <div className={styles.guardrail} key={item.id}>
+                  <strong>{item.publicLabel} · bloqueado</strong>
+                  <p>{item.publicCopy}</p>
+                </div>
+              ))}
+
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen">Ver Wondergreen técnico</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/contacto">Hablar con Greenatics</Link>
+              </div>
             </div>
           </div>
         </section>

--- a/src/data/home-garden-readiness.test.ts
+++ b/src/data/home-garden-readiness.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  blockedHomeGardenLaunchItems,
+  homeGardenAllInCostChecklist,
+  homeGardenCommerceGate,
+  homeGardenLaunchReadiness,
+  pendingHomeGardenLaunchItems,
+  readyHomeGardenLaunchItems,
+} from "./home-garden-readiness";
+
+describe("Casa, Jardín y Vivero commercial readiness", () => {
+  it("separates what is already governed from launch dependencies", () => {
+    expect(readyHomeGardenLaunchItems.map((item) => item.id)).toEqual([
+      "technical-product-truth",
+      "kit-composition-v1",
+      "safe-diagnostic",
+    ]);
+
+    expect(pendingHomeGardenLaunchItems.map((item) => item.id)).toEqual([
+      "household-skus",
+      "regulatory",
+      "dose-and-dosifier",
+      "all-in-cost",
+      "fulfillment",
+      "public-assets",
+    ]);
+
+    expect(blockedHomeGardenLaunchItems.map((item) => item.id)).toEqual(["transplant-kit"]);
+  });
+
+  it("keeps ecommerce, price and margin claims fail-closed", () => {
+    expect(homeGardenCommerceGate).toMatchObject({
+      indexable: false,
+      checkoutEnabled: false,
+      priceEnabled: false,
+      canPublishPrice: false,
+      canClaimMargin: false,
+    });
+    expect(homeGardenCommerceGate.rule).toMatch(/regulatorios/i);
+    expect(homeGardenCommerceGate.rule).toMatch(/costo all-in/i);
+  });
+
+  it("requires an all-in cost instead of deriving margin from fertilizer content alone", () => {
+    expect(homeGardenAllInCostChecklist).toEqual(expect.arrayContaining([
+      "Contenido/fertilizante por presentación",
+      "Empaque individual y cierre",
+      "Etiqueta y material impreso",
+      "Dosificador",
+      "Contenedor del kit / fique",
+      "Caja o embalaje exterior",
+      "Mano de obra y ensamble",
+      "Control de calidad",
+      "Merma y reproceso",
+      "Pasarela de pago y comisiones",
+      "Logística y flete según política comercial",
+    ]));
+    expect(homeGardenAllInCostChecklist.length).toBeGreaterThanOrEqual(14);
+  });
+
+  it("contains no price or margin numeric assumptions", () => {
+    const serialized = JSON.stringify({ homeGardenLaunchReadiness, homeGardenAllInCostChecklist, homeGardenCommerceGate });
+    expect(serialized).not.toMatch(/\$\s?\d/);
+    expect(serialized).not.toMatch(/\b\d+(?:[.,]\d+)?\s?%/);
+  });
+});

--- a/src/data/home-garden-readiness.ts
+++ b/src/data/home-garden-readiness.ts
@@ -1,0 +1,123 @@
+export type HomeGardenReadinessStatus = "ready" | "pending" | "blocked";
+
+export type HomeGardenReadinessItem = {
+  id: string;
+  area: string;
+  status: HomeGardenReadinessStatus;
+  publicLabel: string;
+  publicCopy: string;
+  gate: string;
+};
+
+export const homeGardenLaunchReadiness: readonly HomeGardenReadinessItem[] = [
+  {
+    id: "technical-product-truth",
+    area: "Producto",
+    status: "ready",
+    publicLabel: "Referencias y fórmulas",
+    publicCopy: "Las cinco etapas visibles están conectadas con referencias Wondergreen ya gobernadas; el nombre doméstico no reemplaza la referencia técnica.",
+    gate: "Conservar correspondencia con Product Truth y no derivar nuevos claims desde el arte.",
+  },
+  {
+    id: "kit-composition-v1",
+    area: "Kits",
+    status: "ready",
+    publicLabel: "Composición V1 de los cinco kits visibles",
+    publicCopy: "La composición y secuencia de los kits de pre-lanzamiento ya están estructuradas por etapa.",
+    gate: "No interpretar composición como disponibilidad, precio, ahorro, cobertura o uso simultáneo.",
+  },
+  {
+    id: "safe-diagnostic",
+    area: "Uso",
+    status: "ready",
+    publicLabel: "Diagnóstico y guardrails de seguridad",
+    publicCopy: "El diagnóstico puede detener una recomendación cuando hay señales de encharcamiento, daño sanitario, raíces comprometidas o marchitez severa.",
+    gate: "Mantener deshabilitada la calculadora de dosis hasta completar calibración doméstica.",
+  },
+  {
+    id: "household-skus",
+    area: "Presentaciones",
+    status: "pending",
+    publicLabel: "Presentaciones domésticas como SKUs comerciales",
+    publicCopy: "Los tamaños 500 g, 1 kg, 2 kg y 5 kg son propuestas de la línea B2C; todavía no equivalen a inventario vendible reconciliado.",
+    gate: "Cerrar SKU, stock, empaque, etiqueta y trazabilidad por presentación.",
+  },
+  {
+    id: "regulatory",
+    area: "Regulatorio",
+    status: "pending",
+    publicLabel: "Cobertura regulatoria de cada presentación",
+    publicCopy: "Antes de vender una nueva presentación debe verificarse que registro de venta, etiquetado y condición aplicable de envasado/empacado la cubran.",
+    gate: "Verificación documental ICA por referencia y presentación antes de activar compra.",
+  },
+  {
+    id: "dose-and-dosifier",
+    area: "Dosificación",
+    status: "pending",
+    publicLabel: "Dosis doméstica y dosificador",
+    publicCopy: "S/M/L/XL ya se capturan como tamaños de matera, pero todavía no se convierten a gramos ni frecuencia universal.",
+    gate: "Validar tabla por formulación, tamaño de planta/contenedor y equivalencia real del dosificador.",
+  },
+  {
+    id: "all-in-cost",
+    area: "Economía unitaria",
+    status: "pending",
+    publicLabel: "Costo total y PVP gobernado",
+    publicCopy: "El costo de producto es solo una parte. El PVP se publicará únicamente cuando exista costo total puesto a venta y una política de margen verificable.",
+    gate: "Cerrar el checklist all-in completo antes de calcular margen, ahorro, descuento o precio público.",
+  },
+  {
+    id: "fulfillment",
+    area: "Operación",
+    status: "pending",
+    publicLabel: "Armado, inventario y logística",
+    publicCopy: "La tienda requiere una promesa operativa real: disponibilidad, armado, embalaje, despacho y tratamiento del flete.",
+    gate: "Definir stock vendible, punto de armado, tiempos, cobertura logística y manejo de incidencias.",
+  },
+  {
+    id: "public-assets",
+    area: "Activos",
+    status: "pending",
+    publicLabel: "Packshots, guías y QR finales",
+    publicCopy: "Hay activos candidatos y guías fuente, pero el arte no puede sustituir Product Truth ni usar QR o pesos inconsistentes.",
+    gate: "Publicar solo binarios auditados contra fórmula, peso, composición, etiqueta y destino QR final.",
+  },
+  {
+    id: "transplant-kit",
+    area: "Kits",
+    status: "blocked",
+    publicLabel: "Kit Trasplanta & Arranca",
+    publicCopy: "Permanece fuera del catálogo vendible mientras el componente radicular o bioinsumo no tenga verdad técnica, regulatoria y comercial reconciliada.",
+    gate: "No exponer como SKU ni habilitar checkout hasta cerrar el componente faltante.",
+  },
+] as const;
+
+export const homeGardenAllInCostChecklist = [
+  "Contenido/fertilizante por presentación",
+  "Empaque individual y cierre",
+  "Etiqueta y material impreso",
+  "Dosificador",
+  "Contenedor del kit / fique",
+  "Caja o embalaje exterior",
+  "Guía, tarjeta e insertos",
+  "Mano de obra y ensamble",
+  "Control de calidad",
+  "Energía y costos industriales asignables",
+  "Merma y reproceso",
+  "Pasarela de pago y comisiones",
+  "Preparación de despacho",
+  "Logística y flete según política comercial",
+] as const;
+
+export const readyHomeGardenLaunchItems = homeGardenLaunchReadiness.filter((item) => item.status === "ready");
+export const pendingHomeGardenLaunchItems = homeGardenLaunchReadiness.filter((item) => item.status === "pending");
+export const blockedHomeGardenLaunchItems = homeGardenLaunchReadiness.filter((item) => item.status === "blocked");
+
+export const homeGardenCommerceGate = {
+  indexable: false,
+  checkoutEnabled: false,
+  priceEnabled: false,
+  canPublishPrice: false,
+  canClaimMargin: false,
+  rule: "No activar indexación comercial, precio, checkout, margen, ahorro o descuento hasta que los gates regulatorios, de dosificación, SKU, costo all-in, operación y activos estén reconciliados.",
+} as const;


### PR DESCRIPTION
## Objetivo
Continuar Casa, Jardín y Vivero después de #194 con una capa explícita de readiness comercial B2C, sin activar ecommerce ni convertir hipótesis de PVP/margen en verdad pública.

## Cambios
- crea `home-garden-readiness.ts` como matriz gobernada de lanzamiento;
- separa elementos `ready`, `pending` y `blocked`;
- deja como ya gobernados Product Truth técnico, composición V1 de kits y diagnóstico seguro;
- fija como pendientes SKUs domésticos, verificación regulatoria, dosis/dosificador, costo all-in, fulfillment y activos finales;
- mantiene `Trasplanta & Arranca` bloqueado;
- define checklist all-in previo a PVP/margen: producto, empaque, etiqueta, dosificador, fique/contenedor, caja, insertos, ensamble, calidad, energía/costos industriales, merma, pasarela/comisiones, despacho y logística/flete;
- la landing muestra de forma diferenciada qué ya está cerrado y qué falta antes de activar ecommerce;
- añade pruebas unitarias y E2E para conservar el gate fail-closed.

## Deliberadamente NO incluido
- valores de costos;
- PVP;
- margen, ahorro o descuento;
- dosis/frecuencia;
- checkout;
- indexación comercial;
- nuevos SKUs;
- cambios a Product Truth técnico, OPS, Auth, Supabase, RLS o migraciones.

## Base
Parte de `develop` en `26e6595489ed9375c5a4f72887fe075be24b521c` y está 4 commits adelante / 0 detrás al abrir esta PR.

## Gate
Merge únicamente con CI final verde sobre la cabeza exacta de la PR.