### PR TITLE
feat(home-garden): derivar matriz de lanzamiento por SKU

### DIFF
--- a/src/data/home-garden-sku-launch-matrix.test.ts
+++ b/src/data/home-garden-sku-launch-matrix.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import type { HomeGardenEvidenceRecord } from "./home-garden-evidence";
+import {
+  buildHomeGardenSkuLaunchMatrix,
+  homeGardenPlannedSkuCandidates,
+  homeGardenSkuLaunchMatrix,
+} from "./home-garden-sku-launch-matrix";
+
+const verified = (
+  kind: HomeGardenEvidenceRecord["kind"],
+  overrides: Partial<HomeGardenEvidenceRecord> = {},
+): HomeGardenEvidenceRecord => ({
+  kind,
+  verified: true,
+  sameReference: true,
+  samePresentation: true,
+  completeForGate: true,
+  ...overrides,
+});
+
+describe("Casa, Jardín y Vivero SKU launch matrix", () => {
+  it("derives all planned B2C presentations from the governed product model", () => {
+    expect(homeGardenPlannedSkuCandidates).toHaveLength(18);
+    expect(new Set(homeGardenPlannedSkuCandidates.map((candidate) => candidate.id)).size).toBe(18);
+
+    expect(homeGardenPlannedSkuCandidates.filter((candidate) => candidate.productId === "prepara")).toHaveLength(2);
+    for (const productId of ["crece", "equilibra", "florece", "fructifica"] as const) {
+      expect(homeGardenPlannedSkuCandidates.filter((candidate) => candidate.productId === productId)).toHaveLength(4);
+    }
+  });
+
+  it("keeps every planned presentation fail-closed by default", () => {
+    expect(homeGardenSkuLaunchMatrix).toHaveLength(18);
+    expect(homeGardenSkuLaunchMatrix.every((candidate) => candidate.gates["technical-product-truth"])).toBe(true);
+    expect(homeGardenSkuLaunchMatrix.every((candidate) => candidate.commerceReady === false)).toBe(true);
+    expect(homeGardenSkuLaunchMatrix.every((candidate) => candidate.gates.regulatory === false)).toBe(true);
+    expect(homeGardenSkuLaunchMatrix.every((candidate) => candidate.gates["all-in-cost"] === false)).toBe(true);
+  });
+
+  it("can close one exact presentation only when every commercial gate has valid evidence", () => {
+    const target = homeGardenPlannedSkuCandidates.find((candidate) => candidate.id === "crece-500-g");
+    expect(target).toBeDefined();
+    if (!target) return;
+
+    const fullEvidence: HomeGardenEvidenceRecord[] = [
+      verified("sku-master"),
+      verified("regulatory-registration"),
+      verified("approved-label"),
+      verified("dose-validation"),
+      verified("cost-model"),
+      verified("fulfillment-record"),
+      verified("public-asset"),
+    ];
+
+    const matrix = buildHomeGardenSkuLaunchMatrix({ [target.id]: fullEvidence });
+    const evaluated = matrix.find((candidate) => candidate.id === target.id);
+
+    expect(evaluated?.commerceReady).toBe(true);
+    expect(Object.values(evaluated?.gates ?? {}).every(Boolean)).toBe(true);
+    expect(matrix.filter((candidate) => candidate.commerceReady)).toHaveLength(1);
+  });
+
+  it("does not accept laboratory reports or partial cost evidence as shortcuts", () => {
+    const target = homeGardenPlannedSkuCandidates.find((candidate) => candidate.id === "equilibra-1-kg");
+    expect(target).toBeDefined();
+    if (!target) return;
+
+    const incompleteEvidence: HomeGardenEvidenceRecord[] = [
+      verified("laboratory-report"),
+      verified("cost-model", { completeForGate: false }),
+      verified("approved-label"),
+    ];
+
+    const evaluated = buildHomeGardenSkuLaunchMatrix({ [target.id]: incompleteEvidence })
+      .find((candidate) => candidate.id === target.id);
+
+    expect(evaluated?.gates.regulatory).toBe(false);
+    expect(evaluated?.gates["all-in-cost"]).toBe(false);
+    expect(evaluated?.commerceReady).toBe(false);
+  });
+
+  it("rejects evidence that belongs to a different presentation", () => {
+    const target = homeGardenPlannedSkuCandidates.find((candidate) => candidate.id === "florece-2-kg");
+    expect(target).toBeDefined();
+    if (!target) return;
+
+    const mismatched: HomeGardenEvidenceRecord[] = [
+      verified("sku-master", { samePresentation: false }),
+      verified("regulatory-registration", { samePresentation: false }),
+      verified("approved-label", { samePresentation: false }),
+      verified("dose-validation", { samePresentation: false }),
+      verified("cost-model", { samePresentation: false }),
+      verified("fulfillment-record", { samePresentation: false }),
+      verified("public-asset", { samePresentation: false }),
+    ];
+
+    const evaluated = buildHomeGardenSkuLaunchMatrix({ [target.id]: mismatched })
+      .find((candidate) => candidate.id === target.id);
+
+    expect(evaluated?.commerceReady).toBe(false);
+    expect(evaluated?.gates["household-skus"]).toBe(false);
+    expect(evaluated?.gates.regulatory).toBe(false);
+  });
+});

