### PR TITLE
feat(home-garden): integrar visuales reales y catálogo Wondergreen

### DIFF
--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from "@playwright/test";
 
-test("Casa Jardín and Vivero exposes stage system without price or checkout", async ({ page }) => {
+test("Casa Jardín and Vivero exposes stage system with real Wondergreen visuals and without checkout", async ({ page }) => {
   await page.goto("/casa-jardin");
+
+  await expect(page.getByRole("img", { name: /Sistema Wondergreen por etapas/i })).toHaveAttribute("src", "/api/public-media/wondergreen-system-stages");
+  await expect(page.getByRole("link", { name: /Descargar catálogo Wondergreen/i })).toHaveAttribute("href", "/api/public-resources/wondergreen-product-master");
 
   for (const [name, formula] of [
     ["CRECE", "15-3-3"],
@@ -13,6 +16,15 @@ test("Casa Jardín and Vivero exposes stage system without price or checkout", a
     await expect(page.getByText(formula, { exact: true }).first()).toBeVisible();
   }
   await expect(page.getByText("COMPOST", { exact: true }).first()).toBeVisible();
+
+  for (const [alt, src] of [
+    [/Línea Wondergreen 2Grow/i, "/api/public-media/wondergreen-2grow"],
+    [/Línea Wondergreen 2Balance/i, "/api/public-media/wondergreen-2balance"],
+    [/Línea Wondergreen 2Bloom/i, "/api/public-media/wondergreen-2bloom"],
+    [/Línea Wondergreen 2Fruit/i, "/api/public-media/wondergreen-2fruit"],
+  ] as const) {
+    await expect(page.getByRole("img", { name: alt })).toHaveAttribute("src", src);
+  }
 
   for (const kit of ["Kit Plantas Verdes", "Kit Plantas con Flor", "Kit Mi Huerta", "Kit Casa Completa", "Casa Completa XL"]) {
     await expect(page.getByRole("heading", { name: kit, exact: true })).toBeVisible();
@@ -29,6 +41,7 @@ test("Casa Jardín and Vivero exposes stage system without price or checkout", a
   await expect(page.getByRole("heading", { name: "Kit Trasplanta & Arranca", exact: true })).toHaveCount(0);
   await expect(page.getByRole("link", { name: /Ver etapa y formatos propuestos/i }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: /Ver composición y ruta/i }).first()).toBeVisible();
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
 });
 
 test("Casa product detail exposes proposed household formats without making them commercial SKUs", async ({ page }) => {

--- a/src/app/casa-jardin/casa-jardin.module.css
+++ b/src/app/casa-jardin/casa-jardin.module.css
@@ -14,8 +14,8 @@
 
 .container { width: min(1180px, calc(100% - 40px)); margin: 0 auto; }
 .hero { position: relative; overflow: hidden; padding: 104px 0 88px; background: #f6f3e9; border-bottom: 1px solid var(--line); }
-.hero::after { content: ""; position: absolute; width: 420px; height: 420px; right: -120px; top: -170px; border: 1px solid rgba(47,125,50,.18); border-radius: 50%; }
-.heroGrid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(320px, .7fr); gap: 68px; align-items: center; }
+.hero::after { content: ""; position: absolute; width: 420px; height: 420px; right: -120px; top: -170px; border: 1px solid rgba(47,125,50,.18); border-radius: 50%; pointer-events: none; }
+.heroGrid { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(350px, .78fr); gap: 68px; align-items: center; }
 .eyebrow { display: inline-block; color: var(--green); font-size: .72rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
 .hero h1, .section h2, .card h3, .guideCard h3, .kitCard h3 { font-family: var(--display); font-weight: 600; }
 .hero h1 { max-width: 760px; margin: 18px 0 22px; font-size: clamp(3.6rem, 7vw, 6.7rem); line-height: .92; letter-spacing: -.045em; }
@@ -24,10 +24,10 @@
 .button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; padding: 0 18px; border: 1px solid var(--forest); font-weight: 800; text-decoration: none; }
 .primary { background: var(--forest); color: #fff; }
 .ghost { color: var(--forest); background: transparent; }
-.heroVisual { position: relative; min-height: 430px; display: grid; place-items: center; padding: 42px; background: var(--forest); overflow: hidden; }
-.heroVisual::before { content: "4 ETAPAS. 1 SISTEMA."; position: absolute; inset: auto 28px 26px; color: #dceac0; font-size: .72rem; font-weight: 900; letter-spacing: .12em; }
-.heroVisual img { width: min(100%, 360px); height: auto; object-fit: contain; filter: drop-shadow(0 16px 26px rgba(0,0,0,.22)); }
-.heroNote { position: absolute; top: 25px; left: 26px; right: 26px; color: #d5e2dc; line-height: 1.55; font-size: .82rem; }
+.heroVisual { position: relative; min-height: 500px; display: grid; place-items: center; padding: 64px 34px 30px; background: var(--forest); overflow: hidden; box-shadow: 0 34px 80px rgba(6,61,44,.18); }
+.heroVisual::before { content: "4 ETAPAS. 1 SISTEMA."; position: absolute; inset: auto 28px 22px; z-index: 2; color: #dceac0; font-size: .7rem; font-weight: 900; letter-spacing: .12em; }
+.heroVisualLabel { position: absolute; z-index: 2; top: 22px; left: 24px; right: 24px; color: #e3eddc; font-size: .78rem; font-weight: 800; letter-spacing: .04em; }
+.heroSystemImage { width: min(100%, 365px); height: auto; display: block; border: 1px solid rgba(255,255,255,.18); box-shadow: 0 18px 36px rgba(0,0,0,.2); }
 
 .path { background: var(--forest); color: #fff; }
 .pathGrid { display: grid; grid-template-columns: repeat(5, 1fr); border-left: 1px solid rgba(255,255,255,.16); }
@@ -44,8 +44,15 @@
 .sectionHead p { margin: 0; color: var(--muted); line-height: 1.7; }
 
 .productGrid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
-.card { min-height: 360px; display: flex; flex-direction: column; padding: 26px 22px; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: #fff; }
-.stageBar { height: 7px; margin: -26px -22px 24px; background: var(--stage); }
+.card { min-height: 390px; display: flex; flex-direction: column; padding: 26px 22px; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: #fff; overflow: hidden; }
+.cardWithVisual { min-height: 650px; }
+.stageBar { height: 7px; flex: 0 0 auto; margin: -26px -22px 24px; background: var(--stage); }
+.productVisual { position: relative; margin: 0 -8px 22px; aspect-ratio: 760/1074; overflow: hidden; background: #f6f3e9; border: 1px solid var(--line); }
+.productVisual img { width: 100%; height: 100%; display: block; object-fit: cover; object-position: top center; }
+.compostVisual { min-height: 255px; margin: 0 -8px 22px; padding: 28px 20px; display: flex; flex-direction: column; justify-content: end; gap: 8px; background: linear-gradient(160deg,#eadfc8,#f8f4ea 58%,#d8e7cc); border: 1px solid var(--line); }
+.compostVisual span { color: #8b6d46; font-size: 3.8rem; line-height: .8; font-family: var(--display); }
+.compostVisual strong { color: #5f492f; font-size: 1.5rem; letter-spacing: .06em; }
+.compostVisual small { color: #745f45; line-height: 1.4; }
 .card small { color: var(--muted); font-weight: 800; text-transform: uppercase; letter-spacing: .08em; }
 .card h3 { margin: 12px 0 4px; font-size: 2rem; }
 .formula { color: var(--green); font-size: .9rem; font-weight: 900; }
@@ -82,6 +89,9 @@
 .guideCard { min-height: 270px; display: flex; flex-direction: column; }
 .guideCard span { color: var(--green); font-size: .72rem; font-weight: 900; text-transform: uppercase; letter-spacing: .08em; }
 .guideCard a { margin-top: auto; color: var(--forest); font-weight: 800; }
+.catalogGuideCard { background: var(--forest); color: #fff; }
+.catalogGuideCard span, .catalogGuideCard a { color: #d9ed9e; }
+.catalogGuideCard p { color: #c4d4cc; }
 
 .faq { display: grid; border-top: 1px solid var(--line); }
 .faq details { padding: 22px 0; border-bottom: 1px solid var(--line); }
@@ -99,16 +109,18 @@
 
 @media (max-width: 820px) {
   .heroGrid, .sectionHead, .releaseGrid { grid-template-columns: 1fr; }
-  .heroVisual { min-height: 330px; }
+  .heroVisual { min-height: 500px; }
   .pathGrid { grid-template-columns: repeat(2, 1fr); }
   .productGrid, .decisionGrid, .kitGrid, .trafficGrid, .guideGrid, .flow { grid-template-columns: 1fr; }
-  .card, .kitCard { min-height: auto; }
+  .card, .cardWithVisual, .kitCard { min-height: auto; }
+  .productVisual { max-width: 420px; width: 100%; margin-left: auto; margin-right: auto; }
 }
 
 @media (max-width: 560px) {
   .container { width: min(100% - 28px, 1180px); }
   .hero { padding: 78px 0 62px; }
   .hero h1 { font-size: clamp(3rem, 16vw, 4.5rem); }
+  .heroVisual { min-height: 450px; padding-inline: 20px; }
   .section { padding: 72px 0; }
   .pathGrid { grid-template-columns: 1fr; }
   .actions { flex-direction: column; }

--- a/src/app/casa-jardin/page.tsx
+++ b/src/app/casa-jardin/page.tsx
@@ -32,6 +32,13 @@ const plantQuestions = [
   ["Vas a preparar o recuperar sustrato", "COMPOST", "Materia orgánica + acondicionamiento"],
 ] as const;
 
+const stageVisuals: Record<string, { src: string; alt: string }> = {
+  crece: { src: "/api/public-media/wondergreen-2grow", alt: "Línea Wondergreen 2Grow para crecimiento y recuperación" },
+  equilibra: { src: "/api/public-media/wondergreen-2balance", alt: "Línea Wondergreen 2Balance para equilibrio y mantenimiento" },
+  florece: { src: "/api/public-media/wondergreen-2bloom", alt: "Línea Wondergreen 2Bloom para prefloración y floración" },
+  fructifica: { src: "/api/public-media/wondergreen-2fruit", alt: "Línea Wondergreen 2Fruit para llenado y maduración" },
+};
+
 export default function CasaJardinPage() {
   return (
     <div className={styles.page}>
@@ -41,15 +48,16 @@ export default function CasaJardinPage() {
             <div>
               <span className={styles.eyebrow}>Wondergreen · Casa, jardín y vivero</span>
               <h1>Nutrición por etapas para tus plantas.</h1>
-              <p className={styles.lead}>Tu planta cambia. Su nutrición también. Observa qué está haciendo, identifica su condición y elige solo la etapa que necesita. La propuesta Casa & Jardín lleva la lógica Wondergreen a hogares, huertas, jardines y viveros sin convertir la fertilización en una receta automática.</p>
+              <p className={styles.lead}>Tu planta cambia. Su nutrición también. Observa qué está haciendo, identifica su condición y elige la etapa que necesita. Casa & Jardín lleva la lógica Wondergreen a hogares, huertas, jardines y viveros con una ruta simple: suelo, crecimiento, equilibrio, floración y fruto.</p>
               <div className={styles.actions}>
                 <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Encontrar un punto de partida</Link>
-                <a className={`${styles.button} ${styles.ghost}`} href="#kits">Explorar kits</a>
+                <a className={`${styles.button} ${styles.ghost}`} href="#etapas">Ver las etapas</a>
+                <a className={`${styles.button} ${styles.ghost}`} href="/api/public-resources/wondergreen-product-master" target="_blank" rel="noreferrer">Descargar catálogo Wondergreen ↓</a>
               </div>
             </div>
             <aside className={styles.heroVisual}>
-              <p className={styles.heroNote}>No apliques todo. Aplica lo que necesita. La identidad técnica sigue en Wondergreen; Greenatics aporta el sistema circular, el conocimiento y el soporte.</p>
-              <Image src="/brand/wondergreen-nutrients.webp" width={720} height={310} alt="Logotipo oficial de Wondergreen Nutrients" priority />
+              <div className={styles.heroVisualLabel}>El sistema Wondergreen, de un vistazo.</div>
+              <Image className={styles.heroSystemImage} src="/api/public-media/wondergreen-system-stages" width={760} height={1074} alt="Sistema Wondergreen por etapas: compost, 2Grow, 2Balance, 2Bloom, 2Fruit y bioinsumos" priority unoptimized />
             </aside>
           </div>
         </section>
@@ -64,20 +72,32 @@ export default function CasaJardinPage() {
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>4 etapas + suelo</span><h2>No necesita más. Necesita lo correcto.</h2></div>
-              <p>CRECE, EQUILIBRA, FLORECE y FRUCTIFICA son nombres de uso doméstico para referencias sólidas Wondergreen ya existentes. COMPOST prepara y acondiciona el sistema de suelo. Los formatos B2C del handoff se muestran como propuestas, no como inventario comprable.</p>
+              <p>CRECE, EQUILIBRA, FLORECE y FRUCTIFICA traducen para uso doméstico cuatro referencias sólidas Wondergreen ya existentes. COMPOST prepara y acondiciona el sistema de suelo. Aquí puedes conocer el sistema y sus formatos propuestos antes de que la tienda esté activa.</p>
             </div>
             <div className={styles.productGrid}>
-              {homeGardenProducts.map((product) => (
-                <article className={`${styles.card} ${styles[product.accent]}`} key={product.id}>
-                  <div className={styles.stageBar} aria-hidden="true" />
-                  <small>{product.id === "prepara" ? "Base del sistema" : "Etapa nutricional"}</small>
-                  <h3>{product.consumerName}</h3>
-                  <span className={styles.formula}>{product.formula ?? "Compost"}</span>
-                  <p>{product.role}</p>
-                  <p><strong>{product.prompt}</strong></p>
-                  <Link href={`/casa-jardin/productos/${product.id}`}>Ver etapa y formatos propuestos →</Link>
-                </article>
-              ))}
+              {homeGardenProducts.map((product) => {
+                const visual = stageVisuals[product.id];
+                return (
+                  <article className={`${styles.card} ${styles[product.accent]} ${visual ? styles.cardWithVisual : ""}`} key={product.id}>
+                    <div className={styles.stageBar} aria-hidden="true" />
+                    {visual ? (
+                      <div className={styles.productVisual}>
+                        <Image src={visual.src} width={760} height={1074} alt={visual.alt} sizes="(max-width: 820px) 88vw, (max-width: 1100px) 30vw, 18vw" unoptimized />
+                      </div>
+                    ) : (
+                      <div className={styles.compostVisual} aria-label="Compost como base del sistema">
+                        <span>01</span><strong>COMPOST</strong><small>Suelo · materia orgánica · acondicionamiento</small>
+                      </div>
+                    )}
+                    <small>{product.id === "prepara" ? "Base del sistema" : "Etapa nutricional"}</small>
+                    <h3>{product.consumerName}</h3>
+                    <span className={styles.formula}>{product.formula ?? "Compost"}</span>
+                    <p>{product.role}</p>
+                    <p><strong>{product.prompt}</strong></p>
+                    <Link href={`/casa-jardin/productos/${product.id}`}>Ver etapa y formatos propuestos →</Link>
+                  </article>
+                );
+              })}
             </div>
           </div>
         </section>
@@ -159,17 +179,23 @@ export default function CasaJardinPage() {
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>Conocimiento práctico</span><h2>Guías para mirar mejor antes de decidir.</h2></div>
-              <p>El handoff incluye guías maestras de Casa & Jardín, Mi Huerta, etapas y trasplante. Las llevamos a una biblioteca navegable para que el PDF sea soporte, no el único lugar donde vive el conocimiento.</p>
+              <p>Casa & Jardín, Mi Huerta, etapas y trasplante ya están disponibles como lectura web. El catálogo general Wondergreen también puede descargarse completo desde esta página.</p>
             </div>
             <div className={styles.guideGrid}>
               {homeGardenGuides.map((guide) => (
                 <article className={styles.guideCard} key={guide.id}>
-                  <span>Guía del handoff</span>
+                  <span>Lectura web</span>
                   <h3>{guide.title}</h3>
                   <p>{guide.summary}</p>
                   <Link href={`/casa-jardin/guias#${guide.id}`}>Abrir guía →</Link>
                 </article>
               ))}
+              <article className={`${styles.guideCard} ${styles.catalogGuideCard}`}>
+                <span>PDF descargable</span>
+                <h3>Catálogo Wondergreen</h3>
+                <p>Consulta el sistema completo, organominerales, líquidos, bioinsumos, presentaciones y narrativa de las líneas Wondergreen.</p>
+                <a href="/api/public-resources/wondergreen-product-master" target="_blank" rel="noreferrer">Descargar catálogo PDF ↓</a>
+              </article>
             </div>
           </div>
         </section>

--- a/src/lib/sharepoint/public-resource-download.test.ts
+++ b/src/lib/sharepoint/public-resource-download.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { downloadPublicWondergreenPdf, getPublicWondergreenPdf, publicWondergreenPdfs } from "./public-resource-download";
+import {
+  downloadPublicWondergreenPdf,
+  getPublicWondergreenMedia,
+  getPublicWondergreenPdf,
+  publicWondergreenMedia,
+  publicWondergreenPdfs,
+} from "./public-resource-download";
 
 const env = {
   SHAREPOINT_SITE_HOSTNAME: "example.sharepoint.com",
@@ -11,8 +17,8 @@ const env = {
   SHAREPOINT_CLIENT_SECRET: "secret",
 };
 
-describe("public Wondergreen PDF proxy", () => {
-  it("exposes exactly the six explicitly approved resources", () => {
+describe("public Wondergreen resource proxy", () => {
+  it("exposes exactly the six explicitly approved PDFs", () => {
     expect(publicWondergreenPdfs.map((item) => item.id)).toEqual([
       "wondergreen-product-master",
       "wondergreen-guide-cafe",
@@ -24,7 +30,33 @@ describe("public Wondergreen PDF proxy", () => {
     expect(getPublicWondergreenPdf("home-garden-guide-green-plants")).toBeNull();
   });
 
-  it("returns null before auth for resources outside the allowlist", async () => {
+  it("registers the real Wondergreen visuals reused by Casa Jardin", () => {
+    for (const assetId of [
+      "wondergreen-system-stages",
+      "wondergreen-2grow",
+      "wondergreen-2balance",
+      "wondergreen-2bloom",
+      "wondergreen-2fruit",
+      "wondergreen-bioinsumos",
+    ]) {
+      const asset = getPublicWondergreenMedia(assetId);
+      expect(asset).not.toBeNull();
+      expect(asset?.contentType).toBe("image/webp");
+      expect(asset?.filename).toMatch(/\.webp$/);
+    }
+
+    expect(publicWondergreenMedia.map((item) => item.id)).toEqual(expect.arrayContaining([
+      "wondergreen-system-stages",
+      "wondergreen-2grow",
+      "wondergreen-2balance",
+      "wondergreen-2bloom",
+      "wondergreen-2fruit",
+      "wondergreen-bioinsumos",
+    ]));
+    expect(getPublicWondergreenMedia("unknown-home-garden-visual")).toBeNull();
+  });
+
+  it("returns null before auth for resources outside the PDF allowlist", async () => {
     const fetchImpl = vi.fn<typeof fetch>();
     await expect(downloadPublicWondergreenPdf("unknown", env, fetchImpl)).resolves.toBeNull();
     expect(fetchImpl).not.toHaveBeenCalled();

--- a/src/lib/sharepoint/public-resource-download.ts
+++ b/src/lib/sharepoint/public-resource-download.ts
@@ -15,7 +15,11 @@ export type PublicWondergreenMediaId =
   | "guia-aguacate-cover"
   | "guia-citricos-cover"
   | "guia-pastos-cover"
+  | "wondergreen-system-stages"
+  | "wondergreen-2grow"
+  | "wondergreen-2balance"
   | "wondergreen-2bloom"
+  | "wondergreen-2fruit"
   | "wondergreen-bioinsumos";
 
 type PublicGraphAsset<TId extends string> = Readonly<{
@@ -45,7 +49,11 @@ export const publicWondergreenMedia: readonly PublicGraphAsset<PublicWondergreen
   { id: "guia-aguacate-cover", itemId: "01VAJGQORJQCA46SIRKJBIXBDBFNVU3L4T", filename: "guia-aguacate-cover.webp", contentType: "image/webp" },
   { id: "guia-citricos-cover", itemId: "01VAJGQOSTVLT43UZJZNHJZ4NTLSIL24SG", filename: "guia-citricos-cover.webp", contentType: "image/webp" },
   { id: "guia-pastos-cover", itemId: "01VAJGQOQRG24OXXNDEZB2WQVPBUZYIX25", filename: "guia-pastos-cover.webp", contentType: "image/webp" },
+  { id: "wondergreen-system-stages", itemId: "01VAJGQOQGN5JPABJ6NBAJXR4PUSLSZGJJ", filename: "wondergreen-system-stages.webp", contentType: "image/webp" },
+  { id: "wondergreen-2grow", itemId: "01VAJGQOXLFZYZPDA7MFFJAF5MRQM7VGJQ", filename: "wondergreen-2grow.webp", contentType: "image/webp" },
+  { id: "wondergreen-2balance", itemId: "01VAJGQOQ4K7CZQDH77RCLX4BBI7MYTRWS", filename: "wondergreen-2balance.webp", contentType: "image/webp" },
   { id: "wondergreen-2bloom", itemId: "01VAJGQOTFHK6KH3Y7C5DJKBA5OULRMGHO", filename: "wondergreen-2bloom.webp", contentType: "image/webp" },
+  { id: "wondergreen-2fruit", itemId: "01VAJGQOUZYXMXQKDW6BAZFIUFO33MZKVL", filename: "wondergreen-2fruit.webp", contentType: "image/webp" },
   { id: "wondergreen-bioinsumos", itemId: "01VAJGQOUNL6KJ5VX3MBAYA3BP74SWZRQ2", filename: "wondergreen-bioinsumos.webp", contentType: "image/webp" },
 ]);
 


### PR DESCRIPTION
## Objetivo
Elevar Casa & Jardín con activos reales del catálogo Wondergreen ya publicado, sin inventar packshots ni habilitar ecommerce.

## Cambios
- incorpora el arte real del sistema Wondergreen por etapas en el hero de `/casa-jardin`;
- integra visuales reales de 2Grow, 2Balance, 2Bloom y 2Fruit en las cuatro etapas nutricionales;
- mantiene COMPOST con una representación editorial tipográfica, sin fabricar un packshot inexistente;
- añade acceso directo al catálogo Wondergreen PDF ya publicado;
- añade una card de catálogo dentro de la sección de guías;
- amplía el allowlist del proxy público de medios con cuatro WebP nuevos almacenados en `WEB_PUBLICA_ASSETS`;
- actualiza E2E para exigir los assets exactos y conservar noindex, sin precios ni checkout;
- amplía pruebas unitarias del allowlist visual.

## PDFs Casa & Jardín
Se buscaron los cuatro maestros del handoff en SharePoint y File Library y no se localizaron como binarios finales recuperables. No se sustituyen por documentos ajenos ni se inventan descargas. Las cuatro guías continúan disponibles como lectura web y podrán conectarse al proxy en cuanto reaparezcan sus PDFs exactos.

## Guardrails
- `/casa-jardin` sigue `noindex`;
- sin precios públicos;
- sin checkout;
- sin links privados de SharePoint/Graph en HTML;
- no cambia Product Truth, RLS ni módulos OPS.

## Gate
Merge únicamente con CI final 4/4 verde sobre la cabeza exacta, branch 0 behind y 0 review threads pendientes.