### PR TITLE
feat(wondergreen): reforzar portafolio con visuales reales

### DIFF
--- a/e2e/wondergreen-visual-band.spec.ts
+++ b/e2e/wondergreen-visual-band.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+const expectedVisuals = [
+  ["Línea Wondergreen 2Grow", "/api/public-media/wondergreen-2grow"],
+  ["Línea Wondergreen 2Balance", "/api/public-media/wondergreen-2balance"],
+  ["Línea Wondergreen 2Bloom", "/api/public-media/wondergreen-2bloom"],
+  ["Línea Wondergreen 2Fruit", "/api/public-media/wondergreen-2fruit"],
+] as const;
+
+async function expectWondergreenVisualBand(page: import("@playwright/test").Page) {
+  await expect(page.getByRole("heading", { name: "Del suelo a cada etapa de la planta." })).toBeVisible();
+  await expect(page.getByRole("img", { name: "Sistema Wondergreen por etapas", exact: true })).toHaveAttribute("src", "/api/public-media/wondergreen-system-stages");
+  await expect(page.getByRole("img", { name: "Bioinsumos Wondergreen", exact: true })).toHaveAttribute("src", "/api/public-media/wondergreen-bioinsumos");
+
+  for (const [alt, src] of expectedVisuals) {
+    await expect(page.getByRole("img", { name: alt, exact: true })).toHaveAttribute("src", src);
+  }
+
+  await expect(page.getByRole("link", { name: /Descargar catálogo PDF/i })).toHaveAttribute("href", "/api/public-resources/wondergreen-product-master");
+  await expect(page.getByRole("link", { name: "Ver Product Master →", exact: true })).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(page.getByRole("link", { name: "Casa & Jardín →", exact: true })).toHaveAttribute("href", "/casa-jardin");
+}
+
+test("Wondergreen landing closes with the real visual product system", async ({ page }) => {
+  await page.goto("/wondergreen");
+  await expectWondergreenVisualBand(page);
+});
+
+test("Wondergreen product pages retain the shared visual catalogue band", async ({ page }) => {
+  await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
+  await expectWondergreenVisualBand(page);
+});

