### PR TITLE
fix(resources): gobernar auditoría de maestros públicos

### DIFF
--- a/e2e/public-library-home-garden.spec.ts
+++ b/e2e/public-library-home-garden.spec.ts
@@ -19,5 +19,5 @@ test("central public library integrates Casa Jardin without exposing private doc
   expect(hrefs.join(" ")).not.toMatch(/sharepoint|graph\.microsoft/i);
   expect(hrefs.filter((href) => /\.pdf(?:$|\?)/i.test(href))).toHaveLength(0);
 
-  await expect(page.getByText(/PDF maestro identificado · descarga pública en preparación/i).first()).toBeVisible();
+  await expect(page.getByText(/PDF maestro identificado · auditoría pública pendiente/i).first()).toBeVisible();
 });

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -17,7 +17,8 @@ test("public library exposes live Wondergreen knowledge resources and governed s
   });
   await expect(deficiencyCard.getByRole("link", { name: "Abrir guía →", exact: true })).toHaveAttribute("href", "/biblioteca/guia-deficiencias");
 
-  await expect(page.getByText("Lectura web disponible · PDF maestro identificado · descarga pública en preparación", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("Lectura web disponible · PDF maestro identificado · auditoría pública pendiente", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("Lectura web disponible · PDF maestro retenido por auditoría", { exact: true })).toBeVisible();
   await expect(page.getByText("Maestro: Catálogo Wondergreen optimizado · 10 páginas", { exact: true })).toBeVisible();
 });
 

--- a/src/app/biblioteca/page.tsx
+++ b/src/app/biblioteca/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { publicResources, type PublicResource } from "@/data/public-resources";
+import { getPublicResourceMasterAudit } from "@/data/public-resource-master-audits";
+import { publicResourceHostingGate, publicResources, type PublicResource } from "@/data/public-resources";
 import styles from "./library.module.css";
 import refresh from "./library-refresh.module.css";
 
