### PR TITLE
feat(public): hacer descubrible Casa Jardín desde HOME y Wondergreen

### DIFF
--- a/e2e/public-editorial-home.spec.ts
+++ b/e2e/public-editorial-home.spec.ts
@@ -19,6 +19,10 @@ test("public HOME exposes the three Greenatics pillars and commercial doors befo
   await expect(page.getByRole("heading", { name: "Economía circular" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Operación y acompañamiento" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Empieza por el problema que necesitas resolver." })).toBeVisible();
+  await expect(page.getByText("Seis puertas de entrada", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Casa & Jardín", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Explorar Casa & Jardín →", exact: true })).toHaveAttribute("href", "/casa-jardin");
+  await expect(page.getByRole("link", { name: "Abrir biblioteca →", exact: true })).toHaveAttribute("href", "/biblioteca");
 
   const levelTwoHeadings = await page.getByRole("heading", { level: 2 }).allTextContents();
   const doorsIndex = levelTwoHeadings.indexOf("Empieza por el problema que necesitas resolver.");
@@ -45,6 +49,7 @@ test("public HOME keeps its primary routes explicit and separate from OPS", asyn
 
   await expect(page.getByRole("link", { name: "Descubrir Wondergreen" })).toHaveAttribute("href", "/wondergreen");
   await expect(page.getByRole("link", { name: "Explorar soluciones", exact: true }).first()).toHaveAttribute("href", "/soluciones");
+  await expect(page.getByRole("link", { name: "Casa & Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
   await expect(page.getByRole("link", { name: "Contactar a Greenatics" })).toHaveAttribute("href", "/contacto");
   await expect(page.getByRole("link", { name: "Acceder a la app interna" })).toHaveAttribute("href", "/app");
 });

--- a/e2e/wondergreen-editorial.spec.ts
+++ b/e2e/wondergreen-editorial.spec.ts
@@ -10,13 +10,28 @@ test("Wondergreen uses the canonical public shell without duplicate chrome", asy
   await expect(page.getByRole("link", { name: "GREENATICS OPS" })).toHaveAttribute("href", "/app");
 });
 
-test("Wondergreen subnavigation connects products, crops and knowledge", async ({ page }) => {
+test("Wondergreen subnavigation connects products, crops, Casa Jardin and knowledge", async ({ page }) => {
   await page.goto("/wondergreen");
 
   const nav = page.getByRole("navigation", { name: "Navegación Wondergreen" });
   await expect(nav.getByRole("link", { name: "Productos" })).toHaveAttribute("href", "/wondergreen/productos");
   await expect(nav.getByRole("link", { name: "Cultivos" })).toHaveAttribute("href", "/wondergreen/cultivos");
+  await expect(nav.getByRole("link", { name: "Casa & Jardín" })).toHaveAttribute("href", "/casa-jardin");
   await expect(nav.getByRole("link", { name: "Guías" })).toHaveAttribute("href", "/biblioteca");
+});
+
+test("Wondergreen exposes a household entry without turning Casa Jardin into ecommerce", async ({ page }) => {
+  await page.goto("/wondergreen");
+
+  const householdEntry = page.getByRole("article").filter({
+    has: page.getByRole("heading", { name: "Tengo plantas en casa", exact: true }),
+  });
+  await expect(householdEntry.getByRole("link", { name: "Continuar →" })).toHaveAttribute("href", "/casa-jardin");
+
+  await page.goto("/casa-jardin");
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
+  await expect(page.getByRole("button", { name: /comprar/i })).toHaveCount(0);
+  await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
 });
 
 test("Wondergreen editorial hub preserves governed product truth and opens exact references", async ({ page }) => {
@@ -33,6 +48,7 @@ test("Wondergreen editorial hub preserves governed product truth and opens exact
   await expect(portfolio.getByRole("link", { name: /2Grow Sólido · 15-3-3/ })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
   await expect(portfolio.getByRole("link", { name: "Abrir catálogo completo" })).toHaveAttribute("href", "/wondergreen/productos");
   await expect(portfolio.getByRole("link", { name: "Abrir Biblioteca Wondergreen" })).toHaveAttribute("href", "/biblioteca");
+  await expect(portfolio.getByRole("link", { name: "Casa & Jardín" })).toHaveAttribute("href", "/casa-jardin");
   await expect(page.getByText(/únicamente desde la versión técnica vigente/i)).toBeVisible();
 });
 
@@ -44,13 +60,17 @@ test("Wondergreen finder follows diagnosis to follow-up without automatic prescr
   await expect(finder.getByText("Diagnóstico y análisis", { exact: true })).toBeVisible();
   await expect(finder.getByText("Seguimiento y ajuste", { exact: true })).toBeVisible();
   await expect(finder.getByText(/no una prescripción automática/i)).toBeVisible();
+  await expect(finder.getByRole("link", { name: "Empezar por cultivo" })).toHaveAttribute("href", "/wondergreen/cultivos");
   await expect(finder.getByRole("link", { name: "Consultar guías" })).toHaveAttribute("href", "/biblioteca");
 });
 
-test("Wondergreen commercial routes end in real public destinations", async ({ page }) => {
+test("Wondergreen audience routes end in real governed destinations", async ({ page }) => {
   await page.goto("/wondergreen");
 
-  await expect(page.getByRole("link", { name: "Empezar por cultivo" })).toHaveAttribute("href", "/wondergreen/cultivos");
+  const routes = page.locator("#acompanamiento");
+  await expect(routes.getByRole("link", { name: "Empezar por cultivo →" })).toHaveAttribute("href", "/wondergreen/cultivos");
+  await expect(routes.getByRole("link", { name: "Explorar Casa & Jardín →" })).toHaveAttribute("href", "/casa-jardin");
+  await expect(routes.getByRole("link", { name: "Quiero vender Wondergreen →" })).toHaveAttribute("href", "/contacto");
+  await expect(routes.getByRole("link", { name: "Abrir biblioteca técnica →" })).toHaveAttribute("href", "/biblioteca");
   await expect(page.getByRole("link", { name: "Hablar con equipo técnico" })).toHaveAttribute("href", "/contacto");
-  await expect(page.getByRole("link", { name: "Quiero vender Wondergreen →" })).toHaveAttribute("href", "/contacto");
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import refresh from "./public-home-refresh.module.css";
 export const metadata: Metadata = {
   title: "Greenatics | Transformamos residuos en vida",
   description:
-    "Greenatics integra aprovechamiento de residuos orgánicos, tecnología, operación, Wondergreen y conocimiento para devolver valor al territorio y al suelo.",
+    "Greenatics integra aprovechamiento de residuos orgánicos, tecnología, operación, Wondergreen, Casa & Jardín y conocimiento para devolver valor al territorio y al suelo.",
   alternates: { canonical: "/" },
 };
 
@@ -24,6 +24,14 @@ const entryPoints = [
   },
   {
     number: "02",
+    kicker: "Hogar · jardín · vivero",
+    title: "Casa & Jardín",
+    copy: "Nutrición por etapas, diagnóstico orientativo, kits de pre-lanzamiento y guías para plantas, huertas, jardines y viveros.",
+    href: "/casa-jardin",
+    cta: "Explorar Casa & Jardín",
+  },
+  {
+    number: "03",
     kicker: "Territorios",
     title: "Municipios y ESP",
     copy: "Diagnóstico, rutas selectivas, plantas, rehabilitación, operación y trazabilidad para convertir planeación en capacidad real.",
@@ -31,7 +39,7 @@ const entryPoints = [
     cta: "Explorar soluciones",
   },
   {
-    number: "03",
+    number: "04",
     kicker: "Generadores",
     title: "Empresas",
     copy: "Caracterización, separación, recolección, tratamiento, infraestructura y evidencia para corrientes orgánicas empresariales.",
@@ -39,12 +47,20 @@ const entryPoints = [
     cta: "Explorar soluciones",
   },
   {
-    number: "04",
+    number: "05",
     kicker: "Ingeniería + biología",
     title: "Plantas y tecnología",
     copy: "Compostaje, digestión anaerobia, biogás, biol, fertilizantes y operación basada en parámetros, mantenimiento y datos.",
     href: "/#tecnologia",
     cta: "Entender la tecnología",
+  },
+  {
+    number: "06",
+    kicker: "Guías + decisión",
+    title: "Conocimiento",
+    copy: "Programas por cultivo, Casa & Jardín, deficiencias, criterios nutricionales y manuales convertidos en rutas navegables.",
+    href: "/biblioteca",
+    cta: "Abrir biblioteca",
   },
 ];
 
@@ -199,9 +215,9 @@ export default function Home() {
         <section className={styles.paths} id="soluciones">
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
-              <span className={styles.eyebrow}>Cuatro puertas de entrada</span>
+              <span className={styles.eyebrow}>Seis puertas de entrada</span>
               <h2>Empieza por el problema que necesitas resolver.</h2>
-              <p>La ruta cambia según el residuo, el cultivo, el territorio y la infraestructura existente.</p>
+              <p>La ruta cambia según el residuo, el cultivo, las plantas en casa, el territorio, la infraestructura o la información que necesitas.</p>
             </div>
             <div className={styles.pathGrid}>
               {entryPoints.map((item) => (
@@ -218,8 +234,8 @@ export default function Home() {
             </div>
             <div className={styles.router}>
               <div>
-                <strong>¿Tienes un residuo, un cultivo o un proyecto por resolver?</strong>
-                <span>Primero entendemos el caso; luego definimos producto, servicio o infraestructura.</span>
+                <strong>¿Tienes un residuo, un cultivo, una planta o un proyecto por resolver?</strong>
+                <span>Primero entendemos el caso; luego definimos producto, servicio, conocimiento o infraestructura.</span>
               </div>
               <Link className={`${styles.button} ${styles.buttonDark}`} href="/contacto">Hablar con Greenatics</Link>
             </div>
@@ -241,6 +257,7 @@ export default function Home() {
                 <div className={styles.buttonRow}>
                   <Link className={`${styles.button} ${styles.buttonLight}`} href="/wondergreen/productos">Ver productos</Link>
                   <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/wondergreen/cultivos">Buscar por cultivo</Link>
+                  <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/casa-jardin">Casa & Jardín</Link>
                 </div>
               </div>
             </div>

--- a/src/app/wondergreen/page.tsx
+++ b/src/app/wondergreen/page.tsx
@@ -9,7 +9,7 @@ import refresh from "./wondergreen-refresh.module.css";
 export const metadata: Metadata = {
   title: "Wondergreen | Suelo, nutrición y biología",
   description:
-    "Wondergreen integra fertilizantes sólidos y líquidos, compost, bioinsumos, guías por cultivo y acompañamiento técnico.",
+    "Wondergreen integra fertilizantes sólidos y líquidos, compost, bioinsumos, guías por cultivo, Casa & Jardín y acompañamiento técnico.",
   alternates: { canonical: "/wondergreen" },
 };
 
@@ -17,6 +17,7 @@ const entryPaths = [
   ["01", "Tengo un cultivo", "Empieza por especie, etapa y objetivo antes de elegir producto.", "/wondergreen/cultivos"],
   ["02", "Tengo una necesidad", "Nutrición, suelo, floración, producción, raíz, plagas o enfermedades.", "#finder"],
   ["03", "Sé qué producto busco", "Entra al Product Master público y revisa familia, formato y condición comercial.", "/wondergreen/productos"],
+  ["04", "Tengo plantas en casa", "Entra a Casa, Jardín y Vivero para observar la etapa, usar el diagnóstico orientativo y recorrer kits y guías de pre-lanzamiento.", "/casa-jardin"],
 ];
 
 const system = [
@@ -50,9 +51,10 @@ const bioFamilies = [
 ];
 
 const audiences = [
-  ["01", "Productor", "Encuentra una ruta técnica para tu cultivo.", "Encontrar solución"],
-  ["02", "Agrotienda / distribuidor", "Conoce familias, formatos y oportunidad comercial.", "Quiero vender Wondergreen"],
-  ["03", "Agrónomo / técnico", "Accede a portafolio, guías y soporte técnico.", "Conocer portafolio técnico"],
+  ["01", "Productor", "Encuentra una ruta técnica para tu cultivo.", "Empezar por cultivo", "/wondergreen/cultivos"],
+  ["02", "Hogar / jardín", "Observa la etapa de tus plantas y entra al sistema doméstico sin dosificar a ciegas.", "Explorar Casa & Jardín", "/casa-jardin"],
+  ["03", "Agrotienda / distribuidor", "Conoce familias, formatos y oportunidad comercial.", "Quiero vender Wondergreen", "/contacto"],
+  ["04", "Agrónomo / técnico", "Accede a portafolio, guías y criterios técnicos navegables.", "Abrir biblioteca técnica", "/biblioteca"],
 ];
 
 export default function WondergreenPage() {
@@ -64,6 +66,7 @@ export default function WondergreenPage() {
           <div>
             <Link href="/wondergreen/productos">Productos</Link>
             <Link href="/wondergreen/cultivos">Cultivos</Link>
+            <Link href="/casa-jardin">Casa & Jardín</Link>
             <a href="#tecnologia">Tecnología</a>
             <a href="#bioinsumos">Bioinsumos</a>
             <Link href="/biblioteca">Guías</Link>
@@ -114,8 +117,8 @@ export default function WondergreenPage() {
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Empieza por tu contexto</span>
-              <h2>No empieces por el producto. Empieza por lo que tu cultivo necesita.</h2>
-              <p>La selección cambia con cultivo, suelo, etapa, problema y objetivo. Wondergreen organiza el portafolio para hacer esa ruta más clara.</p>
+              <h2>No empieces por el producto. Empieza por lo que necesitas resolver.</h2>
+              <p>La selección cambia con cultivo, planta, suelo o sustrato, etapa, problema y objetivo. Wondergreen organiza distintas rutas para hacer esa decisión más clara.</p>
             </div>
             <div className={styles.entryList}>
               {entryPaths.map(([number, title, copy, href]) => (
@@ -185,6 +188,7 @@ export default function WondergreenPage() {
             <div className={styles.buttonRow}>
               <Link className={`${styles.button} ${styles.light}`} href="/wondergreen/productos">Abrir catálogo completo</Link>
               <Link className={`${styles.button} ${refresh.outlineLight}`} href="/biblioteca">Abrir Biblioteca Wondergreen</Link>
+              <Link className={`${styles.button} ${refresh.outlineLight}`} href="/casa-jardin">Casa & Jardín</Link>
             </div>
           </div>
         </section>
@@ -266,12 +270,12 @@ export default function WondergreenPage() {
         <section className={styles.commercial} id="acompanamiento">
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
-              <span className={styles.eyebrow}>Tres rutas comerciales</span>
-              <h2>El mismo portafolio, distintas preguntas.</h2>
+              <span className={styles.eyebrow}>Cuatro rutas de entrada</span>
+              <h2>El mismo sistema, distintas preguntas.</h2>
             </div>
             <div className={styles.commercialList}>
-              {audiences.map(([number, title, copy, cta]) => (
-                <article key={title}><span>{number}</span><div><h3>{title}</h3><p>{copy}</p></div><Link href="/contacto">{cta} →</Link></article>
+              {audiences.map(([number, title, copy, cta, href]) => (
+                <article key={title}><span>{number}</span><div><h3>{title}</h3><p>{copy}</p></div><Link href={href}>{cta} →</Link></article>
               ))}
             </div>
           </div>
@@ -279,7 +283,7 @@ export default function WondergreenPage() {
 
         <section className={styles.closing} id="contacto">
           <div className={`${styles.container} ${styles.closingInner}`}>
-            <div><span className={styles.eyebrow}>Wondergreen</span><h2>¿Tienes un cultivo, una necesidad o un problema por resolver?</h2><p>Cuéntanos el contexto. El siguiente paso puede ser una guía, un producto, un análisis o acompañamiento técnico.</p></div>
+            <div><span className={styles.eyebrow}>Wondergreen</span><h2>¿Tienes un cultivo, plantas en casa, una necesidad o un problema por resolver?</h2><p>Empieza por el contexto. El siguiente paso puede ser Casa & Jardín, una guía, un producto, un análisis o acompañamiento técnico.</p></div>
             <div className={styles.buttonRow}><Link className={`${styles.button} ${styles.dark}`} href="/contacto">Hablar con equipo técnico</Link><Link className={`${styles.button} ${styles.ghost}`} href="/">Volver a Greenatics</Link></div>
           </div>
         </section>


### PR DESCRIPTION
## Objetivo
Conectar Casa, Jardín y Vivero con las superficies comerciales principales de la web pública para que un usuario doméstico pueda descubrir la línea desde HOME y Wondergreen, sin cambiar su estado de pre-lanzamiento ni activar ecommerce.

## Cambios
- HOME pasa de 4 a 6 puertas de entrada: Wondergreen, Casa & Jardín, Municipios/ESP, Empresas, Plantas/tecnología y Conocimiento;
- añade CTA Casa & Jardín dentro del bloque Wondergreen de HOME;
- Wondergreen incorpora Casa & Jardín en su subnavegación;
- añade una cuarta ruta contextual `Tengo plantas en casa`;
- el portafolio Wondergreen enlaza explícitamente a Casa & Jardín;
- las rutas por audiencia dejan de enviar todo a Contacto y apuntan a destinos gobernados: cultivos, Casa & Jardín, contacto comercial o biblioteca;
- copy final amplía el contexto a cultivo + plantas domésticas;
- E2E fija navegación y conserva `noindex`, ausencia de precio y ausencia de compra en Casa & Jardín.

## Guardrails
- Casa & Jardín continúa noindex;
- cero PVP, margen, descuento, checkout o stock público;
- cero nuevas dosis/frecuencias;
- no modifica Product Truth, Crop Truth ni composiciones de kits;
- no toca OPS, Auth, Supabase, RLS ni migraciones;
- no toca `main`.

## Base
Parte de `develop` en `dd274b1c62e834ef61e9b3880ddfabacdaead429` y está 4 commits adelante / 0 detrás.

## Gate
Merge únicamente con CI final verde sobre la cabeza exacta de la PR.