### PR TITLE
feat(home-garden): gobernar evidencia de lanzamiento B2C

### DIFF
--- a/src/data/home-garden-evidence.test.ts
+++ b/src/data/home-garden-evidence.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  canHomeGardenEvidenceSetCloseGate,
+  getHomeGardenEvidenceRule,
+  homeGardenEvidenceRules,
+  homeGardenGateEvidenceRequirements,
+  type HomeGardenEvidenceRecord,
+} from "./home-garden-evidence";
+
+const verified = (
+  kind: HomeGardenEvidenceRecord["kind"],
+  overrides: Partial<HomeGardenEvidenceRecord> = {},
+): HomeGardenEvidenceRecord => ({
+  kind,
+  verified: true,
+  sameReference: true,
+  samePresentation: true,
+  completeForGate: true,
+  ...overrides,
+});
+
+describe("Casa, Jardín y Vivero launch evidence contract", () => {
+  it("keeps laboratory evidence analytically useful but unable to close commercial gates", () => {
+    const laboratory = getHomeGardenEvidenceRule("laboratory-report");
+
+    expect(laboratory?.supports.join(" ")).toMatch(/muestra/i);
+    expect(laboratory?.doesNotProve.join(" ")).toMatch(/registro de venta/i);
+    expect(laboratory?.eligibleToClose).toEqual([]);
+    expect(canHomeGardenEvidenceSetCloseGate("regulatory", [verified("laboratory-report")])).toBe(false);
+  });
+
+  it("requires regulatory coverage and approved label for the same reference and presentation", () => {
+    expect(canHomeGardenEvidenceSetCloseGate("regulatory", [
+      verified("regulatory-registration"),
+      verified("approved-label"),
+    ])).toBe(true);
+
+    expect(canHomeGardenEvidenceSetCloseGate("regulatory", [
+      verified("regulatory-registration"),
+      verified("approved-label", { samePresentation: false }),
+    ])).toBe(false);
+
+    expect(canHomeGardenEvidenceSetCloseGate("regulatory", [verified("regulatory-registration")])).toBe(false);
+  });
+
+  it("does not let a partial cost model close the all-in cost gate", () => {
+    expect(canHomeGardenEvidenceSetCloseGate("all-in-cost", [
+      verified("cost-model", { completeForGate: false }),
+    ])).toBe(false);
+
+    expect(canHomeGardenEvidenceSetCloseGate("all-in-cost", [verified("cost-model")])).toBe(true);
+  });
+
+  it("requires exact presentation matching for SKU, dosing, fulfillment and public assets", () => {
+    expect(canHomeGardenEvidenceSetCloseGate("household-skus", [verified("sku-master")])).toBe(true);
+    expect(canHomeGardenEvidenceSetCloseGate("dose-and-dosifier", [verified("dose-validation")])).toBe(true);
+    expect(canHomeGardenEvidenceSetCloseGate("fulfillment", [verified("fulfillment-record")])).toBe(true);
+    expect(canHomeGardenEvidenceSetCloseGate("public-assets", [
+      verified("approved-label"),
+      verified("public-asset"),
+    ])).toBe(true);
+
+    expect(canHomeGardenEvidenceSetCloseGate("household-skus", [
+      verified("sku-master", { samePresentation: false }),
+    ])).toBe(false);
+  });
+
+  it("defines every evidence kind and gate exactly once", () => {
+    const evidenceKinds = homeGardenEvidenceRules.map((rule) => rule.kind);
+    const gates = homeGardenGateEvidenceRequirements.map((requirement) => requirement.gate);
+
+    expect(new Set(evidenceKinds).size).toBe(evidenceKinds.length);
+    expect(new Set(gates).size).toBe(gates.length);
+    expect(gates).toEqual([
+      "technical-product-truth",
+      "household-skus",
+      "regulatory",
+      "dose-and-dosifier",
+      "all-in-cost",
+      "fulfillment",
+      "public-assets",
+    ]);
+  });
+});