@@ -70,10 +71,26 @@ const intentRoutes = [
 
 function getDeliveryLabel(resource: PublicResource) {
   if (resource.delivery === "web-native") return "Lectura web disponible";
-  if (resource.delivery === "web-native-master-pending") {
-    return "Lectura web disponible · PDF maestro identificado · descarga pública en preparación";
+  const audit = getPublicResourceMasterAudit(resource.id);
+  if (audit?.status === "blocked") return "Lectura web disponible · PDF maestro retenido por auditoría";
+  if (audit?.status === "approved" && !publicResourceHostingGate.publicDownloadEnabled) {
+    return "Lectura web disponible · PDF maestro aprobado · hosting público pendiente";
   }
-  return "Lectura web disponible · descarga pública en preparación";
+  if (resource.delivery === "web-native-master-pending") {
+    return "Lectura web disponible · PDF maestro identificado · auditoría pública pendiente";
+  }
+  return "Lectura web disponible · descarga pública pendiente";
+}
+
+function getMasterNotice(resource: PublicResource) {
+  const audit = getPublicResourceMasterAudit(resource.id);
+  if (audit?.status === "blocked") {
+    return "El PDF maestro no se publica todavía porque requiere conciliación técnica/comercial. La lectura web gobernada sigue disponible.";
+  }
+  if (audit?.status === "pending") {
+    return "El maestro fue identificado, pero todavía debe pasar auditoría de contenido antes de habilitar una descarga pública.";
+  }
+  return null;
 }
 
 export default function LibraryPage() {
@@ -123,18 +140,22 @@ export default function LibraryPage() {
               <p>Cada recurso se conecta con el Product Master, una ruta agronómica, Casa & Jardín o una decisión concreta. El estado visible evita presentar como definitivo lo que todavía requiere validación o hosting público.</p>
             </div>
             <div className={styles.libraryGrid}>
-              {publicResources.map((resource) => (
-                <article className={styles.libraryCard} key={resource.id}>
-                  <div className={styles.resourceMeta}>
-                    <span className={styles.status}>{resource.statusLabel}</span>
-                    <small className={styles.delivery}>{getDeliveryLabel(resource)}</small>
-                  </div>
-                  <h3>{resource.title}</h3>
-                  <p>{resource.copy}</p>
-                  {resource.masterLabel ? <small className={styles.delivery}>Maestro: {resource.masterLabel}</small> : null}
-                  <Link href={resource.href}>{resource.cta} →</Link>
-                </article>
-              ))}
+              {publicResources.map((resource) => {
+                const masterNotice = getMasterNotice(resource);
+                return (
+                  <article className={styles.libraryCard} key={resource.id}>
+                    <div className={styles.resourceMeta}>
+                      <span className={styles.status}>{resource.statusLabel}</span>
+                      <small className={styles.delivery}>{getDeliveryLabel(resource)}</small>
+                    </div>
+                    <h3>{resource.title}</h3>
+                    <p>{resource.copy}</p>
+                    {resource.masterLabel ? <small className={styles.delivery}>Maestro: {resource.masterLabel}</small> : null}
+                    {masterNotice ? <small className={styles.delivery}>{masterNotice}</small> : null}
+                    <Link href={resource.href}>{resource.cta} →</Link>
+                  </article>
+                );
+              })}
             </div>
           </div>
         </section>

--- a/src/data/public-resource-master-audits.test.ts
+++ b/src/data/public-resource-master-audits.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { publicResources } from "./public-resources";
+import {
+  canPublishPublicResourceMaster,
+  getPublicResourceMasterAudit,
+  publicResourceMasterAudits,
+} from "./public-resource-master-audits";
+
+describe("public resource master audits", () => {
+  it("covers every resource that references a document master", () => {
+    const masterResources = publicResources.filter((resource) => resource.masterLabel);
+    expect(publicResourceMasterAudits).toHaveLength(masterResources.length);
+    expect(publicResourceMasterAudits.map((audit) => audit.resourceId).sort())
+      .toEqual(masterResources.map((resource) => resource.id).sort());
+  });
+
+  it("keeps the 10-page Wondergreen catalog blocked after Product Truth audit", () => {
+    const audit = getPublicResourceMasterAudit("wondergreen-product-master");
+    expect(audit?.status).toBe("blocked");
+    expect(audit?.auditedAt).toBe("2026-08-20");
+    expect(audit?.findings.join(" ")).toMatch(/Neem/i);
+    expect(audit?.findings.join(" ")).toMatch(/Beauveria/i);
+    expect(audit?.findings.join(" ")).toMatch(/precios|descuentos/i);
+  });
+
+  it("keeps crop and Casa Jardin masters pending until each PDF is audited", () => {
+    for (const audit of publicResourceMasterAudits.filter((item) => item.resourceId !== "wondergreen-product-master")) {
+      expect(audit.status).toBe("pending");
+      expect(audit.findings.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("cannot publish any master while content or hosting gates remain open", () => {
+    for (const resource of publicResources.filter((item) => item.masterLabel)) {
+      expect(canPublishPublicResourceMaster(resource)).toBe(false);
+    }
+  });
+});

--- a/src/data/public-resource-master-audits.ts
+++ b/src/data/public-resource-master-audits.ts
@@ -1,0 +1,50 @@
+import { publicResourceHostingGate, publicResources, type PublicResource } from "./public-resources";
+
+export type PublicResourceMasterAuditStatus = "pending" | "blocked" | "approved";
+
+export type PublicResourceMasterAudit = {
+  resourceId: string;
+  status: PublicResourceMasterAuditStatus;
+  authority: string;
+  auditedAt?: string;
+  findings: readonly string[];
+};
+
+const defaultPendingAudit = (resource: PublicResource): PublicResourceMasterAudit => ({
+  resourceId: resource.id,
+  status: "pending",
+  authority: "Auditoría pública pendiente",
+  findings: [
+    "El maestro está identificado, pero todavía debe conciliar contenido, presentación y destino público antes de habilitar descarga.",
+  ],
+});
+
+const catalogAudit: PublicResourceMasterAudit = {
+  resourceId: "wondergreen-product-master",
+  status: "blocked",
+  authority: "Auditoría visual del PDF vs. Wondergreen Product Truth",
+  auditedAt: "2026-08-20",
+  findings: [
+    "La página 9 publica usos y blancos concretos para Extracto de Neem, Extracto Ajo-Ají y Beauveria bassiana, mientras Product Truth exige no publicar blancos, uso o eficacia de esos bioinsumos hasta reconciliar ficha y condición regulatoria.",
+    "La página 10 incorpora precios por presentación y una política de descuentos; antes de publicar el PDF completo, esos valores y reglas deben tener aprobación comercial de publicación para la versión vigente.",
+    "El PDF permanece como maestro interno de trabajo; no se crea enlace público mientras exista cualquiera de estos bloqueos.",
+  ],
+};
+
+export const publicResourceMasterAudits: readonly PublicResourceMasterAudit[] = publicResources
+  .filter((resource) => Boolean(resource.masterLabel))
+  .map((resource) => resource.id === catalogAudit.resourceId ? catalogAudit : defaultPendingAudit(resource));
+
+export function getPublicResourceMasterAudit(resourceId: string) {
+  return publicResourceMasterAudits.find((audit) => audit.resourceId === resourceId);
+}
+
+export function canPublishPublicResourceMaster(resource: PublicResource) {
+  if (!resource.masterLabel) return false;
+  const audit = getPublicResourceMasterAudit(resource.id);
+  return Boolean(
+    audit?.status === "approved"
+    && publicResourceHostingGate.publicDownloadEnabled
+    && !publicResourceHostingGate.privateSourceLinksAllowed,
+  );
+}


### PR DESCRIPTION
## Objetivo
Evitar que localizar un PDF maestro en SharePoint se interprete como autorización para publicarlo, añadiendo una auditoría explícita de contenido antes del gate de hosting.

## Cambios
- añade estados de auditoría `pending`, `blocked` y `approved` para todo recurso con maestro documental;
- todos los maestros identificados entran automáticamente en auditoría;
- el catálogo Wondergreen optimizado de 10 páginas queda `blocked` tras auditoría visual contra Product Truth;
- hallazgo principal: la página 9 publica usos/blancos concretos para Neem, Ajo-Ají y Beauveria mientras Product Truth exige reconciliar ficha y condición regulatoria antes de publicar ese tipo de afirmaciones;
- la página 10 también requiere aprobación comercial de publicación de precios/política de descuentos para su versión vigente;
- `canPublishPublicResourceMaster` exige auditoría aprobada + hosting público habilitado;
- la Biblioteca diferencia públicamente `auditoría pendiente` de `PDF maestro retenido por auditoría`, manteniendo disponible la lectura web gobernada;
- no se expone ninguna URL privada de SharePoint/Graph ni se crea enlace público.

## Guardrails
- no modifica Product Truth ni Crop Truth;
- no publica el PDF auditado;
- no crea enlaces anónimos ni cambia permisos de SharePoint;
- no habilita descargas públicas;
- no toca ecommerce, precios B2C, checkout, `main` ni backend operativo.

## Base
Parte de `develop` en `6317f0abee8c8fb44fc33a878d29e22562337412` y está 3 commits adelante / 0 detrás.

## Gate
Merge únicamente con CI final 4/4 verde sobre la cabeza exacta.