### PR TITLE
feat(home-garden): guiar siguiente evidencia de readiness

### DIFF
--- a/src/components/home-garden-readiness-admin-view.tsx
+++ b/src/components/home-garden-readiness-admin-view.tsx
@@ -8,12 +8,14 @@ import {
   buildHomeGardenReadinessRegistry,
   canAppendHomeGardenEvidence,
   canManageHomeGardenReadiness,
+  getNextHomeGardenEvidenceKind,
   homeGardenGateLabels,
   homeGardenLaneLabels,
   homeGardenLaunchEvidenceKinds,
   type HomeGardenEvidenceDisposition,
   type HomeGardenLaunchEvidenceKind,
   type HomeGardenLaunchEvidenceRevision,
+  type HomeGardenReadinessRegistryItem,
 } from "@/lib/home-garden-readiness-registry";
 import {
   appendHomeGardenLaunchEvidence,
@@ -30,6 +32,12 @@ const dispositionLabels: Record<HomeGardenEvidenceDisposition, string> = {
   rejected: "Rechazada / reabre gate",
   superseded: "Superada",
 };
+
+const requirementStatusLabels = {
+  ready: "LISTA",
+  missing: "FALTA",
+  "needs-review": "REVISAR",
+} as const;
 
 function GatePill({ closed, label }: { closed: boolean; label: string }) {
   return <span className={`status-pill ${closed ? "status-normal" : "status-planned"}`}>{closed ? "✓" : "○"} {label}</span>;
@@ -93,6 +101,31 @@ export function HomeGardenReadinessAdminView() {
     return true;
   }), [filter, gateFilter, registry.items]);
   const selectedRule = homeGardenEvidenceRules.find((rule) => rule.kind === effectiveEvidenceKind);