--- a/src/data/home-garden-evidence.ts
+++ b/src/data/home-garden-evidence.ts
@@ -1,0 +1,187 @@
+export type HomeGardenEvidenceKind =
+  | "product-truth"
+  | "laboratory-report"
+  | "regulatory-registration"
+  | "approved-label"
+  | "sku-master"
+  | "dose-validation"
+  | "cost-model"
+  | "fulfillment-record"
+  | "public-asset";
+
+export type HomeGardenEvidenceGateId =
+  | "technical-product-truth"
+  | "household-skus"
+  | "regulatory"
+  | "dose-and-dosifier"
+  | "all-in-cost"
+  | "fulfillment"
+  | "public-assets";
+
+export type HomeGardenEvidenceRule = {
+  kind: HomeGardenEvidenceKind;
+  label: string;
+  supports: readonly string[];
+  doesNotProve: readonly string[];
+  eligibleToClose: readonly HomeGardenEvidenceGateId[];
+};
+
+export type HomeGardenEvidenceRecord = {
+  kind: HomeGardenEvidenceKind;
+  verified: boolean;
+  sameReference: boolean;
+  samePresentation: boolean;
+  completeForGate: boolean;
+};
+
+export type HomeGardenGateEvidenceRequirement = {
+  gate: HomeGardenEvidenceGateId;
+  requiredEvidence: readonly HomeGardenEvidenceKind[];
+  requireSameReference: boolean;
+  requireSamePresentation: boolean;
+  rule: string;
+};
+
+export const homeGardenEvidenceRules: readonly HomeGardenEvidenceRule[] = [
+  {
+    kind: "product-truth",
+    label: "Product Truth",
+    supports: ["Nombre técnico", "fórmula", "familia", "formato y condición pública gobernada"],
+    doesNotProve: ["Registro de venta", "etiqueta aprobada", "stock", "PVP", "margen"],
+    eligibleToClose: ["technical-product-truth"],
+  },
+  {
+    kind: "laboratory-report",
+    label: "Reporte de laboratorio",
+    supports: ["Resultado analítico de la muestra ensayada bajo el alcance del reporte"],
+    doesNotProve: ["Registro de venta del producto", "autorización de una presentación", "etiqueta aprobada", "eficacia comercial", "PVP"],
+    eligibleToClose: [],
+  },
+  {
+    kind: "regulatory-registration",
+    label: "Registro o cobertura regulatoria aplicable",
+    supports: ["Condición regulatoria documentada de la referencia dentro de su alcance"],
+    doesNotProve: ["Que cualquier nuevo tamaño o arte esté cubierto", "costo", "stock", "dosificación doméstica"],
+    eligibleToClose: ["regulatory"],
+  },
+  {
+    kind: "approved-label",
+    label: "Etiqueta o arte regulatoriamente conciliado",
+    supports: ["Correspondencia entre referencia, presentación, rotulado y condición regulatoria"],
+    doesNotProve: ["Stock", "PVP", "margen", "capacidad logística"],
+    eligibleToClose: ["regulatory", "public-assets"],
+  },
+  {
+    kind: "sku-master",
+    label: "SKU Master",
+    supports: ["Identidad comercial de una presentación reconciliada con producto, empaque y trazabilidad"],
+    doesNotProve: ["Disponibilidad física", "precio", "margen", "cobertura regulatoria por sí solo"],
+    eligibleToClose: ["household-skus"],
+  },
+  {
+    kind: "dose-validation",
+    label: "Validación de dosis doméstica",
+    supports: ["Equivalencia de dosis y dosificador para la formulación y contexto validados"],
+    doesNotProve: ["Una dosis universal para todas las plantas", "registro de venta", "precio"],
+    eligibleToClose: ["dose-and-dosifier"],
+  },
+  {
+    kind: "cost-model",
+    label: "Modelo de costo all-in",
+    supports: ["Costo puesto a venta cuando incluye todos los componentes exigidos por el checklist vigente"],
+    doesNotProve: ["PVP autorizado si el modelo está incompleto", "registro de venta", "stock"],
+    eligibleToClose: ["all-in-cost"],
+  },
+  {
+    kind: "fulfillment-record",
+    label: "Evidencia operativa de fulfillment",
+    supports: ["Stock vendible, armado, embalaje, tiempos, despacho y tratamiento logístico reconciliados"],
+    doesNotProve: ["Registro de venta", "dosis", "PVP por sí solo"],
+    eligibleToClose: ["fulfillment"],
+  },
+  {
+    kind: "public-asset",
+    label: "Activo público auditado",
+    supports: ["Packshot, guía o QR reconciliado con la referencia y destino público final"],
+    doesNotProve: ["Fórmula distinta a Product Truth", "registro de venta", "precio", "stock"],
+    eligibleToClose: ["public-assets"],
+  },
+] as const;
+
+export const homeGardenGateEvidenceRequirements: readonly HomeGardenGateEvidenceRequirement[] = [
+  {
+    gate: "technical-product-truth",
+    requiredEvidence: ["product-truth"],
+    requireSameReference: true,
+    requireSamePresentation: false,
+    rule: "La identidad técnica debe provenir de Product Truth vigente; un arte o reporte analítico no puede reemplazarlo.",
+  },
+  {
+    gate: "household-skus",
+    requiredEvidence: ["sku-master"],
+    requireSameReference: true,
+    requireSamePresentation: true,
+    rule: "Cada presentación doméstica debe existir como SKU reconciliado con referencia, empaque y trazabilidad.",
+  },
+  {
+    gate: "regulatory",
+    requiredEvidence: ["regulatory-registration", "approved-label"],
+    requireSameReference: true,
+    requireSamePresentation: true,
+    rule: "El gate regulatorio exige cobertura documental y etiqueta conciliada para la misma referencia y presentación; un reporte de laboratorio nunca basta.",
+  },
+  {
+    gate: "dose-and-dosifier",
+    requiredEvidence: ["dose-validation"],
+    requireSameReference: true,
+    requireSamePresentation: true,
+    rule: "La dosis doméstica debe estar validada para la formulación y presentación que se pretende publicar.",
+  },
+  {
+    gate: "all-in-cost",
+    requiredEvidence: ["cost-model"],
+    requireSameReference: true,
+    requireSamePresentation: true,
+    rule: "Un costo parcial de fertilizante o empaque no cierra economía unitaria: el modelo debe estar completo para el checklist all-in vigente.",
+  },
+  {
+    gate: "fulfillment",
+    requiredEvidence: ["fulfillment-record"],
+    requireSameReference: true,
+    requireSamePresentation: true,
+    rule: "La promesa comercial requiere evidencia operativa reconciliada de stock, armado, embalaje y despacho.",
+  },
+  {
+    gate: "public-assets",
+    requiredEvidence: ["approved-label", "public-asset"],
+    requireSameReference: true,
+    requireSamePresentation: true,
+    rule: "Los activos finales deben coincidir con la referencia, presentación, etiqueta y destino público auditados.",
+  },
+] as const;
+
+export function getHomeGardenEvidenceRule(kind: HomeGardenEvidenceKind) {
+  return homeGardenEvidenceRules.find((rule) => rule.kind === kind);
+}
+
+export function getHomeGardenGateEvidenceRequirement(gate: HomeGardenEvidenceGateId) {
+  return homeGardenGateEvidenceRequirements.find((requirement) => requirement.gate === gate);
+}
+
+export function canHomeGardenEvidenceSetCloseGate(
+  gate: HomeGardenEvidenceGateId,
+  evidence: readonly HomeGardenEvidenceRecord[],
+) {
+  const requirement = getHomeGardenGateEvidenceRequirement(gate);
+  if (!requirement) return false;
+
+  return requirement.requiredEvidence.every((requiredKind) => {
+    const record = evidence.find((candidate) => candidate.kind === requiredKind);
+    if (!record || !record.verified || !record.completeForGate) return false;
+    if (requirement.requireSameReference && !record.sameReference) return false;
+    if (requirement.requireSamePresentation && !record.samePresentation) return false;
+
+    const rule = getHomeGardenEvidenceRule(requiredKind);
+    return Boolean(rule?.eligibleToClose.includes(gate));
+  });
+}