--- a/src/data/home-garden-sku-launch-matrix.ts
+++ b/src/data/home-garden-sku-launch-matrix.ts
@@ -1,0 +1,99 @@
+import {
+  canHomeGardenEvidenceSetCloseGate,
+  type HomeGardenEvidenceGateId,
+  type HomeGardenEvidenceRecord,
+} from "./home-garden-evidence";
+import { homeGardenProducts, type HomeGardenStage } from "./home-garden";
+
+export const homeGardenCommerceEvidenceGates = [
+  "household-skus",
+  "regulatory",
+  "dose-and-dosifier",
+  "all-in-cost",
+  "fulfillment",
+  "public-assets",
+] as const satisfies readonly HomeGardenEvidenceGateId[];
+
+export type HomeGardenSkuCandidate = {
+  id: string;
+  productId: HomeGardenStage;
+  consumerName: string;
+  technicalName: string;
+  technicalSlug: string;
+  formula?: string;
+  plannedVariant: string;
+  sourceStatus: "planned-b2c";
+  productTruthReady: boolean;
+};
+
+export type HomeGardenSkuEvidenceMap = Readonly<
+  Record<string, readonly HomeGardenEvidenceRecord[]>
+>;
+
+export type HomeGardenSkuLaunchEvaluation = HomeGardenSkuCandidate & {
+  gates: Record<HomeGardenEvidenceGateId, boolean>;
+  commerceReady: boolean;
+};
+
+function toSkuFragment(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export const homeGardenPlannedSkuCandidates: readonly HomeGardenSkuCandidate[] = homeGardenProducts.flatMap((product) =>
+  product.plannedHouseholdVariants.map((plannedVariant) => ({
+    id: `${product.id}-${toSkuFragment(plannedVariant)}`,
+    productId: product.id,
+    consumerName: product.consumerName,
+    technicalName: product.technicalName,
+    technicalSlug: product.technicalSlug,
+    formula: product.formula,
+    plannedVariant,
+    sourceStatus: "planned-b2c" as const,
+    productTruthReady: product.availability === "technical-truth",
+  })),
+);
+
+export function evaluateHomeGardenSkuCandidate(
+  candidate: HomeGardenSkuCandidate,
+  evidence: readonly HomeGardenEvidenceRecord[] = [],
+): HomeGardenSkuLaunchEvaluation {
+  const productTruthEvidence: HomeGardenEvidenceRecord = {
+    kind: "product-truth",
+    verified: candidate.productTruthReady,
+    sameReference: true,
+    samePresentation: true,
+    completeForGate: candidate.productTruthReady,
+  };
+
+  const gates = {
+    "technical-product-truth": canHomeGardenEvidenceSetCloseGate(
+      "technical-product-truth",
+      [productTruthEvidence],
+    ),
+    "household-skus": canHomeGardenEvidenceSetCloseGate("household-skus", evidence),
+    regulatory: canHomeGardenEvidenceSetCloseGate("regulatory", evidence),
+    "dose-and-dosifier": canHomeGardenEvidenceSetCloseGate("dose-and-dosifier", evidence),
+    "all-in-cost": canHomeGardenEvidenceSetCloseGate("all-in-cost", evidence),
+    fulfillment: canHomeGardenEvidenceSetCloseGate("fulfillment", evidence),
+    "public-assets": canHomeGardenEvidenceSetCloseGate("public-assets", evidence),
+  } satisfies Record<HomeGardenEvidenceGateId, boolean>;
+
+  const commerceReady = gates["technical-product-truth"]
+    && homeGardenCommerceEvidenceGates.every((gate) => gates[gate]);
+
+  return { ...candidate, gates, commerceReady };
+}
+
+export function buildHomeGardenSkuLaunchMatrix(
+  evidenceByCandidate: HomeGardenSkuEvidenceMap = {},
+): readonly HomeGardenSkuLaunchEvaluation[] {
+  return homeGardenPlannedSkuCandidates.map((candidate) =>
+    evaluateHomeGardenSkuCandidate(candidate, evidenceByCandidate[candidate.id] ?? []),
+  );
+}
+
+export const homeGardenSkuLaunchMatrix = buildHomeGardenSkuLaunchMatrix();


### PR DESCRIPTION
## Objetivo
Derivar una matriz única de lanzamiento para todas las presentaciones B2C propuestas de Casa, Jardín y Vivero, sin duplicar manualmente el catálogo ni convertir propuestas de formato en SKUs vendibles.

## Cambios
- deriva automáticamente candidatos SKU desde `homeGardenProducts.plannedHouseholdVariants`;
- genera 18 candidatas actuales: 2 de compost + 4 formatos para cada una de las 4 referencias sólidas por etapa;
- vincula cada candidata con Product Truth técnico y su `technicalSlug`;
- evalúa por presentación los gates: SKU Master, regulatorio, dosis/dosificador, costo all-in, fulfillment y activos;
- mantiene todas las presentaciones fail-closed por defecto;
- solo marca `commerceReady` cuando todos los gates de la misma presentación están cerrados;
- rechaza reportes de laboratorio, costos parciales y evidencia de otra presentación como atajos;
- añade unit tests para cardinalidad, unicidad, fail-closed y cierre completo por presentación.

## Guardrails
- no crea SKUs comerciales reales;
- no publica stock, PVP, margen, descuento ni dosis;
- no incorpora fuentes privadas;
- no modifica Product Truth, kits ni UI pública;
- no toca OPS, Auth, Supabase, RLS ni migraciones;
- no toca `main`.

## Base
Parte de `develop` en `0d95ea5c1dea50c15d6b245e76334fce8fac9937` y está 2 commits adelante / 0 detrás.

## Gate
Merge únicamente con CI final verde sobre la cabeza exacta de la PR.