+
+  function prepareNextEvidence(item: HomeGardenReadinessRegistryItem, gate: HomeGardenEvidenceGateId) {
+    const nextKind = getNextHomeGardenEvidenceKind(item, gate);
+    if (!nextKind) {
+      setFeedback({ kind: "error", text: "Este criterio no tiene una siguiente evidencia registrable pendiente." });
+      return;
+    }
+    if (!access.some((entry) => canAppendHomeGardenEvidence(entry.role, nextKind))) {
+      setFeedback({ kind: "error", text: `Tu rol puede consultar ${homeGardenGateLabels[gate]}, pero no registrar la evidencia pendiente.` });
+      return;
+    }
+
+    setCandidateId(item.id);
+    setEvidenceKind(nextKind);
+    setDisposition("draft");
+    setTitle("");
+    setSourceReference("");
+    setSourceDate("");
+    setSameReference(false);
+    setSamePresentation(false);
+    setCompleteForGate(false);
+    setNote("");
+    setFeedback(null);
+    window.requestAnimationFrame(() => document.getElementById("home-garden-evidence-form")?.scrollIntoView({ behavior: "smooth", block: "start" }));
+  }
 
   async function saveEvidence() {
     if (!access.some((item) => canAppendHomeGardenEvidence(item.role, effectiveEvidenceKind))) {
@@ -181,7 +214,7 @@ export function HomeGardenReadinessAdminView() {
 
     {registry.orphanEvidence.length ? <section className="panel border border-[var(--red)]"><p className="eyebrow">Deriva detectada</p><h2>Evidencia sin candidato vigente</h2><p className="quiet mt-1">No se aplica silenciosamente a otra presentación. Debe reconciliarse.</p><ul className="mt-3 grid gap-2 text-sm">{registry.orphanEvidence.map((item) => <li key={item.id}><strong>{item.candidateId}</strong> · {item.evidenceKind} · rev. {item.revisionNo}</li>)}</ul></section> : null}
 
-    <section className="panel">
+    <section className="panel scroll-mt-4" id="home-garden-evidence-form">
       <div className="section-head"><div><p className="eyebrow">Nueva revisión</p><h2>Anexar evidencia gobernada</h2><p className="quiet mt-1">Guarda una referencia interna al documento; no pegues enlaces firmados, tokens ni credenciales. Los tipos disponibles dependen de tu rol.</p></div></div>
       <div className="grid gap-3 lg:grid-cols-3">
         <label className="grid gap-1 text-xs font-semibold">Presentación<select className="min-h-10 rounded-lg border border-[var(--line)] bg-white px-3 text-sm" value={candidateId} onChange={(event) => setCandidateId(event.target.value)}>{homeGardenPlannedSkuCandidates.map((candidate) => <option key={candidate.id} value={candidate.id}>{candidate.consumerName} · {candidate.plannedVariant} · {candidate.id}</option>)}</select></label>
@@ -203,17 +236,37 @@ export function HomeGardenReadinessAdminView() {
 
     <section className="grid gap-3">
       <div className="section-head"><div><p className="eyebrow">Presentaciones</p><h2>{gateFilter === "all" ? "Matriz por presentación" : `Pendientes · ${homeGardenGateLabels[gateFilter]}`}</h2><p className="quiet mt-1">Mostrando {visibleItems.length} de {registry.items.length} presentaciones.</p></div>{gateFilter !== "all" ? <button className="button secondary" type="button" onClick={() => setGateFilter("all")}>Quitar filtro de frente</button> : null}</div>
-      {visibleItems.map((item) => <article className="panel" key={item.id}>
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div><p className="eyebrow">{item.consumerName} · {item.plannedVariant}</p><h2>{item.technicalName}{item.formula ? ` · ${item.formula}` : ""}</h2><p className="quiet mt-1 text-xs">{item.id} · Product Truth: {item.technicalSlug}</p></div>
-          <span className={`status-pill ${item.commerceReady ? "status-normal" : "status-planned"}`}>{item.commerceReady ? "LISTO PARA COMERCIO" : `${item.missingGates.length} GATES ABIERTOS`}</span>
-        </div>
-        <div className="mt-4 flex flex-wrap gap-2">{(Object.entries(item.gates) as Array<[keyof typeof item.gates, boolean]>).map(([gate, closed]) => <GatePill key={gate} closed={closed} label={homeGardenGateLabels[gate]} />)}</div>
-        <div className="mt-4 border-t border-[var(--line)] pt-4">
-          <strong className="text-sm">Evidencia vigente</strong>
-          {item.latestEvidence.length ? <div className="mt-2 grid gap-2">{item.latestEvidence.map((evidence) => <div className="rounded-lg bg-[var(--surface-soft)] p-3 text-xs" key={evidence.id}><div className="flex flex-wrap justify-between gap-2"><strong>{homeGardenEvidenceRules.find((rule) => rule.kind === evidence.evidenceKind)?.label ?? evidence.evidenceKind} · {dispositionLabels[evidence.disposition]}</strong><span>rev. {evidence.revisionNo}</span></div><p className="mt-1">{evidence.title}</p><p className="quiet mt-1 break-all">Fuente interna: {evidence.sourceReference}</p><p className="mt-1">{evidence.note}</p></div>)}</div> : <p className="quiet mt-2 text-xs">Sin evidencia registrada para esta presentación.</p>}
-        </div>
-      </article>)}
+      {visibleItems.map((item) => {
+        const nextKind = gateFilter === "all" ? undefined : getNextHomeGardenEvidenceKind(item, gateFilter);
+        const canPrepare = nextKind ? access.some((entry) => canAppendHomeGardenEvidence(entry.role, nextKind)) : false;
+        const nextRule = nextKind ? homeGardenEvidenceRules.find((rule) => rule.kind === nextKind) : undefined;
+        return <article className="panel" key={item.id}>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div><p className="eyebrow">{item.consumerName} · {item.plannedVariant}</p><h2>{item.technicalName}{item.formula ? ` · ${item.formula}` : ""}</h2><p className="quiet mt-1 text-xs">{item.id} · Product Truth: {item.technicalSlug}</p></div>
+            <span className={`status-pill ${item.commerceReady ? "status-normal" : "status-planned"}`}>{item.commerceReady ? "LISTO PARA COMERCIO" : `${item.missingGates.length} GATES ABIERTOS`}</span>
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">{(Object.entries(item.gates) as Array<[keyof typeof item.gates, boolean]>).map(([gate, closed]) => <GatePill key={gate} closed={closed} label={homeGardenGateLabels[gate]} />)}</div>
+
+          {gateFilter !== "all" ? <div className="mt-4 rounded-xl border border-[var(--line)] p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3"><div><strong className="text-sm">Qué falta · {homeGardenGateLabels[gateFilter]}</strong><p className="quiet mt-1 text-xs">El estado se deriva exclusivamente de la última revisión vigente por tipo de evidencia.</p></div>{nextKind ? <span className="quiet text-xs">Siguiente: {nextRule?.label ?? nextKind}</span> : null}</div>
+            <div className="mt-3 grid gap-2">
+              {item.gateEvidence[gateFilter].map((state) => <div className="rounded-lg bg-[var(--surface-soft)] p-3 text-xs" key={state.kind}>
+                <div className="flex flex-wrap items-center justify-between gap-2"><strong>{state.label}</strong><span className={`status-pill ${state.status === "ready" ? "status-normal" : "status-planned"}`}>{requirementStatusLabels[state.status]}</span></div>
+                <p className="mt-1">{state.reason}</p>
+                {state.latestRevision ? <p className="quiet mt-1">Rev. {state.latestRevision.revisionNo} · {dispositionLabels[state.latestRevision.disposition]}</p> : null}
+              </div>)}
+            </div>
+            {nextKind && canPrepare ? <button className="button secondary mt-3" type="button" onClick={() => prepareNextEvidence(item, gateFilter)}>Preparar registro · {nextRule?.label ?? nextKind}</button> : null}
+            {nextKind && !canPrepare ? <p className="quiet mt-3 text-xs">Tu rol puede consultar este bloqueo, pero el siguiente registro corresponde al carril {homeGardenLaneLabels[registry.workstreams.find((workstream) => workstream.gate === gateFilter)?.lane ?? "admin-director"]}.</p> : null}
+            {!nextKind ? <p className="quiet mt-3 text-xs">No hay otra evidencia registrable pendiente para este criterio.</p> : null}
+          </div> : null}
+
+          <div className="mt-4 border-t border-[var(--line)] pt-4">
+            <strong className="text-sm">Evidencia vigente</strong>
+            {item.latestEvidence.length ? <div className="mt-2 grid gap-2">{item.latestEvidence.map((evidence) => <div className="rounded-lg bg-[var(--surface-soft)] p-3 text-xs" key={evidence.id}><div className="flex flex-wrap justify-between gap-2"><strong>{homeGardenEvidenceRules.find((rule) => rule.kind === evidence.evidenceKind)?.label ?? evidence.evidenceKind} · {dispositionLabels[evidence.disposition]}</strong><span>rev. {evidence.revisionNo}</span></div><p className="mt-1">{evidence.title}</p><p className="quiet mt-1 break-all">Fuente interna: {evidence.sourceReference}</p><p className="mt-1">{evidence.note}</p></div>)}</div> : <p className="quiet mt-2 text-xs">Sin evidencia registrada para esta presentación.</p>}
+          </div>
+        </article>;
+      })}
       {!visibleItems.length ? <section className="panel"><p className="quiet">No hay presentaciones que coincidan con los filtros actuales.</p></section> : null}
     </section>
   </div>;

--- a/src/lib/home-garden-readiness-registry.test.ts
+++ b/src/lib/home-garden-readiness-registry.test.ts
@@ -4,6 +4,7 @@ import {
   buildHomeGardenReadinessRegistry,
   canAppendHomeGardenEvidence,
   canManageHomeGardenReadiness,
+  getNextHomeGardenEvidenceKind,
   homeGardenLaunchEvidenceKinds,
   selectLatestHomeGardenEvidence,
 } from "./home-garden-readiness-registry";
@@ -88,6 +89,76 @@ describe("home garden readiness registry", () => {
     expect(cost).toMatchObject({ lane: "admin-director", total: 18, closedCount: 0, openCount: 18 });
   });
 
+  it("derives the exact missing evidence for a multi-document regulatory gate", () => {
+    const registry = buildHomeGardenReadinessRegistry([]);
+    const item = registry.items.find((candidate) => candidate.id === "crece-500-g");
+    const regulatory = item?.gateEvidence.regulatory;
+
+    expect(regulatory).toHaveLength(2);
+    expect(regulatory?.map((state) => [state.kind, state.status])).toEqual([
+      ["regulatory-registration", "missing"],
+      ["approved-label", "missing"],
+    ]);
+    expect(item && getNextHomeGardenEvidenceKind(item, "regulatory")).toBe("regulatory-registration");
+  });
+
+  it("advances to the second regulatory requirement when the first is ready", () => {
+    const registry = buildHomeGardenReadinessRegistry([
+      revision({
+        id: "reg-1",
+        evidenceKind: "regulatory-registration",
+        title: "Cobertura regulatoria CRECE 500 g",
+      }),
+    ]);
+    const item = registry.items.find((candidate) => candidate.id === "crece-500-g");
+    const regulatory = item?.gateEvidence.regulatory;
+
+    expect(regulatory?.find((state) => state.kind === "regulatory-registration")?.status).toBe("ready");
+    expect(regulatory?.find((state) => state.kind === "approved-label")?.status).toBe("missing");
+    expect(item && getNextHomeGardenEvidenceKind(item, "regulatory")).toBe("approved-label");
+    expect(item?.gates.regulatory).toBe(false);
+  });
+
+  it("marks a non-verified latest revision as needs-review instead of treating it as missing", () => {
+    const registry = buildHomeGardenReadinessRegistry([
+      revision({
+        id: "label-draft",
+        evidenceKind: "approved-label",
+        disposition: "draft",
+        completeForGate: false,
+        title: "Etiqueta CRECE 500 g en revisión",
+      }),
+    ]);
+    const item = registry.items.find((candidate) => candidate.id === "crece-500-g");
+    const labelState = item?.gateEvidence.regulatory.find((state) => state.kind === "approved-label");
+
+    expect(labelState?.status).toBe("needs-review");
+    expect(labelState?.latestRevision?.id).toBe("label-draft");
+    expect(labelState?.reason).toMatch(/borrador/i);
+  });
+
+  it("has no next regulatory evidence once both required revisions satisfy the gate", () => {
+    const registry = buildHomeGardenReadinessRegistry([
+      revision({
+        id: "reg-1",
+        revisionNo: 1,
+        evidenceKind: "regulatory-registration",
+        title: "Cobertura regulatoria CRECE 500 g",
+      }),
+      revision({
+        id: "label-2",
+        revisionNo: 2,
+        evidenceKind: "approved-label",
+        title: "Etiqueta conciliada CRECE 500 g",
+      }),
+    ]);
+    const item = registry.items.find((candidate) => candidate.id === "crece-500-g");
+
+    expect(item?.gates.regulatory).toBe(true);
+    expect(item?.gateEvidence.regulatory.every((state) => state.status === "ready")).toBe(true);
+    expect(item && getNextHomeGardenEvidenceKind(item, "regulatory")).toBeUndefined();
+  });
+
   it("reduces a workstream blocker count only for the exact presentation whose gate closes", () => {
     const registry = buildHomeGardenReadinessRegistry([revision()]);
     const skuWorkstream = registry.workstreams.find((item) => item.gate === "household-skus");
@@ -107,6 +178,7 @@ describe("home garden readiness registry", () => {
     expect(item?.gates["household-skus"]).toBe(false);
     expect(item?.latestEvidence).toHaveLength(1);
     expect(item?.latestEvidence[0]?.revisionNo).toBe(2);
+    expect(item?.gateEvidence["household-skus"][0]?.status).toBe("needs-review");
     expect(registry.workstreams.find((workstream) => workstream.gate === "household-skus")?.openCount).toBe(18);
   });
 

--- a/src/lib/home-garden-readiness-registry.ts
+++ b/src/lib/home-garden-readiness-registry.ts
@@ -4,6 +4,10 @@ import type {
   HomeGardenEvidenceRecord,
 } from "@/data/home-garden-evidence";
 import {
+  getHomeGardenEvidenceRule,
+  getHomeGardenGateEvidenceRequirement,
+} from "@/data/home-garden-evidence";
+import {
   buildHomeGardenSkuLaunchMatrix,
   homeGardenPlannedSkuCandidates,
   type HomeGardenSkuLaunchEvaluation,
@@ -12,6 +16,7 @@ import {
 export type HomeGardenEvidenceDisposition = "draft" | "verified" | "rejected" | "superseded";
 export type HomeGardenLaunchEvidenceKind = Exclude<HomeGardenEvidenceKind, "product-truth">;
 export type HomeGardenReadinessLane = "canonical" | "technical" | "admin-director";
+export type HomeGardenRequirementStatus = "ready" | "missing" | "needs-review";
 
 export const homeGardenLaunchEvidenceKinds = [
   "laboratory-report",
@@ -59,9 +64,19 @@ export type HomeGardenLaunchEvidenceRevision = {
   createdBy: string;
 };
 
+export type HomeGardenGateEvidenceState = {
+  kind: HomeGardenEvidenceKind;
+  label: string;
+  status: HomeGardenRequirementStatus;
+  registrable: boolean;
+  reason: string;
+  latestRevision?: HomeGardenLaunchEvidenceRevision;
+};
+
 export type HomeGardenReadinessRegistryItem = HomeGardenSkuLaunchEvaluation & {
   latestEvidence: readonly HomeGardenLaunchEvidenceRevision[];
   missingGates: readonly HomeGardenEvidenceGateId[];
+  gateEvidence: Readonly<Record<HomeGardenEvidenceGateId, readonly HomeGardenGateEvidenceState[]>>;
 };
 
 export type HomeGardenGateWorkstream = {
@@ -151,6 +166,93 @@ export function toHomeGardenEvidenceRecord(
   };
 }
 
+function evidenceStateReason(
+  revision: HomeGardenLaunchEvidenceRevision,
+  gate: HomeGardenEvidenceGateId,
+) {
+  const requirement = getHomeGardenGateEvidenceRequirement(gate);
+  if (revision.disposition === "draft") return "La revisión vigente sigue en borrador o pendiente de verificación.";
+  if (revision.disposition === "rejected") return "La revisión vigente fue rechazada y mantiene el criterio abierto.";
+  if (revision.disposition === "superseded") return "La revisión vigente está superada; se requiere una evidencia sustituta.";
+  if (!revision.completeForGate) return "La revisión está verificada, pero no está completa para este criterio.";
+  if (requirement?.requireSameReference && !revision.sameReference) return "La evidencia no está conciliada con la misma referencia técnica.";
+  if (requirement?.requireSamePresentation && !revision.samePresentation) return "La evidencia no está conciliada con la misma presentación.";
+  return "La revisión vigente no satisface todavía todas las condiciones de este criterio.";
+}
+
+function buildGateEvidenceState(
+  gate: HomeGardenEvidenceGateId,
+  gateClosed: boolean,
+  latestEvidence: readonly HomeGardenLaunchEvidenceRevision[],
+): readonly HomeGardenGateEvidenceState[] {
+  const requirement = getHomeGardenGateEvidenceRequirement(gate);
+  if (!requirement) return [];
+
+  return requirement.requiredEvidence.map((kind): HomeGardenGateEvidenceState => {
+    const rule = getHomeGardenEvidenceRule(kind);
+    const label = rule?.label ?? kind;
+
+    if (kind === "product-truth") {
+      return {
+        kind,
+        label,
+        registrable: false,
+        status: gateClosed ? "ready" : "needs-review",
+        reason: gateClosed
+          ? "Se resuelve desde Product Truth canónico en código; no requiere ni admite una revisión en este ledger."
+          : "Product Truth canónico debe reconciliarse en código antes de continuar.",
+      };
+    }
+
+    const latestRevision = latestEvidence.find((revision) => revision.evidenceKind === kind);
+    if (!latestRevision) {
+      return {
+        kind,
+        label,
+        registrable: true,
+        status: "missing",
+        reason: "No hay una revisión registrada para esta presentación.",
+      };
+    }
+
+    const eligibleForGate = Boolean(rule?.eligibleToClose.includes(gate));
+    const ready = latestRevision.disposition === "verified"
+      && latestRevision.completeForGate
+      && (!requirement.requireSameReference || latestRevision.sameReference)
+      && (!requirement.requireSamePresentation || latestRevision.samePresentation)
+      && eligibleForGate;
+
+    return {
+      kind,
+      label,
+      registrable: true,
+      status: ready ? "ready" : "needs-review",
+      reason: ready
+        ? "Revisión vigente verificada, completa y conciliada para este criterio."
+        : evidenceStateReason(latestRevision, gate),
+      latestRevision,
+    };
+  });
+}
+
+function buildGateEvidenceMap(
+  evaluation: HomeGardenSkuLaunchEvaluation,
+  latestEvidence: readonly HomeGardenLaunchEvidenceRevision[],
+): Readonly<Record<HomeGardenEvidenceGateId, readonly HomeGardenGateEvidenceState[]>> {
+  return Object.fromEntries(homeGardenGateOrder.map((gate) => [
+    gate,
+    buildGateEvidenceState(gate, evaluation.gates[gate], latestEvidence),
+  ])) as Record<HomeGardenEvidenceGateId, readonly HomeGardenGateEvidenceState[]>;
+}
+
+export function getNextHomeGardenEvidenceKind(
+  item: HomeGardenReadinessRegistryItem,
+  gate: HomeGardenEvidenceGateId,
+): HomeGardenLaunchEvidenceKind | undefined {
+  const pending = item.gateEvidence[gate].find((state) => state.status !== "ready" && state.registrable);
+  return pending && pending.kind !== "product-truth" ? pending.kind : undefined;
+}
+
 function buildGateWorkstreams(items: readonly HomeGardenReadinessRegistryItem[]): readonly HomeGardenGateWorkstream[] {
   return homeGardenGateOrder.map((gate) => {
     const openCandidateIds = items.filter((item) => !item.gates[gate]).map((item) => item.id);
@@ -181,11 +283,15 @@ export function buildHomeGardenReadinessRegistry(
     (latestByCandidate[revision.candidateId] ??= []).push(revision);
   }
 
-  const items = buildHomeGardenSkuLaunchMatrix(evidenceByCandidate).map((evaluation): HomeGardenReadinessRegistryItem => ({
-    ...evaluation,
-    latestEvidence: latestByCandidate[evaluation.id] ?? [],
-    missingGates: homeGardenGateOrder.filter((gate) => !evaluation.gates[gate]),
-  }));
+  const items = buildHomeGardenSkuLaunchMatrix(evidenceByCandidate).map((evaluation): HomeGardenReadinessRegistryItem => {
+    const latestEvidence = latestByCandidate[evaluation.id] ?? [];
+    return {
+      ...evaluation,
+      latestEvidence,
+      missingGates: homeGardenGateOrder.filter((gate) => !evaluation.gates[gate]),
+      gateEvidence: buildGateEvidenceMap(evaluation, latestEvidence),
+    };
+  });
 
   const workstreams = buildGateWorkstreams(items);
   const commerceReady = items.filter((item) => item.commerceReady).length;


### PR DESCRIPTION
## Objetivo
Convertir cada gate abierto del readiness B2C en una instrucción operativa concreta: qué evidencia exige, qué evidencia vigente ya satisface el criterio, qué falta o requiere revisión y cuál es el siguiente registro gobernado.

## Cambios
- deriva el estado de cada evidencia requerida por gate: `ready`, `missing` o `needs-review`;
- usa exclusivamente `homeGardenGateEvidenceRequirements` y la última revisión vigente del ledger;
- Product Truth continúa fuera del ledger y se muestra como cierre canónico en código;
- para gates con múltiples evidencias, como regulatorio y activos públicos, conserva el estado individual de cada requisito;
- calcula la siguiente evidencia registrable pendiente por presentación/gate;
- al filtrar un frente, cada presentación muestra `Lista / Falta / Revisar`, motivo y revisión vigente cuando existe;
- permite preparar el siguiente registro solo si el rol actual puede autorar ese tipo de evidencia;
- la preparación precarga únicamente presentación + tipo de evidencia, vuelve a `draft` y limpia conciliaciones/campos para evitar heredar afirmaciones;
- añade pruebas para ausencia total, requisito parcial, borrador pendiente y gate regulatorio completo.

## Guardrails
- no añade tablas, migraciones ni persistencia;
- no cambia RLS, RPC, roles ni permisos;
- no modifica Product Truth, Crop Truth ni las 18 presentaciones;
- no verifica evidencia automáticamente;
- no preselecciona `sameReference`, `samePresentation` ni `completeForGate`;
- no publica documentos privados, costos, PVP, márgenes ni dosis;
- no toca UI pública, checkout, indexación ni `main`.

## Base
Parte de `develop` en `f0b2241093174a84c8e95abe45a2097f9b6d77c5` y está 3 commits adelante / 0 detrás.

## Gate
Merge únicamente con CI final 4/4 verde sobre la cabeza exacta: quality, database y Playwright desktop/mobile.