--- a/src/data/home-garden-readiness.test.ts
+++ b/src/data/home-garden-readiness.test.ts
@@ -28,6 +28,20 @@ describe("Casa, Jardín y Vivero commercial readiness", () => {
     expect(blockedHomeGardenLaunchItems.map((item) => item.id)).toEqual(["transplant-kit"]);
   });
 
+  it("binds launch dependencies to explicit evidence gates", () => {
+    expect(pendingHomeGardenLaunchItems.map((item) => [item.id, item.evidenceGate])).toEqual([
+      ["household-skus", "household-skus"],
+      ["regulatory", "regulatory"],
+      ["dose-and-dosifier", "dose-and-dosifier"],
+      ["all-in-cost", "all-in-cost"],
+      ["fulfillment", "fulfillment"],
+      ["public-assets", "public-assets"],
+    ]);
+
+    expect(readyHomeGardenLaunchItems.find((item) => item.id === "technical-product-truth")?.evidenceGate)
+      .toBe("technical-product-truth");
+  });
+
   it("keeps ecommerce, price and margin claims fail-closed", () => {
     expect(homeGardenCommerceGate).toMatchObject({
       indexable: false,
@@ -38,6 +52,7 @@ describe("Casa, Jardín y Vivero commercial readiness", () => {
     });
     expect(homeGardenCommerceGate.rule).toMatch(/regulatorios/i);
     expect(homeGardenCommerceGate.rule).toMatch(/costo all-in/i);
+    expect(homeGardenCommerceGate.rule).toMatch(/misma referencia y presentación/i);
   });
 
   it("requires an all-in cost instead of deriving margin from fertilizer content alone", () => {

--- a/src/data/home-garden-readiness.ts
+++ b/src/data/home-garden-readiness.ts
@@ -1,3 +1,5 @@
+import type { HomeGardenEvidenceGateId } from "./home-garden-evidence";
+
 export type HomeGardenReadinessStatus = "ready" | "pending" | "blocked";
 
 export type HomeGardenReadinessItem = {
@@ -7,6 +9,7 @@ export type HomeGardenReadinessItem = {
   publicLabel: string;
   publicCopy: string;
   gate: string;
+  evidenceGate?: HomeGardenEvidenceGateId;
 };
 
 export const homeGardenLaunchReadiness: readonly HomeGardenReadinessItem[] = [
@@ -17,6 +20,7 @@ export const homeGardenLaunchReadiness: readonly HomeGardenReadinessItem[] = [
     publicLabel: "Referencias y fórmulas",
     publicCopy: "Las cinco etapas visibles están conectadas con referencias Wondergreen ya gobernadas; el nombre doméstico no reemplaza la referencia técnica.",
     gate: "Conservar correspondencia con Product Truth y no derivar nuevos claims desde el arte.",
+    evidenceGate: "technical-product-truth",
   },
   {
     id: "kit-composition-v1",
@@ -41,6 +45,7 @@ export const homeGardenLaunchReadiness: readonly HomeGardenReadinessItem[] = [
     publicLabel: "Presentaciones domésticas como SKUs comerciales",
     publicCopy: "Los tamaños 500 g, 1 kg, 2 kg y 5 kg son propuestas de la línea B2C; todavía no equivalen a inventario vendible reconciliado.",
     gate: "Cerrar SKU, stock, empaque, etiqueta y trazabilidad por presentación.",
+    evidenceGate: "household-skus",
   },
   {
     id: "regulatory",
@@ -49,6 +54,7 @@ export const homeGardenLaunchReadiness: readonly HomeGardenReadinessItem[] = [
     publicLabel: "Cobertura regulatoria de cada presentación",
     publicCopy: "Antes de vender una nueva presentación debe verificarse que registro de venta, etiquetado y condición aplicable de envasado/empacado la cubran.",
     gate: "Verificación documental ICA por referencia y presentación antes de activar compra.",
+    evidenceGate: "regulatory",
   },
   {
     id: "dose-and-dosifier",
@@ -57,6 +63,7 @@ export const homeGardenLaunchReadiness: readonly HomeGardenReadinessItem[] = [
     publicLabel: "Dosis doméstica y dosificador",
     publicCopy: "S/M/L/XL ya se capturan como tamaños de matera, pero todavía no se convierten a gramos ni frecuencia universal.",
     gate: "Validar tabla por formulación, tamaño de planta/contenedor y equivalencia real del dosificador.",
+    evidenceGate: "dose-and-dosifier",
   },
   {
     id: "all-in-cost",
@@ -65,6 +72,7 @@ export const homeGardenLaunchReadiness: readonly HomeGardenReadinessItem[] = [
     publicLabel: "Costo total y PVP gobernado",
     publicCopy: "El costo de producto es solo una parte. El PVP se publicará únicamente cuando exista costo total puesto a venta y una política de margen verificable.",
     gate: "Cerrar el checklist all-in completo antes de calcular margen, ahorro, descuento o precio público.",
+    evidenceGate: "all-in-cost",
   },
   {
     id: "fulfillment",
@@ -73,6 +81,7 @@ export const homeGardenLaunchReadiness: readonly HomeGardenReadinessItem[] = [
     publicLabel: "Armado, inventario y logística",
     publicCopy: "La tienda requiere una promesa operativa real: disponibilidad, armado, embalaje, despacho y tratamiento del flete.",
     gate: "Definir stock vendible, punto de armado, tiempos, cobertura logística y manejo de incidencias.",
+    evidenceGate: "fulfillment",
   },
   {
     id: "public-assets",
@@ -81,6 +90,7 @@ export const homeGardenLaunchReadiness: readonly HomeGardenReadinessItem[] = [
     publicLabel: "Packshots, guías y QR finales",
     publicCopy: "Hay activos candidatos y guías fuente, pero el arte no puede sustituir Product Truth ni usar QR o pesos inconsistentes.",
     gate: "Publicar solo binarios auditados contra fórmula, peso, composición, etiqueta y destino QR final.",
+    evidenceGate: "public-assets",
   },
   {
     id: "transplant-kit",
@@ -119,5 +129,5 @@ export const homeGardenCommerceGate = {
   priceEnabled: false,
   canPublishPrice: false,
   canClaimMargin: false,
-  rule: "No activar indexación comercial, precio, checkout, margen, ahorro o descuento hasta que los gates regulatorios, de dosificación, SKU, costo all-in, operación y activos estén reconciliados.",
+  rule: "No activar indexación comercial, precio, checkout, margen, ahorro o descuento hasta que los gates regulatorios, de dosificación, SKU, costo all-in, operación y activos estén reconciliados con la evidencia exigida para la misma referencia y presentación.",
 } as const;


### PR DESCRIPTION
## Objetivo
Convertir la verdad de lanzamiento de Casa, Jardín y Vivero en un contrato técnico que impida cerrar gates comerciales con evidencia de naturaleza equivocada.

## Cambios
- añade taxonomía explícita de evidencias: Product Truth, reporte de laboratorio, registro/cobertura regulatoria, etiqueta conciliada, SKU Master, validación de dosis, modelo de costo, fulfillment y activo público;
- define qué soporta y qué NO demuestra cada tipo de evidencia;
- define qué evidencia puede cerrar cada gate de lanzamiento;
- exige coincidencia de referencia y presentación cuando corresponde;
- exige registro/cobertura regulatoria + etiqueta conciliada para cerrar regulatorio;
- impide que un reporte de laboratorio cierre regulatorio;
- impide que un modelo de costo parcial cierre costo all-in;
- conecta los readiness items existentes con sus evidence gates;
- mantiene ecommerce, precio y margen fail-closed.

## Guardrails
- no incorpora documentos privados ni enlaces SharePoint/Graph;
- no publica resultados analíticos, costos, PVP, márgenes ni números regulatorios;
- no cambia Product Truth, Crop Truth, dosis, SKUs ni estado comercial;
- no toca OPS, Auth, Supabase, RLS ni migraciones;
- no toca `main`.

## Base
Parte de `develop` en `c11754babc71105184edd786056fdd94c0f001e6` y está 4 commits adelante / 0 detrás.

## Gate
Merge únicamente con CI final verde sobre la cabeza exacta de la PR.