### PR TITLE
feat(home-garden): priorizar readiness por frentes de cierre

### DIFF
--- a/src/components/home-garden-readiness-admin-view.tsx
+++ b/src/components/home-garden-readiness-admin-view.tsx
@@ -160,16 +160,16 @@ export function HomeGardenReadinessAdminView() {
 
     {feedback ? <p role="status" className={`rounded-xl p-4 text-sm font-semibold ${feedback.kind === "error" ? "bg-[var(--red-soft)] text-[var(--red)]" : "bg-[var(--surface-soft)] text-[var(--green)]"}`}>{feedback.text}</p> : null}
 
-    <section className="grid gap-3 md:grid-cols-5">
+    <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
       <article className="panel"><span className="quiet text-xs">Presentaciones propuestas</span><strong className="mt-2 block text-3xl">{registry.summary.total}</strong></article>
-      <article className="panel"><span className="quiet text-xs">Commerce ready</span><strong className="mt-2 block text-3xl">{registry.summary.commerceReady}</strong></article>
-      <article className="panel"><span className="quiet text-xs">Pendientes</span><strong className="mt-2 block text-3xl">{registry.summary.pending}</strong></article>
-      <article className="panel"><span className="quiet text-xs">Gate-instancias abiertas</span><strong className="mt-2 block text-3xl">{registry.summary.openGateInstances}</strong></article>
+      <article className="panel"><span className="quiet text-xs">Listas para comercio</span><strong className="mt-2 block text-3xl">{registry.summary.commerceReady}</strong></article>
+      <article className="panel"><span className="quiet text-xs">Presentaciones pendientes</span><strong className="mt-2 block text-3xl">{registry.summary.pending}</strong></article>
+      <article className="panel"><span className="quiet text-xs">Cierres pendientes</span><strong className="mt-2 block text-3xl">{registry.summary.openGateInstances}</strong></article>
       <article className="panel"><span className="quiet text-xs">Evidencia huérfana</span><strong className="mt-2 block text-3xl">{registry.summary.orphanEvidence}</strong></article>
     </section>
 
     <section className="panel">
-      <div className="section-head"><div><p className="eyebrow">Priorización</p><h2>Bloqueadores por frente</h2><p className="quiet mt-1">Cada cifra representa presentaciones con ese gate abierto. El carril indica la función responsable del tipo de cierre, no una persona asignada.</p></div><span className="quiet">{registry.summary.openGateInstances} pendientes acumulados</span></div>
+      <div className="section-head"><div><p className="eyebrow">Priorización</p><h2>Bloqueadores por frente</h2><p className="quiet mt-1">Cada cifra representa presentaciones con ese criterio de lanzamiento abierto. El carril indica la función responsable del tipo de cierre, no una persona asignada.</p></div><span className="quiet">{registry.summary.openGateInstances} cierres pendientes</span></div>
       <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         {registry.workstreams.map((workstream) => <article className="rounded-xl border border-[var(--line)] p-4" key={workstream.gate}>
           <div className="flex flex-wrap items-start justify-between gap-2"><div><strong>{workstream.label}</strong><span className="quiet mt-1 block text-xs">Carril: {homeGardenLaneLabels[workstream.lane]}</span></div><span className={`status-pill ${workstream.openCount === 0 ? "status-normal" : "status-planned"}`}>{workstream.openCount === 0 ? "CERRADO" : `${workstream.openCount} ABIERTAS`}</span></div>
@@ -202,7 +202,7 @@ export function HomeGardenReadinessAdminView() {
     </section>
 
     <section className="grid gap-3">
-      <div className="section-head"><div><p className="eyebrow">Presentaciones</p><h2>{gateFilter === "all" ? "Matriz por presentación" : `Pendientes · ${homeGardenGateLabels[gateFilter]}`}</h2><p className="quiet mt-1">Mostrando {visibleItems.length} de {registry.items.length} presentaciones.</p></div>{gateFilter !== "all" ? <button className="button secondary" type="button" onClick={() => setGateFilter("all")}>Quitar filtro de gate</button> : null}</div>
+      <div className="section-head"><div><p className="eyebrow">Presentaciones</p><h2>{gateFilter === "all" ? "Matriz por presentación" : `Pendientes · ${homeGardenGateLabels[gateFilter]}`}</h2><p className="quiet mt-1">Mostrando {visibleItems.length} de {registry.items.length} presentaciones.</p></div>{gateFilter !== "all" ? <button className="button secondary" type="button" onClick={() => setGateFilter("all")}>Quitar filtro de frente</button> : null}</div>
       {visibleItems.map((item) => <article className="panel" key={item.id}>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div><p className="eyebrow">{item.consumerName} · {item.plannedVariant}</p><h2>{item.technicalName}{item.formula ? ` · ${item.formula}` : ""}</h2><p className="quiet mt-1 text-xs">{item.id} · Product Truth: {item.technicalSlug}</p></div>

--- a/src/components/home-garden-readiness-admin-view.tsx
+++ b/src/components/home-garden-readiness-admin-view.tsx
@@ -2,13 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useOpsStore } from "@/components/ops-store";
-import { homeGardenEvidenceRules } from "@/data/home-garden-evidence";
+import { homeGardenEvidenceRules, type HomeGardenEvidenceGateId } from "@/data/home-garden-evidence";
 import { homeGardenPlannedSkuCandidates } from "@/data/home-garden-sku-launch-matrix";
 import {
   buildHomeGardenReadinessRegistry,
   canAppendHomeGardenEvidence,
   canManageHomeGardenReadiness,
   homeGardenGateLabels,
+  homeGardenLaneLabels,
   homeGardenLaunchEvidenceKinds,
   type HomeGardenEvidenceDisposition,
   type HomeGardenLaunchEvidenceKind,
@@ -21,6 +22,7 @@ import {
 
 type Feedback = { kind: "ok" | "error"; text: string } | null;
 type RegistryFilter = "all" | "pending" | "ready";
+type GateFilter = "all" | HomeGardenEvidenceGateId;
 
 const dispositionLabels: Record<HomeGardenEvidenceDisposition, string> = {
   draft: "Borrador / por revisar",
@@ -45,6 +47,7 @@ export function HomeGardenReadinessAdminView() {
   const [saving, setSaving] = useState(false);
   const [feedback, setFeedback] = useState<Feedback>(null);
   const [filter, setFilter] = useState<RegistryFilter>("all");
+  const [gateFilter, setGateFilter] = useState<GateFilter>("all");
 
   const [candidateId, setCandidateId] = useState(homeGardenPlannedSkuCandidates[0]?.id ?? "");
   const [evidenceKind, setEvidenceKind] = useState<HomeGardenLaunchEvidenceKind>("laboratory-report");
@@ -84,10 +87,11 @@ export function HomeGardenReadinessAdminView() {
 
   const registry = useMemo(() => buildHomeGardenReadinessRegistry(revisions), [revisions]);
   const visibleItems = useMemo(() => registry.items.filter((item) => {
-    if (filter === "ready") return item.commerceReady;
-    if (filter === "pending") return !item.commerceReady;
+    if (filter === "ready" && !item.commerceReady) return false;
+    if (filter === "pending" && item.commerceReady) return false;
+    if (gateFilter !== "all" && item.gates[gateFilter]) return false;
     return true;
-  }), [filter, registry.items]);
+  }), [filter, gateFilter, registry.items]);
   const selectedRule = homeGardenEvidenceRules.find((rule) => rule.kind === effectiveEvidenceKind);
 
   async function saveEvidence() {
@@ -147,17 +151,32 @@ export function HomeGardenReadinessAdminView() {
         <select aria-label="Filtro readiness" className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={filter} onChange={(event) => setFilter(event.target.value as RegistryFilter)}>
           <option value="all">Todas</option><option value="pending">Pendientes</option><option value="ready">Listas para comercio</option>
         </select>
+        <select aria-label="Filtro por gate" className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={gateFilter} onChange={(event) => setGateFilter(event.target.value as GateFilter)}>
+          <option value="all">Todos los frentes</option>{registry.workstreams.map((workstream) => <option key={workstream.gate} value={workstream.gate}>{workstream.label} · {workstream.openCount} abiertas</option>)}
+        </select>
         <button className="button secondary" type="button" disabled={loading} onClick={() => void load()}>{loading ? "Actualizando…" : "Actualizar"}</button>
       </div>
     </header>
 
     {feedback ? <p role="status" className={`rounded-xl p-4 text-sm font-semibold ${feedback.kind === "error" ? "bg-[var(--red-soft)] text-[var(--red)]" : "bg-[var(--surface-soft)] text-[var(--green)]"}`}>{feedback.text}</p> : null}
 
-    <section className="grid gap-3 md:grid-cols-4">
+    <section className="grid gap-3 md:grid-cols-5">
       <article className="panel"><span className="quiet text-xs">Presentaciones propuestas</span><strong className="mt-2 block text-3xl">{registry.summary.total}</strong></article>
       <article className="panel"><span className="quiet text-xs">Commerce ready</span><strong className="mt-2 block text-3xl">{registry.summary.commerceReady}</strong></article>
       <article className="panel"><span className="quiet text-xs">Pendientes</span><strong className="mt-2 block text-3xl">{registry.summary.pending}</strong></article>
+      <article className="panel"><span className="quiet text-xs">Gate-instancias abiertas</span><strong className="mt-2 block text-3xl">{registry.summary.openGateInstances}</strong></article>
       <article className="panel"><span className="quiet text-xs">Evidencia huérfana</span><strong className="mt-2 block text-3xl">{registry.summary.orphanEvidence}</strong></article>
+    </section>
+
+    <section className="panel">
+      <div className="section-head"><div><p className="eyebrow">Priorización</p><h2>Bloqueadores por frente</h2><p className="quiet mt-1">Cada cifra representa presentaciones con ese gate abierto. El carril indica la función responsable del tipo de cierre, no una persona asignada.</p></div><span className="quiet">{registry.summary.openGateInstances} pendientes acumulados</span></div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {registry.workstreams.map((workstream) => <article className="rounded-xl border border-[var(--line)] p-4" key={workstream.gate}>
+          <div className="flex flex-wrap items-start justify-between gap-2"><div><strong>{workstream.label}</strong><span className="quiet mt-1 block text-xs">Carril: {homeGardenLaneLabels[workstream.lane]}</span></div><span className={`status-pill ${workstream.openCount === 0 ? "status-normal" : "status-planned"}`}>{workstream.openCount === 0 ? "CERRADO" : `${workstream.openCount} ABIERTAS`}</span></div>
+          <div className="mt-3 flex gap-4 text-xs"><span><b>{workstream.closedCount}</b> cerradas</span><span><b>{workstream.openCount}</b> pendientes</span><span><b>{workstream.total}</b> total</span></div>
+          {workstream.openCount > 0 ? <button className="button secondary mt-3" type="button" onClick={() => { setGateFilter(workstream.gate); setFilter("pending"); }}>Ver presentaciones afectadas</button> : <p className="quiet mt-3 text-xs">No bloquea ninguna presentación.</p>}
+        </article>)}
+      </div>
     </section>
 
     {registry.orphanEvidence.length ? <section className="panel border border-[var(--red)]"><p className="eyebrow">Deriva detectada</p><h2>Evidencia sin candidato vigente</h2><p className="quiet mt-1">No se aplica silenciosamente a otra presentación. Debe reconciliarse.</p><ul className="mt-3 grid gap-2 text-sm">{registry.orphanEvidence.map((item) => <li key={item.id}><strong>{item.candidateId}</strong> · {item.evidenceKind} · rev. {item.revisionNo}</li>)}</ul></section> : null}
@@ -183,6 +202,7 @@ export function HomeGardenReadinessAdminView() {
     </section>
 
     <section className="grid gap-3">
+      <div className="section-head"><div><p className="eyebrow">Presentaciones</p><h2>{gateFilter === "all" ? "Matriz por presentación" : `Pendientes · ${homeGardenGateLabels[gateFilter]}`}</h2><p className="quiet mt-1">Mostrando {visibleItems.length} de {registry.items.length} presentaciones.</p></div>{gateFilter !== "all" ? <button className="button secondary" type="button" onClick={() => setGateFilter("all")}>Quitar filtro de gate</button> : null}</div>
       {visibleItems.map((item) => <article className="panel" key={item.id}>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div><p className="eyebrow">{item.consumerName} · {item.plannedVariant}</p><h2>{item.technicalName}{item.formula ? ` · ${item.formula}` : ""}</h2><p className="quiet mt-1 text-xs">{item.id} · Product Truth: {item.technicalSlug}</p></div>
@@ -194,6 +214,7 @@ export function HomeGardenReadinessAdminView() {
           {item.latestEvidence.length ? <div className="mt-2 grid gap-2">{item.latestEvidence.map((evidence) => <div className="rounded-lg bg-[var(--surface-soft)] p-3 text-xs" key={evidence.id}><div className="flex flex-wrap justify-between gap-2"><strong>{homeGardenEvidenceRules.find((rule) => rule.kind === evidence.evidenceKind)?.label ?? evidence.evidenceKind} · {dispositionLabels[evidence.disposition]}</strong><span>rev. {evidence.revisionNo}</span></div><p className="mt-1">{evidence.title}</p><p className="quiet mt-1 break-all">Fuente interna: {evidence.sourceReference}</p><p className="mt-1">{evidence.note}</p></div>)}</div> : <p className="quiet mt-2 text-xs">Sin evidencia registrada para esta presentación.</p>}
         </div>
       </article>)}
+      {!visibleItems.length ? <section className="panel"><p className="quiet">No hay presentaciones que coincidan con los filtros actuales.</p></section> : null}
     </section>
   </div>;
 }

--- a/src/lib/home-garden-readiness-registry.test.ts
+++ b/src/lib/home-garden-readiness-registry.test.ts
@@ -68,13 +68,34 @@ describe("home garden readiness registry", () => {
     expect(selected.find((item) => item.candidateId === "crece-500-g")?.disposition).toBe("rejected");
   });
 
-  it("builds all 18 candidates and keeps them pending without full evidence", () => {
+  it("builds all 18 candidates and a seven-front operational blocker summary", () => {
     const registry = buildHomeGardenReadinessRegistry([]);
     expect(registry.summary.total).toBe(18);
     expect(registry.summary.commerceReady).toBe(0);
     expect(registry.summary.pending).toBe(18);
+    expect(registry.summary.openGateInstances).toBe(108);
     expect(registry.items.every((item) => item.gates["technical-product-truth"])).toBe(true);
     expect(registry.items.every((item) => item.commerceReady === false)).toBe(true);
+    expect(registry.workstreams).toHaveLength(7);
+
+    const productTruth = registry.workstreams.find((item) => item.gate === "technical-product-truth");
+    expect(productTruth).toMatchObject({ lane: "canonical", total: 18, closedCount: 18, openCount: 0 });
+
+    const regulatory = registry.workstreams.find((item) => item.gate === "regulatory");
+    expect(regulatory).toMatchObject({ lane: "technical", total: 18, closedCount: 0, openCount: 18 });
+
+    const cost = registry.workstreams.find((item) => item.gate === "all-in-cost");
+    expect(cost).toMatchObject({ lane: "admin-director", total: 18, closedCount: 0, openCount: 18 });
+  });
+
+  it("reduces a workstream blocker count only for the exact presentation whose gate closes", () => {
+    const registry = buildHomeGardenReadinessRegistry([revision()]);
+    const skuWorkstream = registry.workstreams.find((item) => item.gate === "household-skus");
+
+    expect(skuWorkstream).toMatchObject({ total: 18, closedCount: 1, openCount: 17 });
+    expect(skuWorkstream?.openCandidateIds).not.toContain("crece-500-g");
+    expect(skuWorkstream?.openCandidateIds).toHaveLength(17);
+    expect(registry.summary.openGateInstances).toBe(107);
   });
 
   it("reopens a gate when the latest revision supersedes an older verified record", () => {
@@ -86,6 +107,7 @@ describe("home garden readiness registry", () => {
     expect(item?.gates["household-skus"]).toBe(false);
     expect(item?.latestEvidence).toHaveLength(1);
     expect(item?.latestEvidence[0]?.revisionNo).toBe(2);
+    expect(registry.workstreams.find((workstream) => workstream.gate === "household-skus")?.openCount).toBe(18);
   });
 
   it("flags evidence for candidate ids that no longer exist instead of silently applying it", () => {

--- a/src/lib/home-garden-readiness-registry.ts
+++ b/src/lib/home-garden-readiness-registry.ts
@@ -11,6 +11,7 @@ import {
 
 export type HomeGardenEvidenceDisposition = "draft" | "verified" | "rejected" | "superseded";
 export type HomeGardenLaunchEvidenceKind = Exclude<HomeGardenEvidenceKind, "product-truth">;
+export type HomeGardenReadinessLane = "canonical" | "technical" | "admin-director";
 
 export const homeGardenLaunchEvidenceKinds = [
   "laboratory-report",
@@ -29,6 +30,16 @@ const technicalEvidenceKinds = new Set<HomeGardenLaunchEvidenceKind>([
   "approved-label",
   "dose-validation",
 ]);
+
+export const homeGardenGateOrder = [
+  "technical-product-truth",
+  "household-skus",
+  "regulatory",
+  "dose-and-dosifier",
+  "all-in-cost",
+  "fulfillment",
+  "public-assets",
+] as const satisfies readonly HomeGardenEvidenceGateId[];
 
 export type HomeGardenLaunchEvidenceRevision = {
   id: string;
@@ -53,13 +64,25 @@ export type HomeGardenReadinessRegistryItem = HomeGardenSkuLaunchEvaluation & {
   missingGates: readonly HomeGardenEvidenceGateId[];
 };
 
+export type HomeGardenGateWorkstream = {
+  gate: HomeGardenEvidenceGateId;
+  label: string;
+  lane: HomeGardenReadinessLane;
+  total: number;
+  closedCount: number;
+  openCount: number;
+  openCandidateIds: readonly string[];
+};
+
 export type HomeGardenReadinessRegistry = {
   items: readonly HomeGardenReadinessRegistryItem[];
+  workstreams: readonly HomeGardenGateWorkstream[];
   orphanEvidence: readonly HomeGardenLaunchEvidenceRevision[];
   summary: {
     total: number;
     commerceReady: number;
     pending: number;
+    openGateInstances: number;
     orphanEvidence: number;
   };
 };
@@ -72,6 +95,22 @@ export const homeGardenGateLabels: Record<HomeGardenEvidenceGateId, string> = {
   "all-in-cost": "Costo all-in",
   fulfillment: "Fulfillment",
   "public-assets": "Activos públicos",
+};
+
+export const homeGardenGateLanes: Record<HomeGardenEvidenceGateId, HomeGardenReadinessLane> = {
+  "technical-product-truth": "canonical",
+  "household-skus": "admin-director",
+  regulatory: "technical",
+  "dose-and-dosifier": "technical",
+  "all-in-cost": "admin-director",
+  fulfillment: "admin-director",
+  "public-assets": "admin-director",
+};
+
+export const homeGardenLaneLabels: Record<HomeGardenReadinessLane, string> = {
+  canonical: "Canónico · código",
+  technical: "Técnico",
+  "admin-director": "Admin / Dirección",
 };
 
 export function canManageHomeGardenReadiness(role: string) {
@@ -112,6 +151,21 @@ export function toHomeGardenEvidenceRecord(
   };
 }
 
+function buildGateWorkstreams(items: readonly HomeGardenReadinessRegistryItem[]): readonly HomeGardenGateWorkstream[] {
+  return homeGardenGateOrder.map((gate) => {
+    const openCandidateIds = items.filter((item) => !item.gates[gate]).map((item) => item.id);
+    return {
+      gate,
+      label: homeGardenGateLabels[gate],
+      lane: homeGardenGateLanes[gate],
+      total: items.length,
+      closedCount: items.length - openCandidateIds.length,
+      openCount: openCandidateIds.length,
+      openCandidateIds,
+    };
+  });
+}
+
 export function buildHomeGardenReadinessRegistry(
   revisions: readonly HomeGardenLaunchEvidenceRevision[],
 ): HomeGardenReadinessRegistry {
@@ -130,19 +184,20 @@ export function buildHomeGardenReadinessRegistry(
   const items = buildHomeGardenSkuLaunchMatrix(evidenceByCandidate).map((evaluation): HomeGardenReadinessRegistryItem => ({
     ...evaluation,
     latestEvidence: latestByCandidate[evaluation.id] ?? [],
-    missingGates: (Object.entries(evaluation.gates) as Array<[HomeGardenEvidenceGateId, boolean]>)
-      .filter(([, closed]) => !closed)
-      .map(([gate]) => gate),
+    missingGates: homeGardenGateOrder.filter((gate) => !evaluation.gates[gate]),
   }));
 
+  const workstreams = buildGateWorkstreams(items);
   const commerceReady = items.filter((item) => item.commerceReady).length;
   return {
     items,
+    workstreams,
     orphanEvidence,
     summary: {
       total: items.length,
       commerceReady,
       pending: items.length - commerceReady,
+      openGateInstances: workstreams.reduce((total, workstream) => total + workstream.openCount, 0),
       orphanEvidence: orphanEvidence.length,
     },
   };


### PR DESCRIPTION
## Objetivo
Convertir el readiness interno de Casa, Jardín y Vivero en una herramienta de priorización diaria, agregando los bloqueos de las 18 presentaciones por gate sin crear otra fuente de verdad.

## Cambios
- deriva 7 workstreams desde la matriz vigente: Product Truth, SKU Master, regulatorio + etiqueta, dosis + dosificador, costo all-in, fulfillment y activos públicos;
- calcula por frente presentaciones cerradas, abiertas y candidatas afectadas;
- añade carriles funcionales `Canónico · código`, `Técnico` y `Admin / Dirección` sin asignar personas ni crear nuevos roles;
- añade KPI `Cierres pendientes`;
- incorpora sección interna `Bloqueadores por frente`;
- permite filtrar las 18 presentaciones por criterio abierto y saltar desde cada frente a sus afectadas;
- mejora densidad responsive del resumen;
- mantiene la vista por presentación y el ledger append-only existentes;
- añade unit tests de cardinalidad, carriles, conteos y cierre exacto por presentación.

## Guardrails
- no añade tablas, migraciones ni persistencia nueva;
- no cambia RLS, RPC ni permisos;
- no modifica Product Truth, Crop Truth ni matriz de 18 candidatas;
- no publica costos, PVP, márgenes, dosis ni evidencia privada;
- no toca UI pública, checkout, indexación ni `main`.

## Base y estado final
Parte de `develop` en `8a22d21b263ab6fc7d673b3ad93d81831b7e2a4c` y queda 4 commits adelante / 0 detrás.

## CI final
Run #702 sobre head exacta `892ae9d949699966aa0035e74bfd0a45e8315262`: 4/4 verde.
- quality ✅
- database ✅
- browser desktop ✅
- browser mobile ✅

Merge solo contra esta cabeza exacta.