### PR TITLE
feat(public): integrar Casa Jardín en la Biblioteca

### DIFF
--- a/e2e/public-library-home-garden.spec.ts
+++ b/e2e/public-library-home-garden.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+
+test("central public library integrates Casa Jardin without exposing private document links", async ({ page }) => {
+  await page.goto("/biblioteca");
+
+  await expect(page.getByText("Tengo plantas en casa", { exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Abrir Casa & Jardín/i })).toHaveAttribute("href", "/casa-jardin");
+
+  for (const guide of [
+    "Guía Wondergreen Casa & Jardín",
+    "Guía Mi Huerta",
+    "Guía rápida de etapas",
+    "Guía de trasplante",
+  ]) {
+    await expect(page.getByRole("heading", { name: guide, exact: true })).toBeVisible();
+  }
+
+  const hrefs = await page.locator("a").evaluateAll((links) => links.map((link) => link.getAttribute("href") ?? ""));
+  expect(hrefs.join(" ")).not.toMatch(/sharepoint|graph\.microsoft/i);
+  expect(hrefs.filter((href) => /\.pdf(?:$|\?)/i.test(href))).toHaveLength(0);
+
+  await expect(page.getByText(/PDF maestro identificado · descarga pública en preparación/i).first()).toBeVisible();
+});

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -11,7 +11,12 @@ test("public library exposes live Wondergreen knowledge resources and governed s
   await expect(page.getByRole("heading", { name: "Guía Wondergreen para limón Tahití" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Guía Wondergreen para pastos y gramíneas" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Guía práctica de deficiencias nutricionales" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Abrir guía →", exact: true })).toHaveAttribute("href", "/biblioteca/guia-deficiencias");
+
+  const deficiencyCard = page.getByRole("article").filter({
+    has: page.getByRole("heading", { name: "Guía práctica de deficiencias nutricionales" }),
+  });
+  await expect(deficiencyCard.getByRole("link", { name: "Abrir guía →", exact: true })).toHaveAttribute("href", "/biblioteca/guia-deficiencias");
+
   await expect(page.getByText("Lectura web disponible · PDF maestro identificado · descarga pública en preparación", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("Maestro: Catálogo Wondergreen optimizado · 10 páginas", { exact: true })).toBeVisible();
 });

--- a/src/app/biblioteca/page.tsx
+++ b/src/app/biblioteca/page.tsx
@@ -6,7 +6,7 @@ import refresh from "./library-refresh.module.css";
 
 export const metadata: Metadata = {
   title: "Biblioteca | Greenatics",
-  description: "Guías, programas por cultivo, manuales y herramientas técnicas de Greenatics y Wondergreen convertidas en conocimiento navegable.",
+  description: "Guías, programas por cultivo, Casa & Jardín, manuales y herramientas técnicas de Greenatics y Wondergreen convertidas en conocimiento navegable.",
 };
 
 const intentRoutes = [
@@ -20,6 +20,14 @@ const intentRoutes = [
   },
   {
     number: "02",
+    kicker: "Tengo plantas en casa",
+    title: "Quiero entender qué etapa necesita mi planta.",
+    copy: "Casa, Jardín y Vivero organiza suelo, crecimiento, equilibrio, floración y fructificación con diagnóstico orientativo y guías prácticas.",
+    href: "/casa-jardin",
+    cta: "Abrir Casa & Jardín",
+  },
+  {
+    number: "03",
     kicker: "Veo síntomas",
     title: "Quiero entender una posible deficiencia.",
     copy: "Empieza por tejido afectado, patrón del lote y posibles confundidores antes de asumir que el problema se resuelve con fertilización.",
@@ -27,7 +35,7 @@ const intentRoutes = [
     cta: "Revisar síntomas",
   },
   {
-    number: "03",
+    number: "04",
     kicker: "Estoy revisando una recomendación",
     title: "Quiero comprobar si tengo suficiente contexto.",
     copy: "Revisa suelo, etapa, densidad, historial de fertilización y objetivo productivo antes de cerrar una decisión nutricional.",
@@ -35,7 +43,7 @@ const intentRoutes = [
     cta: "Comprobar criterios",
   },
   {
-    number: "04",
+    number: "05",
     kicker: "Voy a aplicar Wondergreen",
     title: "Necesito preparar y registrar bien la aplicación.",
     copy: "Confirma referencia, condiciones, equipo, vía de aplicación, registro y seguimiento sin convertir el manual en una receta universal.",
@@ -43,7 +51,7 @@ const intentRoutes = [
     cta: "Abrir manual de uso",
   },
   {
-    number: "05",
+    number: "06",
     kicker: "Quiero comparar referencias",
     title: "Necesito ver el Product Master público.",
     copy: "Consulta familias, fórmulas, formatos, estado público y relación con el sistema Wondergreen desde la fuente gobernada.",
@@ -51,7 +59,7 @@ const intentRoutes = [
     cta: "Ver Product Master",
   },
   {
-    number: "06",
+    number: "07",
     kicker: "La información no alcanza",
     title: "Necesito escalar a una conversación técnica.",
     copy: "Cuando faltan análisis, contexto del lote o una referencia clara, la salida correcta es pedir soporte antes de improvisar una recomendación.",
@@ -77,7 +85,7 @@ export default function LibraryPage() {
             <div>
               <span className={styles.eyebrow}>Greenatics · conocimiento aplicado</span>
               <h1>La biblioteca no es un archivo. Es parte de la decisión.</h1>
-              <p className={styles.lead}>Guías, manuales y conocimiento técnico se convierten en rutas web conectadas con cultivos, productos, síntomas, evidencia y acompañamiento.</p>
+              <p className={styles.lead}>Guías, manuales y conocimiento técnico se convierten en rutas web conectadas con cultivos, productos, Casa & Jardín, síntomas, evidencia y acompañamiento.</p>
             </div>
             <aside className={styles.warning}>
               <strong>Conocimiento antes que recomendación.</strong>
@@ -112,7 +120,7 @@ export default function LibraryPage() {
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Recursos disponibles</span>
               <h2>De documentos aislados a un sistema de conocimiento.</h2>
-              <p>Cada recurso se conecta con el Product Master, una ruta agronómica o una decisión concreta. El estado visible evita presentar como definitivo lo que todavía requiere validación.</p>
+              <p>Cada recurso se conecta con el Product Master, una ruta agronómica, Casa & Jardín o una decisión concreta. El estado visible evita presentar como definitivo lo que todavía requiere validación o hosting público.</p>
             </div>
             <div className={styles.libraryGrid}>
               {publicResources.map((resource) => (
@@ -139,9 +147,9 @@ export default function LibraryPage() {
               <p>La navegación debe acompañar la decisión, no obligar al usuario a conocer de antemano el nombre del producto.</p>
             </div>
             <div className={styles.ruleGrid}>
-              <article className={styles.ruleCard}><span>01</span><h3>Diagnosticar</h3><p>Revisa síntomas, lote, suelo y posibles confundidores.</p></article>
-              <article className={styles.ruleCard}><span>02</span><h3>Entender etapa</h3><p>Ubica el momento fisiológico y el objetivo productivo.</p></article>
-              <article className={styles.ruleCard}><span>03</span><h3>Aplicar con criterio</h3><p>Confirma referencia, vía, equipo, condiciones y registro.</p></article>
+              <article className={styles.ruleCard}><span>01</span><h3>Diagnosticar</h3><p>Revisa síntomas, lote, planta, suelo o sustrato y posibles confundidores.</p></article>
+              <article className={styles.ruleCard}><span>02</span><h3>Entender etapa</h3><p>Ubica el momento fisiológico, la condición y el objetivo antes de elegir una ruta.</p></article>
+              <article className={styles.ruleCard}><span>03</span><h3>Aplicar con criterio</h3><p>Confirma referencia, vía, equipo, condiciones y registro; en hogar, evita dosificar a ojo.</p></article>
               <article className={styles.ruleCard}><span>04</span><h3>Medir y ajustar</h3><p>Observa respuesta y usa evidencia para decidir el siguiente evento.</p></article>
             </div>
           </div>
@@ -149,10 +157,10 @@ export default function LibraryPage() {
 
         <section className={styles.closing}>
           <div className={`${styles.container} ${styles.closingInner}`}>
-            <div><span className={styles.eyebrow}>Biblioteca Greenatics</span><h2>¿Buscas una guía para un cultivo específico?</h2></div>
+            <div><span className={styles.eyebrow}>Biblioteca Greenatics</span><h2>¿Buscas una guía para cultivo o para tus plantas en casa?</h2></div>
             <div className={styles.closingActions}>
               <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen/cultivos">Ver cultivos</Link>
-              <Link className={`${styles.button} ${styles.secondary}`} href="/contacto#wondergreen">Hablar con un asesor</Link>
+              <Link className={`${styles.button} ${styles.secondary}`} href="/casa-jardin">Casa & Jardín</Link>
             </div>
           </div>
         </section>

--- a/src/data/public-resources.test.ts
+++ b/src/data/public-resources.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { publicResources } from "./public-resources";
+import { publicResourceHostingGate, publicResources } from "./public-resources";
 
 describe("public knowledge resource registry", () => {
   it("keeps resource ids unique and every resource routable", () => {
@@ -25,6 +25,22 @@ describe("public knowledge resource registry", () => {
     for (const resource of cropMasters) {
       expect(resource.delivery).toBe("web-native-master-pending");
       expect(resource.masterLabel?.trim().length).toBeGreaterThan(0);
+      expect(resource.masterSource).toBe("internal-document-library");
+    }
+  });
+
+  it("integrates the four governed Casa Jardin guide masters into the central library", () => {
+    const homeGarden = publicResources.filter((resource) => resource.id.startsWith("home-garden-guide-"));
+    expect(homeGarden).toHaveLength(4);
+    expect(homeGarden.map((resource) => resource.href).sort()).toEqual([
+      "/casa-jardin/guias#casa-jardin",
+      "/casa-jardin/guias#etapas",
+      "/casa-jardin/guias#mi-huerta",
+      "/casa-jardin/guias#trasplante",
+    ]);
+    for (const resource of homeGarden) {
+      expect(resource.delivery).toBe("web-native-master-pending");
+      expect(resource.masterSource).toBe("validated-handoff");
     }
   });
 
@@ -33,12 +49,22 @@ describe("public knowledge resource registry", () => {
     expect(catalog?.href).toBe("/wondergreen/productos");
     expect(catalog?.delivery).toBe("web-native-master-pending");
     expect(catalog?.masterLabel).toMatch(/10 páginas/i);
+    expect(catalog?.masterSource).toBe("internal-document-library");
   });
 
   it("does not expose a private or fake downloadable asset before public hosting exists", () => {
+    expect(publicResourceHostingGate).toMatchObject({
+      privateSourceLinksAllowed: false,
+      publicDownloadEnabled: false,
+    });
+
+    const serialized = JSON.stringify(publicResources);
+    expect(serialized).not.toMatch(/sharepoint|graph\.microsoft/i);
+
     for (const resource of publicResources.filter((item) => item.delivery !== "web-native")) {
       expect(resource.href).not.toMatch(/\.pdf(?:$|\?)/i);
       expect(resource.href).not.toMatch(/sharepoint|graph\.microsoft/i);
+      expect(resource.masterSource).toBeDefined();
     }
   });
 });

--- a/src/data/public-resources.ts
+++ b/src/data/public-resources.ts
@@ -1,5 +1,8 @@
+import { homeGardenGuides } from "./home-garden";
+
 export type PublicResourceKind = "crop-library" | "manual" | "guide" | "catalog" | "technology" | "finder";
 export type PublicResourceDelivery = "web-native" | "web-native-master-pending" | "public-download-pending";
+export type PublicResourceMasterSource = "internal-document-library" | "validated-handoff";
 
 export type PublicResource = {
   id: string;
@@ -12,7 +15,22 @@ export type PublicResource = {
   delivery: PublicResourceDelivery;
   sourceAuthority: string;
   masterLabel?: string;
+  masterSource?: PublicResourceMasterSource;
 };
+
+const homeGardenPublicResources: PublicResource[] = homeGardenGuides.map((guide) => ({
+  id: `home-garden-guide-${guide.id}`,
+  kind: "guide",
+  statusLabel: "Casa & Jardín",
+  title: guide.title,
+  copy: `${guide.summary} La lectura web está disponible dentro de Casa, Jardín y Vivero; el PDF maestro del handoff se conserva como fuente y todavía no se expone como descarga pública.`,
+  href: `/casa-jardin/guias#${guide.id}`,
+  cta: "Abrir guía",
+  delivery: "web-native-master-pending",
+  sourceAuthority: "Wondergreen Casa & Jardín Truth · handoff validado",
+  masterLabel: `${guide.title} · PDF maestro validado`,
+  masterSource: "validated-handoff",
+}));
 
 export const publicResources: PublicResource[] = [
   {
@@ -37,6 +55,7 @@ export const publicResources: PublicResource[] = [
     delivery: "web-native-master-pending",
     sourceAuthority: "Wondergreen Crop Truth · maestro comercial localizado",
     masterLabel: "Guía Wondergreen Café · 20 páginas",
+    masterSource: "internal-document-library",
   },
   {
     id: "wondergreen-guide-cacao",
@@ -49,6 +68,7 @@ export const publicResources: PublicResource[] = [
     delivery: "web-native-master-pending",
     sourceAuthority: "Wondergreen Crop Truth · maestro comercial localizado",
     masterLabel: "Guía Wondergreen Cacao · 20 páginas",
+    masterSource: "internal-document-library",
   },
   {
     id: "wondergreen-guide-aguacate",
@@ -61,6 +81,7 @@ export const publicResources: PublicResource[] = [
     delivery: "web-native-master-pending",
     sourceAuthority: "Wondergreen Crop Truth · maestro comercial localizado",
     masterLabel: "Guía Wondergreen Aguacate V2 · 20 páginas",
+    masterSource: "internal-document-library",
   },
   {
     id: "wondergreen-guide-limon-tahiti",
@@ -73,6 +94,7 @@ export const publicResources: PublicResource[] = [
     delivery: "web-native-master-pending",
     sourceAuthority: "Wondergreen Crop Truth · maestro comercial localizado",
     masterLabel: "Guía Wondergreen Cítricos · 20 páginas",
+    masterSource: "internal-document-library",
   },
   {
     id: "wondergreen-guide-pastos",
@@ -85,7 +107,9 @@ export const publicResources: PublicResource[] = [
     delivery: "web-native-master-pending",
     sourceAuthority: "Wondergreen Crop Truth · maestro comercial localizado",
     masterLabel: "Guía Wondergreen Pastos y Praderas · 20 páginas",
+    masterSource: "internal-document-library",
   },
+  ...homeGardenPublicResources,
   {
     id: "wondergreen-use-manual",
     kind: "manual",
@@ -130,6 +154,7 @@ export const publicResources: PublicResource[] = [
     delivery: "web-native-master-pending",
     sourceAuthority: "Wondergreen Product Truth · maestro comercial localizado",
     masterLabel: "Catálogo Wondergreen optimizado · 10 páginas",
+    masterSource: "internal-document-library",
   },
   {
     id: "wondergreen-more-than-npk",
@@ -154,3 +179,10 @@ export const publicResources: PublicResource[] = [
     sourceAuthority: "Wondergreen Crop Truth",
   },
 ];
+
+export const publicResourceHostingGate = {
+  privateSourceLinksAllowed: false,
+  publicDownloadEnabled: false,
+  requiredPublicHost: "same-origin-or-approved-public-cdn",
+  rule: "Un maestro interno o de handoff puede sustentar contenido web, pero no se convierte en enlace de descarga hasta existir un binario auditado en un host público estable y gobernado.",
+} as const;


### PR DESCRIPTION
## Objetivo
Unificar la Biblioteca pública de Greenatics/Wondergreen con la nueva arquitectura Casa, Jardín y Vivero, manteniendo separados los recursos web-native de los PDF maestros que todavía no tienen hosting público gobernado.

## Cambios
- añade Casa & Jardín como segunda ruta de intención dentro de `/biblioteca`;
- incorpora las 4 guías B2C validadas del handoff al registro central de recursos;
- distingue maestros provenientes de biblioteca documental interna vs. handoff validado;
- mantiene como autoridad pública la lectura web navegable;
- añade `publicResourceHostingGate` para impedir que fuentes privadas se conviertan directamente en descargas públicas;
- refuerza textos de Biblioteca para cubrir cultivos y hogar/jardín;
- añade unit tests y E2E que verifican ausencia de URLs privadas y PDFs falsos.

## Fuentes verificadas
- catálogo Wondergreen optimizado de 10 páginas localizado en la biblioteca documental interna;
- maestros de café, cacao, aguacate, cítricos y pastos ya localizados;
- 4 guías Casa & Jardín validadas desde el handoff B2C.

## Deliberadamente NO incluido
- enlaces SharePoint/Graph en frontend o código público;
- copias binarias de PDF todavía privadas;
- QR finales;
- nuevas dosis, PVP, margen o checkout;
- cambios a Product Truth, OPS, Auth, Supabase, RLS o migraciones.

## Base
Parte de `develop` en `00daea34f193a66cfb2c811b222d4a82d691a995` y está 4 commits adelante / 0 detrás al abrir esta PR.

## Gate
Merge únicamente con CI final verde sobre la cabeza exacta de la PR.