### PR TITLE
fix(home-garden): endurecer fronteras de evidencia B2C

### DIFF
--- a/src/components/home-garden-readiness-admin-view.tsx
+++ b/src/components/home-garden-readiness-admin-view.tsx
@@ -2,13 +2,16 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useOpsStore } from "@/components/ops-store";
-import { homeGardenEvidenceRules, type HomeGardenEvidenceKind } from "@/data/home-garden-evidence";
+import { homeGardenEvidenceRules } from "@/data/home-garden-evidence";
 import { homeGardenPlannedSkuCandidates } from "@/data/home-garden-sku-launch-matrix";
 import {
   buildHomeGardenReadinessRegistry,
+  canAppendHomeGardenEvidence,
   canManageHomeGardenReadiness,
   homeGardenGateLabels,
+  homeGardenLaunchEvidenceKinds,
   type HomeGardenEvidenceDisposition,
+  type HomeGardenLaunchEvidenceKind,
   type HomeGardenLaunchEvidenceRevision,
 } from "@/lib/home-garden-readiness-registry";
 import {
@@ -33,6 +36,10 @@ function GatePill({ closed, label }: { closed: boolean; label: string }) {
 export function HomeGardenReadinessAdminView() {
   const { backend, access } = useOpsStore();
   const authorized = useMemo(() => access.some((item) => canManageHomeGardenReadiness(item.role)), [access]);
+  const allowedEvidenceKinds = useMemo(
+    () => homeGardenLaunchEvidenceKinds.filter((kind) => access.some((item) => canAppendHomeGardenEvidence(item.role, kind))),
+    [access],
+  );
   const [revisions, setRevisions] = useState<HomeGardenLaunchEvidenceRevision[]>([]);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -40,7 +47,7 @@ export function HomeGardenReadinessAdminView() {
   const [filter, setFilter] = useState<RegistryFilter>("all");
 
   const [candidateId, setCandidateId] = useState(homeGardenPlannedSkuCandidates[0]?.id ?? "");
-  const [evidenceKind, setEvidenceKind] = useState<HomeGardenEvidenceKind>("sku-master");
+  const [evidenceKind, setEvidenceKind] = useState<HomeGardenLaunchEvidenceKind>("laboratory-report");
   const [disposition, setDisposition] = useState<HomeGardenEvidenceDisposition>("draft");
   const [title, setTitle] = useState("");
   const [sourceReference, setSourceReference] = useState("");
@@ -71,6 +78,12 @@ export function HomeGardenReadinessAdminView() {
     return () => window.clearTimeout(timer);
   }, [load]);
 
+  useEffect(() => {
+    if (allowedEvidenceKinds.includes(evidenceKind)) return;
+    const firstAllowed = allowedEvidenceKinds[0];
+    if (firstAllowed) setEvidenceKind(firstAllowed);
+  }, [allowedEvidenceKinds, evidenceKind]);
+
   const registry = useMemo(() => buildHomeGardenReadinessRegistry(revisions), [revisions]);
   const visibleItems = useMemo(() => registry.items.filter((item) => {
     if (filter === "ready") return item.commerceReady;
@@ -80,6 +93,14 @@ export function HomeGardenReadinessAdminView() {
   const selectedRule = homeGardenEvidenceRules.find((rule) => rule.kind === evidenceKind);
 
   async function saveEvidence() {
+    if (!access.some((item) => canAppendHomeGardenEvidence(item.role, evidenceKind))) {
+      setFeedback({ kind: "error", text: "Tu rol no puede registrar este tipo de evidencia." });
+      return;
+    }
+    if (disposition !== "verified" && completeForGate) {
+      setFeedback({ kind: "error", text: "Solo una revisión verificada puede declararse completa para un gate." });
+      return;
+    }
     if (!candidateId || !title.trim() || !sourceReference.trim() || !note.trim()) {
       setFeedback({ kind: "error", text: "Completa presentación, título, referencia fuente y criterio de evaluación." });
       return;
@@ -122,7 +143,7 @@ export function HomeGardenReadinessAdminView() {
       <div>
         <p className="eyebrow">Wondergreen · Casa, Jardín y Vivero</p>
         <h1>Readiness de lanzamiento B2C</h1>
-        <p className="lede">Registro interno por presentación. La evidencia se conserva como revisiones append-only y nunca se publica directamente en la web.</p>
+        <p className="lede">Registro interno por presentación. Product Truth permanece canónico en código; aquí solo se registra evidencia secundaria de lanzamiento mediante revisiones append-only.</p>
       </div>
       <div className="header-actions">
         <select aria-label="Filtro readiness" className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={filter} onChange={(event) => setFilter(event.target.value as RegistryFilter)}>
@@ -144,11 +165,11 @@ export function HomeGardenReadinessAdminView() {
     {registry.orphanEvidence.length ? <section className="panel border border-[var(--red)]"><p className="eyebrow">Deriva detectada</p><h2>Evidencia sin candidato vigente</h2><p className="quiet mt-1">No se aplica silenciosamente a otra presentación. Debe reconciliarse.</p><ul className="mt-3 grid gap-2 text-sm">{registry.orphanEvidence.map((item) => <li key={item.id}><strong>{item.candidateId}</strong> · {item.evidenceKind} · rev. {item.revisionNo}</li>)}</ul></section> : null}
 
     <section className="panel">
-      <div className="section-head"><div><p className="eyebrow">Nueva revisión</p><h2>Anexar evidencia gobernada</h2><p className="quiet mt-1">Guarda una referencia interna al documento; no pegues enlaces firmados, tokens ni credenciales.</p></div></div>
+      <div className="section-head"><div><p className="eyebrow">Nueva revisión</p><h2>Anexar evidencia gobernada</h2><p className="quiet mt-1">Guarda una referencia interna al documento; no pegues enlaces firmados, tokens ni credenciales. Los tipos disponibles dependen de tu rol.</p></div></div>
       <div className="grid gap-3 lg:grid-cols-3">
         <label className="grid gap-1 text-xs font-semibold">Presentación<select className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={candidateId} onChange={(event) => setCandidateId(event.target.value)}>{homeGardenPlannedSkuCandidates.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.consumerName} · {candidate.plannedVariant} · {candidate.id}</option>)}</select></label>
-        <label className="grid gap-1 text-xs font-semibold">Tipo de evidencia<select className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={evidenceKind} onChange={(event) => setEvidenceKind(event.target.value as HomeGardenEvidenceKind)}>{homeGardenEvidenceRules.map((rule) => <option key={rule.kind} value={rule.kind}>{rule.label}</option>)}</select></label>
-        <label className="grid gap-1 text-xs font-semibold">Estado<select className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={disposition} onChange={(event) => setDisposition(event.target.value as HomeGardenEvidenceDisposition)}>{Object.entries(dispositionLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}</select></label>
+        <label className="grid gap-1 text-xs font-semibold">Tipo de evidencia<select className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={evidenceKind} onChange={(event) => setEvidenceKind(event.target.value as HomeGardenLaunchEvidenceKind)}>{allowedEvidenceKinds.map((kind) => { const rule = homeGardenEvidenceRules.find((item) => item.kind === kind); return <option key={kind} value={kind}>{rule?.label ?? kind}</option>; })}</select></label>
+        <label className="grid gap-1 text-xs font-semibold">Estado<select className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={disposition} onChange={(event) => { const next = event.target.value as HomeGardenEvidenceDisposition; setDisposition(next); if (next !== "verified") setCompleteForGate(false); }}>{Object.entries(dispositionLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}</select></label>
         <label className="grid gap-1 text-xs font-semibold lg:col-span-2">Título<input className="min-h-10 rounded-lg border border-[var(--line)] px-3 text-sm" value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Ej. Registro/etiqueta CRECE 500 g · revisión agosto" /></label>
         <label className="grid gap-1 text-xs font-semibold">Fecha fuente<input type="date" className="min-h-10 rounded-lg border border-[var(--line)] px-3 text-sm" value={sourceDate} onChange={(event) => setSourceDate(event.target.value)} /></label>
         <label className="grid gap-1 text-xs font-semibold lg:col-span-3">Referencia fuente<input className="min-h-10 rounded-lg border border-[var(--line)] px-3 text-sm" value={sourceReference} onChange={(event) => setSourceReference(event.target.value)} placeholder="Nombre de archivo, ruta interna o URL privada estable sin tokens" /></label>
@@ -158,9 +179,9 @@ export function HomeGardenReadinessAdminView() {
       <div className="mt-4 flex flex-wrap gap-4 text-xs">
         <label className="flex items-center gap-2"><input type="checkbox" checked={sameReference} onChange={(event) => setSameReference(event.target.checked)} />Misma referencia técnica</label>
         <label className="flex items-center gap-2"><input type="checkbox" checked={samePresentation} onChange={(event) => setSamePresentation(event.target.checked)} />Misma presentación</label>
-        <label className="flex items-center gap-2"><input type="checkbox" checked={completeForGate} onChange={(event) => setCompleteForGate(event.target.checked)} />Completa para el gate evaluado</label>
+        <label className="flex items-center gap-2"><input type="checkbox" checked={completeForGate} disabled={disposition !== "verified"} onChange={(event) => setCompleteForGate(event.target.checked)} />Completa para el gate evaluado {disposition !== "verified" ? "(requiere estado Verificada)" : ""}</label>
       </div>
-      <button className="button primary mt-4" type="button" disabled={saving} onClick={() => void saveEvidence()}>{saving ? "Registrando…" : "Registrar nueva revisión"}</button>
+      <button className="button primary mt-4" type="button" disabled={saving || !allowedEvidenceKinds.length} onClick={() => void saveEvidence()}>{saving ? "Registrando…" : "Registrar nueva revisión"}</button>
     </section>
 
     <section className="grid gap-3">

--- a/src/components/home-garden-readiness-admin-view.tsx
+++ b/src/components/home-garden-readiness-admin-view.tsx
@@ -57,6 +57,10 @@ export function HomeGardenReadinessAdminView() {
   const [completeForGate, setCompleteForGate] = useState(false);
   const [note, setNote] = useState("");
 
+  const effectiveEvidenceKind = allowedEvidenceKinds.includes(evidenceKind)
+    ? evidenceKind
+    : allowedEvidenceKinds[0] ?? "laboratory-report";
+
   const load = useCallback(async () => {
     if (backend.mode !== "supabase" || !authorized) {
       setRevisions([]);
@@ -78,22 +82,16 @@ export function HomeGardenReadinessAdminView() {
     return () => window.clearTimeout(timer);
   }, [load]);
 
-  useEffect(() => {
-    if (allowedEvidenceKinds.includes(evidenceKind)) return;
-    const firstAllowed = allowedEvidenceKinds[0];
-    if (firstAllowed) setEvidenceKind(firstAllowed);
-  }, [allowedEvidenceKinds, evidenceKind]);
-
   const registry = useMemo(() => buildHomeGardenReadinessRegistry(revisions), [revisions]);
   const visibleItems = useMemo(() => registry.items.filter((item) => {
     if (filter === "ready") return item.commerceReady;
     if (filter === "pending") return !item.commerceReady;
     return true;
   }), [filter, registry.items]);
-  const selectedRule = homeGardenEvidenceRules.find((rule) => rule.kind === evidenceKind);
+  const selectedRule = homeGardenEvidenceRules.find((rule) => rule.kind === effectiveEvidenceKind);
 
   async function saveEvidence() {
-    if (!access.some((item) => canAppendHomeGardenEvidence(item.role, evidenceKind))) {
+    if (!access.some((item) => canAppendHomeGardenEvidence(item.role, effectiveEvidenceKind))) {
       setFeedback({ kind: "error", text: "Tu rol no puede registrar este tipo de evidencia." });
       return;
     }
@@ -109,7 +107,7 @@ export function HomeGardenReadinessAdminView() {
     try {
       await appendHomeGardenLaunchEvidence({
         candidateId,
-        evidenceKind,
+        evidenceKind: effectiveEvidenceKind,
         disposition,
         title: title.trim(),
         sourceReference: sourceReference.trim(),
@@ -168,7 +166,7 @@ export function HomeGardenReadinessAdminView() {
       <div className="section-head"><div><p className="eyebrow">Nueva revisión</p><h2>Anexar evidencia gobernada</h2><p className="quiet mt-1">Guarda una referencia interna al documento; no pegues enlaces firmados, tokens ni credenciales. Los tipos disponibles dependen de tu rol.</p></div></div>
       <div className="grid gap-3 lg:grid-cols-3">
         <label className="grid gap-1 text-xs font-semibold">Presentación<select className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={candidateId} onChange={(event) => setCandidateId(event.target.value)}>{homeGardenPlannedSkuCandidates.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.consumerName} · {candidate.plannedVariant} · {candidate.id}</option>)}</select></label>
-        <label className="grid gap-1 text-xs font-semibold">Tipo de evidencia<select className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={evidenceKind} onChange={(event) => setEvidenceKind(event.target.value as HomeGardenLaunchEvidenceKind)}>{allowedEvidenceKinds.map((kind) => { const rule = homeGardenEvidenceRules.find((item) => item.kind === kind); return <option key={kind} value={kind}>{rule?.label ?? kind}</option>; })}</select></label>
+        <label className="grid gap-1 text-xs font-semibold">Tipo de evidencia<select className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={effectiveEvidenceKind} onChange={(event) => setEvidenceKind(event.target.value as HomeGardenLaunchEvidenceKind)}>{allowedEvidenceKinds.map((kind) => { const rule = homeGardenEvidenceRules.find((item) => item.kind === kind); return <option key={kind} value={kind}>{rule?.label ?? kind}</option>; })}</select></label>
         <label className="grid gap-1 text-xs font-semibold">Estado<select className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={disposition} onChange={(event) => { const next = event.target.value as HomeGardenEvidenceDisposition; setDisposition(next); if (next !== "verified") setCompleteForGate(false); }}>{Object.entries(dispositionLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}</select></label>
         <label className="grid gap-1 text-xs font-semibold lg:col-span-2">Título<input className="min-h-10 rounded-lg border border-[var(--line)] px-3 text-sm" value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Ej. Registro/etiqueta CRECE 500 g · revisión agosto" /></label>
         <label className="grid gap-1 text-xs font-semibold">Fecha fuente<input type="date" className="min-h-10 rounded-lg border border-[var(--line)] px-3 text-sm" value={sourceDate} onChange={(event) => setSourceDate(event.target.value)} /></label>

--- a/src/lib/home-garden-readiness-registry.test.ts
+++ b/src/lib/home-garden-readiness-registry.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { HomeGardenLaunchEvidenceRevision } from "./home-garden-readiness-registry";
 import {
   buildHomeGardenReadinessRegistry,
+  canAppendHomeGardenEvidence,
   canManageHomeGardenReadiness,
+  homeGardenLaunchEvidenceKinds,
   selectLatestHomeGardenEvidence,
 } from "./home-garden-readiness-registry";
 
@@ -27,12 +29,31 @@ const revision = (
 });
 
 describe("home garden readiness registry", () => {
-  it("allows only technical, admin and director roles to manage company launch evidence", () => {
+  it("allows only technical, admin and director roles to view company launch readiness", () => {
     expect(canManageHomeGardenReadiness("technical")).toBe(true);
     expect(canManageHomeGardenReadiness("admin")).toBe(true);
     expect(canManageHomeGardenReadiness("director")).toBe(true);
     expect(canManageHomeGardenReadiness("supervisor")).toBe(false);
     expect(canManageHomeGardenReadiness("operator")).toBe(false);
+  });
+
+  it("keeps Product Truth outside the operational evidence ledger", () => {
+    expect(homeGardenLaunchEvidenceKinds).not.toContain("product-truth");
+    expect(homeGardenLaunchEvidenceKinds).toHaveLength(8);
+  });
+
+  it("separates technical evidence authorship from commercial and financial evidence", () => {
+    expect(canAppendHomeGardenEvidence("technical", "laboratory-report")).toBe(true);
+    expect(canAppendHomeGardenEvidence("technical", "regulatory-registration")).toBe(true);
+    expect(canAppendHomeGardenEvidence("technical", "approved-label")).toBe(true);
+    expect(canAppendHomeGardenEvidence("technical", "dose-validation")).toBe(true);
+    expect(canAppendHomeGardenEvidence("technical", "sku-master")).toBe(false);
+    expect(canAppendHomeGardenEvidence("technical", "cost-model")).toBe(false);
+    expect(canAppendHomeGardenEvidence("technical", "fulfillment-record")).toBe(false);
+    expect(canAppendHomeGardenEvidence("technical", "public-asset")).toBe(false);
+    expect(canAppendHomeGardenEvidence("admin", "cost-model")).toBe(true);
+    expect(canAppendHomeGardenEvidence("director", "public-asset")).toBe(true);
+    expect(canAppendHomeGardenEvidence("supervisor", "approved-label")).toBe(false);
   });
 
   it("uses only the latest revision per candidate and evidence kind", () => {

--- a/src/lib/home-garden-readiness-registry.ts
+++ b/src/lib/home-garden-readiness-registry.ts
@@ -10,12 +10,31 @@ import {
 } from "@/data/home-garden-sku-launch-matrix";
 
 export type HomeGardenEvidenceDisposition = "draft" | "verified" | "rejected" | "superseded";
+export type HomeGardenLaunchEvidenceKind = Exclude<HomeGardenEvidenceKind, "product-truth">;
+
+export const homeGardenLaunchEvidenceKinds = [
+  "laboratory-report",
+  "regulatory-registration",
+  "approved-label",
+  "sku-master",
+  "dose-validation",
+  "cost-model",
+  "fulfillment-record",
+  "public-asset",
+] as const satisfies readonly HomeGardenLaunchEvidenceKind[];
+
+const technicalEvidenceKinds = new Set<HomeGardenLaunchEvidenceKind>([
+  "laboratory-report",
+  "regulatory-registration",
+  "approved-label",
+  "dose-validation",
+]);
 
 export type HomeGardenLaunchEvidenceRevision = {
   id: string;
   revisionNo: number;
   candidateId: string;
-  evidenceKind: HomeGardenEvidenceKind;
+  evidenceKind: HomeGardenLaunchEvidenceKind;
   disposition: HomeGardenEvidenceDisposition;
   title: string;
   sourceReference: string;
@@ -57,6 +76,11 @@ export const homeGardenGateLabels: Record<HomeGardenEvidenceGateId, string> = {
 
 export function canManageHomeGardenReadiness(role: string) {
   return role === "technical" || role === "admin" || role === "director";
+}
+
+export function canAppendHomeGardenEvidence(role: string, kind: HomeGardenLaunchEvidenceKind) {
+  if (role === "admin" || role === "director") return true;
+  return role === "technical" && technicalEvidenceKinds.has(kind);
 }
 
 function latestRevisionKey(revision: HomeGardenLaunchEvidenceRevision) {

--- a/src/lib/supabase/home-garden-readiness-repository.ts
+++ b/src/lib/supabase/home-garden-readiness-repository.ts
@@ -1,22 +1,13 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { HomeGardenEvidenceKind } from "@/data/home-garden-evidence";
 import type {
   HomeGardenEvidenceDisposition,
+  HomeGardenLaunchEvidenceKind,
   HomeGardenLaunchEvidenceRevision,
 } from "@/lib/home-garden-readiness-registry";
+import { homeGardenLaunchEvidenceKinds } from "@/lib/home-garden-readiness-registry";
 import { createClient } from "@/lib/supabase/client";
 
-const evidenceKinds = new Set<HomeGardenEvidenceKind>([
-  "product-truth",
-  "laboratory-report",
-  "regulatory-registration",
-  "approved-label",
-  "sku-master",
-  "dose-validation",
-  "cost-model",
-  "fulfillment-record",
-  "public-asset",
-]);
+const evidenceKinds = new Set<HomeGardenLaunchEvidenceKind>(homeGardenLaunchEvidenceKinds);
 const dispositions = new Set<HomeGardenEvidenceDisposition>(["draft", "verified", "rejected", "superseded"]);
 
 type EvidenceRow = {
@@ -39,7 +30,7 @@ type EvidenceRow = {
 
 export type AppendHomeGardenEvidencePayload = {
   candidateId: string;
-  evidenceKind: HomeGardenEvidenceKind;
+  evidenceKind: HomeGardenLaunchEvidenceKind;
   disposition: HomeGardenEvidenceDisposition;
   title: string;
   sourceReference: string;
@@ -57,13 +48,13 @@ function errorMessage(scope: string, error: { message?: string } | null) {
 function parseEvidenceRow(row: EvidenceRow): HomeGardenLaunchEvidenceRevision {
   const revisionNo = Number(row.revision_no);
   if (!Number.isSafeInteger(revisionNo) || revisionNo <= 0) throw new Error(`Revisión inválida para ${row.id}.`);
-  if (!evidenceKinds.has(row.evidence_kind as HomeGardenEvidenceKind)) throw new Error(`Tipo de evidencia desconocido: ${row.evidence_kind}.`);
+  if (!evidenceKinds.has(row.evidence_kind as HomeGardenLaunchEvidenceKind)) throw new Error(`Tipo de evidencia operativa desconocido: ${row.evidence_kind}.`);
   if (!dispositions.has(row.disposition as HomeGardenEvidenceDisposition)) throw new Error(`Estado de evidencia desconocido: ${row.disposition}.`);
   return {
     id: row.id,
     revisionNo,
     candidateId: row.candidate_id,
-    evidenceKind: row.evidence_kind as HomeGardenEvidenceKind,
+    evidenceKind: row.evidence_kind as HomeGardenLaunchEvidenceKind,
     disposition: row.disposition as HomeGardenEvidenceDisposition,
     title: row.title,
     sourceReference: row.source_reference,

--- a/supabase/migrations/0052_home_garden_launch_evidence_hardening.sql
+++ b/supabase/migrations/0052_home_garden_launch_evidence_hardening.sql
@@ -1,0 +1,130 @@
+-- B2C-READINESS-002 · harden evidence boundaries without rewriting the append-only ledger.
+-- Product Truth remains canonical in code and cannot be authored through the operational registry.
+
+-- Fail closed if a hosted environment already contains evidence that should never have lived in this ledger.
+do $$
+begin
+  if exists (
+    select 1
+    from public.home_garden_launch_evidence_revisions
+    where evidence_kind='product-truth'
+  ) then
+    raise exception 'Existen revisiones product-truth en el ledger B2C; reconcílialas antes de aplicar el hardening.';
+  end if;
+end;
+$$;
+
+alter table public.home_garden_launch_evidence_revisions
+  drop constraint if exists home_garden_launch_evidence_revisions_evidence_kind_check;
+
+alter table public.home_garden_launch_evidence_revisions
+  add constraint home_garden_launch_evidence_revisions_evidence_kind_check
+  check (evidence_kind in (
+    'laboratory-report',
+    'regulatory-registration',
+    'approved-label',
+    'sku-master',
+    'dose-validation',
+    'cost-model',
+    'fulfillment-record',
+    'public-asset'
+  ));
+
+alter table public.home_garden_launch_evidence_revisions
+  add constraint home_garden_launch_evidence_revisions_complete_verified_check
+  check (not complete_for_gate or disposition='verified');
+
+create or replace function public.admin_append_home_garden_launch_evidence(
+  target_candidate_id text,
+  target_evidence_kind text,
+  target_disposition text,
+  evidence_title text,
+  evidence_source_reference text,
+  evidence_source_date date,
+  evidence_same_reference boolean,
+  evidence_same_presentation boolean,
+  evidence_complete_for_gate boolean,
+  evidence_note text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  revision_id uuid;
+  clean_candidate text := lower(btrim(target_candidate_id));
+  clean_title text := nullif(btrim(evidence_title),'');
+  clean_source text := nullif(btrim(evidence_source_reference),'');
+  clean_note text := nullif(btrim(evidence_note),'');
+  technical_kind boolean;
+begin
+  if (select auth.uid()) is null then
+    raise exception 'Sesión requerida.';
+  end if;
+
+  if target_evidence_kind='product-truth' then
+    raise exception 'Product Truth se gobierna en código y no se administra desde este registro.';
+  end if;
+  if target_evidence_kind is null or target_evidence_kind not in (
+    'laboratory-report','regulatory-registration','approved-label','sku-master',
+    'dose-validation','cost-model','fulfillment-record','public-asset'
+  ) then
+    raise exception 'Tipo de evidencia inválido.';
+  end if;
+
+  technical_kind := target_evidence_kind in (
+    'laboratory-report','regulatory-registration','approved-label','dose-validation'
+  );
+  if technical_kind then
+    if not private.has_company_role(array['technical','admin','director']) then
+      raise exception 'No tienes permiso para administrar evidencia técnica de lanzamiento.';
+    end if;
+  elsif not private.has_company_role(array['admin','director']) then
+    raise exception 'Este tipo de evidencia requiere rol admin o director.';
+  end if;
+
+  if clean_candidate is null or clean_candidate !~ '^[a-z0-9]+(?:-[a-z0-9]+)*$' or length(clean_candidate)>120 then
+    raise exception 'Candidate ID inválido.';
+  end if;
+  if target_disposition is null or target_disposition not in ('draft','verified','rejected','superseded') then
+    raise exception 'Estado de evidencia inválido.';
+  end if;
+  if coalesce(evidence_complete_for_gate,false) and target_disposition<>'verified' then
+    raise exception 'Solo evidencia verificada puede declararse completa para un gate.';
+  end if;
+  if clean_title is null then raise exception 'Título de evidencia requerido.'; end if;
+  if length(clean_title)>220 then raise exception 'Título de evidencia demasiado largo.'; end if;
+  if clean_source is null then raise exception 'Referencia fuente requerida.'; end if;
+  if length(clean_source)>1500 then raise exception 'Referencia fuente demasiado larga.'; end if;
+  if clean_source ~* '([?&](access_token|token|sig|signature|key|code)=)' then
+    raise exception 'No guardes enlaces firmados, tokens ni credenciales en la referencia fuente.';
+  end if;
+  if evidence_source_date is not null and evidence_source_date>current_date then
+    raise exception 'La fecha de la evidencia no puede estar en el futuro.';
+  end if;
+  if clean_note is null then raise exception 'Registra el criterio de evaluación de la evidencia.'; end if;
+  if length(clean_note)>2000 then raise exception 'La nota de evidencia es demasiado larga.'; end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(
+    'greenatics-home-garden-evidence:' || clean_candidate || ':' || target_evidence_kind,
+    0
+  ));
+
+  insert into public.home_garden_launch_evidence_revisions(
+    candidate_id,evidence_kind,disposition,title,source_reference,source_date,
+    same_reference,same_presentation,complete_for_gate,note,created_by
+  ) values (
+    clean_candidate,target_evidence_kind,target_disposition,clean_title,clean_source,evidence_source_date,
+    coalesce(evidence_same_reference,false),coalesce(evidence_same_presentation,false),coalesce(evidence_complete_for_gate,false),clean_note,auth.uid()
+  ) returning id into revision_id;
+
+  return revision_id;
+end;
+$$;
+
+revoke all on function public.admin_append_home_garden_launch_evidence(text,text,text,text,text,date,boolean,boolean,boolean,text) from public,anon;
+grant execute on function public.admin_append_home_garden_launch_evidence(text,text,text,text,text,date,boolean,boolean,boolean,text) to authenticated;
+
+comment on function public.admin_append_home_garden_launch_evidence(text,text,text,text,text,date,boolean,boolean,boolean,text) is
+'Appends governed B2C launch evidence. Product Truth is excluded; technical evidence may be authored by technical/admin/director, while SKU, cost, fulfillment and public-asset evidence require admin/director. Only verified evidence may be complete_for_gate.';

--- a/supabase/tests/database/home_garden_launch_evidence.test.sql
+++ b/supabase/tests/database/home_garden_launch_evidence.test.sql
@@ -1,6 +1,6 @@
 begin;
 create extension if not exists pgtap with schema extensions;
-select plan(23);
+select plan(26);
 
 select has_table('public','home_garden_launch_evidence_revisions','home garden evidence revision ledger exists');
 select ok(has_table_privilege('authenticated','public.home_garden_launch_evidence_revisions','SELECT'),'authenticated keeps governed read privilege through RLS');
@@ -30,7 +30,7 @@ set local request.jwt.claim.sub='e1000000-0000-4000-8000-000000000001';
 
 select lives_ok($$select public.admin_append_home_garden_launch_evidence(
  'crece-500-g','approved-label','verified','Etiqueta CRECE 500 g','SharePoint/Wondergreen/Etiquetas/CRECE_500G.pdf','2026-08-20',true,true,true,'Arte y presentación conciliados para revisión QA.'
-)$$,'technical can append a governed evidence revision');
+)$$,'technical can append governed technical evidence');
 select is((select count(*) from public.home_garden_launch_evidence_revisions),1::bigint,'first evidence revision is stored once');
 select is((select evidence_kind from public.home_garden_launch_evidence_revisions limit 1),'approved-label','evidence kind is preserved');
 select is((select disposition from public.home_garden_launch_evidence_revisions limit 1),'verified','evidence disposition is preserved');
@@ -52,17 +52,26 @@ select throws_ok($$select public.admin_append_home_garden_launch_evidence(
 select throws_ok($$select public.admin_append_home_garden_launch_evidence(
  'crece-500-g','price-sheet','draft','Invalid kind','SharePoint/Invalid.pdf',null,true,true,false,'Tipo inválido.'
 )$$,'Tipo de evidencia inválido.','unknown evidence kinds cannot enter the governed ledger');
+select throws_ok($$select public.admin_append_home_garden_launch_evidence(
+ 'crece-500-g','product-truth','verified','Attempted Product Truth override','Internal/ProductTruth.txt',null,true,true,true,'No debe poder sustituir Product Truth canónico.'
+)$$,'Product Truth se gobierna en código y no se administra desde este registro.','Product Truth cannot be authored from the operational ledger');
+select throws_ok($$select public.admin_append_home_garden_launch_evidence(
+ 'crece-500-g','approved-label','draft','Incomplete review','Internal/DraftLabel.pdf',null,true,true,true,'Un borrador no puede cerrar el gate.'
+)$$,'Solo evidencia verificada puede declararse completa para un gate.','draft evidence cannot masquerade as gate-complete');
+select throws_ok($$select public.admin_append_home_garden_launch_evidence(
+ 'crece-500-g','cost-model','verified','Technical cost attempt','Finanzas/Costos.xlsx',null,true,true,true,'Technical no debe autorizar costo comercial.'
+)$$,'Este tipo de evidencia requiere rol admin o director.','technical role cannot author commercial or financial evidence');
 
 set local request.jwt.claim.sub='e1000000-0000-4000-8000-000000000002';
 select throws_ok($$select public.admin_append_home_garden_launch_evidence(
  'crece-500-g','laboratory-report','verified','Supervisor attempt','SharePoint/Lab.pdf','2026-08-20',true,true,true,'Supervisor no autorizado.'
-)$$,'No tienes permiso para administrar evidencia de lanzamiento.','supervisor cannot append company launch evidence');
+)$$,'No tienes permiso para administrar evidencia técnica de lanzamiento.','supervisor cannot append company launch evidence');
 select is((select count(*) from public.home_garden_launch_evidence_revisions),0::bigint,'RLS hides company launch evidence from supervisor-only users');
 
 set local request.jwt.claim.sub='e1000000-0000-4000-8000-000000000003';
 select lives_ok($$select public.admin_append_home_garden_launch_evidence(
  'equilibra-1-kg','cost-model','draft','Costo B2C en construcción','Finanzas/Modelo B2C interno.xlsx','2026-08-20',true,true,false,'El modelo todavía no cubre el checklist all-in completo.'
-)$$,'admin can append company launch evidence from another plant membership');
+)$$,'admin can append commercial or financial launch evidence from another plant membership');
 select is((select count(*) from public.home_garden_launch_evidence_revisions),3::bigint,'authorized company role sees the complete governed evidence history');
 select is((select max(revision_no)>min(revision_no) from public.home_garden_launch_evidence_revisions),true,'global revision sequence preserves deterministic history ordering');
 


### PR DESCRIPTION
## Objetivo
Endurecer el registro interno de readiness B2C integrado en #200 para que Product Truth no pueda ser autorado desde el ledger y para separar correctamente permisos técnicos vs. comerciales/financieros.

## Cambios
- añade migración incremental `0052_home_garden_launch_evidence_hardening.sql` sin reescribir `0051`;
- falla de forma fail-closed si una instalación ya contiene revisiones `product-truth` en el ledger;
- elimina `product-truth` de los tipos registrables en DB, TypeScript, repositorio y UI;
- solo evidencia con estado `verified` puede marcar `complete_for_gate=true`;
- `technical` puede registrar laboratorio, regulación, etiqueta y dosis;
- `sku-master`, `cost-model`, `fulfillment-record` y `public-asset` requieren `admin` o `director`;
- la UI filtra tipos de evidencia según el rol real del usuario;
- el checkbox de gate completo queda deshabilitado si la revisión no está verificada;
- amplía unit tests y pgTAP para cubrir Product Truth, roles y draft-vs-verified.

## Guardrails
- no modifica Product Truth ni Crop Truth;
- no publica documentos privados, costos, PVP, márgenes, dosis ni números regulatorios;
- no toca UI pública, checkout, indexación ni `main`;
- mantiene ledger append-only y RLS;
- no elimina ni reescribe historia de evidencia.

## Base y estado final
Parte de `develop` en `8ced5502ab2e50413a203dd50bede960a854f01d` y queda 7 commits adelante / 0 detrás.

## CI final
Run #699 sobre head exacta `9f2d8595409a42df3f8e9d8efb14ce68d1b94bf6`: 4/4 verde.
- quality ✅
- database ✅ (fresh migrations + RLS/pgTAP + Postgres lint)
- browser desktop ✅
- browser mobile ✅

Merge solo contra esta cabeza exacta.