### PR TITLE
feat(public): completar Casa y Jardín en footer compartido

### DIFF
--- a/e2e/public-shell-seo.spec.ts
+++ b/e2e/public-shell-seo.spec.ts
@@ -12,6 +12,7 @@ const shellRoutes = [
 test("public home uses the shared navigation and real routes", async ({ page }) => {
   await page.goto("/");
   const header = page.getByRole("banner");
+  const footer = page.getByRole("contentinfo");
   const nav = header.getByRole("navigation", { name: "Navegación pública" });
   await expect(nav).toBeVisible();
   await expect(nav.getByRole("link", { name: "Soluciones" })).toHaveAttribute("href", "/soluciones");
@@ -21,6 +22,7 @@ test("public home uses the shared navigation and real routes", async ({ page }) 
   await expect(nav.getByRole("link", { name: "Impacto" })).toHaveAttribute("href", "/impacto");
   await expect(header.getByRole("link", { name: "Contacto" })).toHaveAttribute("href", "/contacto");
   await expect(header.getByRole("link", { name: "Acceder a Greenatics" })).toHaveAttribute("href", "/app");
+  await expect(footer.getByRole("link", { name: "Casa y Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
 });
 
 test("Casa y Jardín is functional but remains non-indexed until B2C validation closes", async ({ page }) => {
@@ -40,16 +42,19 @@ test("nested public routes inherit the same shell", async ({ page }) => {
   await expect(header.getByRole("navigation", { name: "Navegación pública" })).toBeVisible();
   await expect(page.getByRole("heading", { name: /Diagnóstico y caracterización/i })).toBeVisible();
   await expect(footer.getByText(/Centro Empresarial Alcalá/)).toBeVisible();
+  await expect(footer.getByRole("link", { name: "Casa y Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
   await expect(footer.getByRole("link", { name: "GREENATICS OPS" })).toHaveAttribute("href", "/app");
 });
 
 test("every governed public route renders exactly one shared shell", async ({ page }) => {
   for (const route of shellRoutes) {
     await page.goto(route);
+    const footer = page.getByRole("contentinfo");
     await expect(page.locator("header"), `${route} should have one header`).toHaveCount(1);
     await expect(page.locator("footer"), `${route} should have one footer`).toHaveCount(1);
     await expect(page.getByRole("navigation", { name: "Navegación pública" }), `${route} should expose the shared navigation`).toBeVisible();
-    await expect(page.getByRole("contentinfo").getByRole("link", { name: "GREENATICS OPS" }), `${route} should expose the OPS bridge`).toHaveAttribute("href", "/app");
+    await expect(footer.getByRole("link", { name: "Casa y Jardín", exact: true }), `${route} should expose the household route in the shared footer`).toHaveAttribute("href", "/casa-jardin");
+    await expect(footer.getByRole("link", { name: "GREENATICS OPS" }), `${route} should expose the OPS bridge`).toHaveAttribute("href", "/app");
   }
 });
 

--- a/src/data/public-site.ts
+++ b/src/data/public-site.ts
@@ -39,6 +39,7 @@ export const publicFooterNav = [
     title: "Agro",
     links: [
       { href: "/wondergreen", label: "Wondergreen" },
+      { href: "/casa-jardin", label: "Casa y Jardín" },
       { href: "/wondergreen/productos", label: "Productos" },
       { href: "/wondergreen/cultivos", label: "Cultivos" },
       { href: "/biblioteca/manual-uso-wondergreen", label: "Manual de uso" },


### PR DESCRIPTION
## Objetivo
Cerrar la inconsistencia de descubrimiento de Casa & Jardín en la navegación pública persistente: ya existe en header, HOME y Wondergreen, pero faltaba en el footer compartido.

## Cambios
- añade `Casa y Jardín` al grupo Agro del footer con ruta `/casa-jardin`;
- extiende el contrato E2E del shell para exigir esa entrada en HOME, una ruta anidada y todas las rutas públicas gobernadas;
- conserva el contrato existente que mantiene Casa & Jardín fuera del sitemap y con `noindex` mientras los gates B2C sigan abiertos.

## Guardrails
- no cambia `publicStaticRoutes` ni `publicReservedRoutes`;
- no habilita indexación, precios, checkout, dosis ni ecommerce;
- no modifica Product Truth, Crop Truth ni auditoría documental;
- no toca `main` ni backend operativo.

## Base
Parte de `develop` en `f6e7ca54eeb831a6cdd9da7380ec0a3ae8047ee4` y está 2 commits adelante / 0 detrás.

## Gate
Merge únicamente con CI final 4/4 verde sobre la cabeza exacta.