--- a/src/app/wondergreen/layout.tsx
+++ b/src/app/wondergreen/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+import { WondergreenVisualBand } from "@/components/wondergreen-visual-band";
 import { publicSocialMetadata } from "@/lib/public-social-metadata";
 
 const social = publicSocialMetadata({
@@ -13,5 +14,10 @@ export const metadata: Metadata = {
 };
 
 export default function WondergreenLayout({ children }: { children: React.ReactNode }) {
-  return <PublicShell ownsMain={false}>{children}</PublicShell>;
+  return (
+    <PublicShell ownsMain={false}>
+      {children}
+      <WondergreenVisualBand />
+    </PublicShell>
+  );
 }

--- a/src/components/wondergreen-visual-band.module.css
+++ b/src/components/wondergreen-visual-band.module.css
@@ -1,0 +1,250 @@
+.section {
+  --forest: #063d2c;
+  --green: #2f7d32;
+  --lime: #8cbd42;
+  --cream: #f5f1e5;
+  --paper: #fafbf7;
+  --muted: #607168;
+  --line: rgba(6, 61, 44, .15);
+  padding: 104px 0;
+  background: var(--cream);
+  color: #18372d;
+  border-top: 1px solid var(--line);
+}
+
+.container {
+  width: min(1220px, calc(100% - 48px));
+  margin: 0 auto;
+}
+
+.heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, .58fr);
+  gap: 56px;
+  align-items: end;
+  margin-bottom: 42px;
+}
+
+.eyebrow {
+  display: inline-block;
+  margin-bottom: 12px;
+  color: var(--green);
+  font-size: .7rem;
+  font-weight: 900;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.heading h2 {
+  max-width: 720px;
+  margin: 0;
+  font-family: var(--display), Georgia, serif;
+  font-size: clamp(2.8rem, 5vw, 5.2rem);
+  font-weight: 600;
+  line-height: .96;
+  letter-spacing: -.04em;
+}
+
+.heading p,
+.systemCopy p,
+.bioCopy p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.systemGrid {
+  display: grid;
+  grid-template-columns: minmax(320px, .7fr) minmax(0, 1.3fr);
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+}
+
+.systemVisual {
+  margin: 0;
+  padding: 28px;
+  background: var(--forest);
+}
+
+.systemVisual img {
+  display: block;
+  width: min(100%, 390px);
+  height: auto;
+  margin: 0 auto;
+  border: 1px solid rgba(255, 255, 255, .16);
+  box-shadow: 0 22px 50px rgba(0, 0, 0, .22);
+}
+
+.systemVisual figcaption {
+  margin-top: 20px;
+  color: #d9e6de;
+  font-size: .72rem;
+  font-weight: 800;
+  letter-spacing: .05em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.systemCopy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 56px;
+  background: var(--paper);
+}
+
+.number {
+  color: var(--green);
+  font-size: .72rem;
+  font-weight: 900;
+  letter-spacing: .1em;
+}
+
+.systemCopy h3,
+.bioCopy h3 {
+  max-width: 690px;
+  margin: 18px 0 12px;
+  font-family: var(--display), Georgia, serif;
+  font-size: clamp(2rem, 3.6vw, 4rem);
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -.035em;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  align-items: center;
+  margin-top: 24px;
+}
+
+.actions a {
+  color: var(--forest);
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.actions a:focus-visible {
+  outline: 3px solid #f4d944;
+  outline-offset: 4px;
+}
+
+.primary {
+  display: inline-flex;
+  min-height: 46px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
+  background: var(--forest);
+  color: #fff !important;
+}
+
+.productGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  margin-top: 42px;
+  background: var(--line);
+  border: 1px solid var(--line);
+}
+
+.productCard {
+  background: #fff;
+}
+
+.productImage {
+  aspect-ratio: 760 / 1074;
+  overflow: hidden;
+  background: #f3f0e7;
+}
+
+.productImage img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top center;
+}
+
+.productMeta {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: baseline;
+  padding: 18px 20px 20px;
+}
+
+.productMeta span {
+  color: var(--green);
+  font-size: .68rem;
+  font-weight: 900;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+.productMeta strong {
+  font-family: var(--display), Georgia, serif;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.bioGrid {
+  display: grid;
+  grid-template-columns: minmax(280px, .72fr) minmax(0, 1.28fr);
+  gap: 1px;
+  margin-top: 42px;
+  background: rgba(255, 255, 255, .18);
+  border: 1px solid rgba(255, 255, 255, .14);
+}
+
+.bioVisual {
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  background: #163e31;
+}
+
+.bioVisual img {
+  width: min(100%, 350px);
+  height: auto;
+  display: block;
+  box-shadow: 0 18px 46px rgba(0, 0, 0, .22);
+}
+
+.bioCopy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 52px;
+  background: #e8f1e2;
+}
+
+@media (max-width: 920px) {
+  .heading,
+  .systemGrid,
+  .bioGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .productGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .systemCopy,
+  .bioCopy {
+    padding: 38px;
+  }
+}
+
+@media (max-width: 620px) {
+  .section { padding: 76px 0; }
+  .container { width: min(100% - 28px, 1220px); }
+  .productGrid { grid-template-columns: 1fr; }
+  .systemVisual,
+  .bioVisual { padding: 20px; }
+  .systemCopy,
+  .bioCopy { padding: 30px 24px; }
+  .actions { align-items: stretch; }
+  .actions a { width: 100%; }
+}

--- a/src/components/wondergreen-visual-band.tsx
+++ b/src/components/wondergreen-visual-band.tsx
@@ -1,0 +1,100 @@
+import Image from "next/image";
+import Link from "next/link";
+import styles from "./wondergreen-visual-band.module.css";
+
+const productVisuals = [
+  { id: "2Grow", stage: "Crece", src: "/api/public-media/wondergreen-2grow", alt: "Línea Wondergreen 2Grow" },
+  { id: "2Balance", stage: "Equilibra", src: "/api/public-media/wondergreen-2balance", alt: "Línea Wondergreen 2Balance" },
+  { id: "2Bloom", stage: "Florece", src: "/api/public-media/wondergreen-2bloom", alt: "Línea Wondergreen 2Bloom" },
+  { id: "2Fruit", stage: "Fructifica", src: "/api/public-media/wondergreen-2fruit", alt: "Línea Wondergreen 2Fruit" },
+] as const;
+
+export function WondergreenVisualBand() {
+  return (
+    <section className={styles.section} aria-labelledby="wondergreen-visual-band-title">
+      <div className={styles.container}>
+        <div className={styles.heading}>
+          <div>
+            <span className={styles.eyebrow}>Wondergreen · sistema visual</span>
+            <h2 id="wondergreen-visual-band-title">Del suelo a cada etapa de la planta.</h2>
+          </div>
+          <p>
+            Explora el sistema completo, conoce las líneas Wondergreen y lleva contigo el catálogo y las guías técnicas.
+          </p>
+        </div>
+
+        <div className={styles.systemGrid}>
+          <figure className={styles.systemVisual}>
+            <Image
+              src="/api/public-media/wondergreen-system-stages"
+              alt="Sistema Wondergreen por etapas"
+              width={760}
+              height={1074}
+              sizes="(max-width: 860px) 88vw, 390px"
+              unoptimized
+            />
+            <figcaption>Suelo · crecimiento · equilibrio · floración · fruto · biología</figcaption>
+          </figure>
+
+          <div className={styles.systemCopy}>
+            <span className={styles.number}>01—05</span>
+            <h3>Un portafolio que se entiende por función y etapa.</h3>
+            <p>
+              Compost, fertilizantes organominerales, líneas líquidas y bioinsumos conviven dentro de un mismo sistema. La web permite entrar por cultivo, por producto o por necesidad.
+            </p>
+            <div className={styles.actions}>
+              <a className={styles.primary} href="/api/public-resources/wondergreen-product-master" target="_blank" rel="noreferrer">
+                Descargar catálogo PDF ↓
+              </a>
+              <Link href="/wondergreen/productos">Ver Product Master →</Link>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.productGrid} aria-label="Líneas organominerales Wondergreen">
+          {productVisuals.map((product) => (
+            <article className={styles.productCard} key={product.id}>
+              <div className={styles.productImage}>
+                <Image
+                  src={product.src}
+                  alt={product.alt}
+                  width={760}
+                  height={1074}
+                  sizes="(max-width: 620px) 84vw, (max-width: 980px) 42vw, 22vw"
+                  unoptimized
+                />
+              </div>
+              <div className={styles.productMeta}>
+                <span>{product.stage}</span>
+                <strong>{product.id}</strong>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className={styles.bioGrid}>
+          <div className={styles.bioVisual}>
+            <Image
+              src="/api/public-media/wondergreen-bioinsumos"
+              alt="Bioinsumos Wondergreen"
+              width={760}
+              height={1074}
+              sizes="(max-width: 760px) 88vw, 360px"
+              unoptimized
+            />
+          </div>
+          <div className={styles.bioCopy}>
+            <span className={styles.eyebrow}>Otra capa del manejo</span>
+            <h3>Bioinsumos Wondergreen.</h3>
+            <p>Microorganismos y extractos botánicos complementan el portafolio nutricional y amplían las rutas de manejo.</p>
+            <div className={styles.actions}>
+              <Link className={styles.primary} href="/wondergreen#bioinsumos">Explorar bioinsumos</Link>
+              <Link href="/biblioteca">Abrir Biblioteca →</Link>
+              <Link href="/casa-jardin">Casa & Jardín →</Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Objetivo
Dar protagonismo visual al portafolio Wondergreen usando los activos reales ya publicados, sin reescribir la arquitectura de contenido ni duplicar la Biblioteca.

## Cambios
- añade una franja visual compartida en el layout Wondergreen;
- muestra el sistema Wondergreen por etapas;
- muestra 2Grow, 2Balance, 2Bloom y 2Fruit con artes reales del catálogo;
- integra el visual de Bioinsumos Wondergreen;
- añade CTA directo para descargar el catálogo PDF;
- conecta Product Master, Biblioteca y Casa & Jardín;
- la franja aparece en landing, cultivos y fichas de producto para reforzar coherencia de marca;
- añade E2E específico para landing y ficha 2Grow.

## Guardrails
- usa únicamente `/api/public-media/*` y `/api/public-resources/*` same-origin;
- no expone SharePoint/Graph;
- no cambia precios, checkout, RLS, Product Truth ni Crop Truth;
- no toca `main`.

## Gate
Merge únicamente con CI final 4/4 verde, branch 0 behind y 0 review threads pendientes.