### PR TITLE
feat(home-garden): publicar cuatro guías Casa y Jardín

### DIFF
--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -109,12 +109,24 @@ test("extremely dry substrate stays in review instead of recommending fertilizer
   await expect(page.getByRole("link", { name: "Abrir siguiente paso →" })).toHaveCount(0);
 });
 
-test("Casa guide library exposes handoff sources without broken download links", async ({ page }) => {
+test("Casa guide library publishes four reconstructed same-origin PDFs", async ({ page }) => {
   await page.goto("/casa-jardin/guias");
 
   for (const guide of ["Guía Wondergreen Casa & Jardín", "Guía Mi Huerta", "Guía rápida de etapas", "Guía de trasplante"]) {
     await expect(page.getByRole("heading", { name: guide, exact: true })).toBeVisible();
   }
-  await expect(page.getByRole("link", { name: /Descargar PDF/i })).toHaveCount(0);
-  await expect(page.getByText(/PDF fuente validado en el handoff/i).first()).toBeVisible();
+
+  const downloads = page.getByRole("link", { name: "Descargar PDF →", exact: true });
+  await expect(downloads).toHaveCount(4);
+  const hrefs = await downloads.evaluateAll((links) => links.map((link) => link.getAttribute("href") ?? ""));
+  expect(hrefs.sort()).toEqual([
+    "/api/public-resources/home-garden-guide-casa-jardin",
+    "/api/public-resources/home-garden-guide-etapas",
+    "/api/public-resources/home-garden-guide-mi-huerta",
+    "/api/public-resources/home-garden-guide-trasplante",
+  ]);
+  expect(hrefs.join(" ")).not.toMatch(/sharepoint|graph\.microsoft/i);
+  await expect(page.getByText(/Master público reconstruido y verificado/i).first()).toBeVisible();
+  await expect(page.getByText(/no se presenta como una copia byte a byte/i).first()).toBeVisible();
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
 });

--- a/e2e/public-library-home-garden.spec.ts
+++ b/e2e/public-library-home-garden.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test("central public library publishes Wondergreen PDFs without exposing private document links", async ({ page }) => {
+test("central public library publishes Wondergreen and Casa Jardin PDFs without exposing private document links", async ({ page }) => {
   await page.goto("/biblioteca");
 
   await expect(page.getByText("Tengo plantas en casa", { exact: true })).toBeVisible();
@@ -18,7 +18,12 @@ test("central public library publishes Wondergreen PDFs without exposing private
   const hrefs = await page.locator("a").evaluateAll((links) => links.map((link) => link.getAttribute("href") ?? ""));
   expect(hrefs.join(" ")).not.toMatch(/sharepoint|graph\.microsoft/i);
   expect(hrefs.filter((href) => href.startsWith("/api/public-resources/wondergreen-")).length).toBe(6);
+  expect(hrefs.filter((href) => href.startsWith("/api/public-resources/home-garden-guide-")).length).toBe(4);
 
-  const homeGardenCards = page.getByRole("article").filter({ hasText: "Casa & Jardín" });
-  await expect(homeGardenCards.first()).toContainText(/PDF maestro pendiente/i);
+  const homeGardenCards = page.getByRole("article").filter({ hasText: "master público reconstruido" });
+  await expect(homeGardenCards).toHaveCount(4);
+  for (const card of await homeGardenCards.all()) {
+    await expect(card).toContainText(/Lectura web \+ PDF disponible/i);
+    await expect(card.getByRole("link", { name: /Descargar guía PDF/i })).toHaveAttribute("href", /^\/api\/public-resources\/home-garden-guide-/);
+  }
 });

--- a/src/app/casa-jardin/guias/page.tsx
+++ b/src/app/casa-jardin/guias/page.tsx
@@ -17,6 +17,13 @@ const guideContent = {
   trasplante: ["Prioriza drenaje y estructura del sustrato.", "Manipula raíces con cuidado y evita sobrecompactar.", "Mantén humedad adecuada sin encharcar.", "Espera estabilidad antes de escoger una etapa nutricional.", "La guía es educativa; no habilita el Kit Trasplanta & Arranca bloqueado."],
 } as const;
 
+const guideDownloads: Record<string, string> = {
+  "casa-jardin": "/api/public-resources/home-garden-guide-casa-jardin",
+  "mi-huerta": "/api/public-resources/home-garden-guide-mi-huerta",
+  etapas: "/api/public-resources/home-garden-guide-etapas",
+  trasplante: "/api/public-resources/home-garden-guide-trasplante",
+};
+
 export default function CasaJardinGuiasPage() {
   return (
     <div className={styles.page}>
@@ -26,7 +33,7 @@ export default function CasaJardinGuiasPage() {
             <div>
               <span className={styles.eyebrow}>Wondergreen Casa & Jardín · biblioteca</span>
               <h1>Guías para observar antes de aplicar.</h1>
-              <p className={styles.lead}>El handoff de MKTG Studio incluye cuatro guías útiles para esta primera versión. Su conocimiento ya vive de forma navegable aquí; los binarios PDF se mantienen separados hasta completar su incorporación técnica al repositorio.</p>
+              <p className={styles.lead}>El conocimiento del handoff vive aquí de forma navegable y ahora se acompaña por cuatro masters públicos reconstruidos desde el contenido gobernado y los activos Wondergreen aprobados. La web sigue siendo la autoridad para límites, estados y actualizaciones.</p>
               <div className={styles.actions}><Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin">← Volver a Casa, Jardín y Vivero</Link></div>
             </div>
             <aside className={styles.heroVisual}><p className={styles.heroNote}>DEL PDF A CONTENIDO NAVEGABLE</p><strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>Conocimiento que acompaña la decisión.</strong></aside>
@@ -44,8 +51,11 @@ export default function CasaJardinGuiasPage() {
                 {guideContent[guide.id as keyof typeof guideContent].map((item, itemIndex) => <article className={styles.decisionCard} key={item}><span className={styles.eyebrow}>{String(itemIndex + 1).padStart(2, "0")}</span><p><strong>{item}</strong></p></article>)}
               </div>
               <div className={styles.guardrail}>
-                <strong>PDF fuente validado en el handoff.</strong>
-                <p>{guide.sourceFile} · El archivo optimizado ya fue extraído y revisado, pero la descarga web permanece deshabilitada hasta que el binario quede incorporado y verificado dentro del deploy.</p>
+                <strong>Master público reconstruido y verificado.</strong>
+                <p>El PDF descargable fue reconstruido desde este contenido gobernado y activos Wondergreen aprobados, renderizado y revisado antes de publicación. No se presenta como una copia byte a byte del binario histórico del handoff.</p>
+                <div className={styles.actions}>
+                  <a className={`${styles.button} ${styles.primary}`} href={guideDownloads[guide.id]} target="_blank" rel="noreferrer">Descargar PDF →</a>
+                </div>
               </div>
             </div>
           </section>

--- a/src/data/public-resource-master-audits.test.ts
+++ b/src/data/public-resource-master-audits.test.ts
@@ -6,7 +6,7 @@ import {
   publicResourceMasterAudits,
 } from "./public-resource-master-audits";
 
-const approvedIds = [
+const legacyApprovedIds = [
   "wondergreen-product-master",
   "wondergreen-guide-cafe",
   "wondergreen-guide-cacao",
@@ -14,6 +14,15 @@ const approvedIds = [
   "wondergreen-guide-limon-tahiti",
   "wondergreen-guide-pastos",
 ];
+
+const homeGardenApprovedIds = [
+  "home-garden-guide-casa-jardin",
+  "home-garden-guide-mi-huerta",
+  "home-garden-guide-etapas",
+  "home-garden-guide-trasplante",
+];
+
+const approvedIds = [...legacyApprovedIds, ...homeGardenApprovedIds];
 
 describe("public resource master audits", () => {
   it("covers every resource that references a document master", () => {
@@ -23,8 +32,8 @@ describe("public resource master audits", () => {
       .toEqual(masterResources.map((resource) => resource.id).sort());
   });
 
-  it("records the catalog and five crop guides as explicitly approved for publication", () => {
-    for (const resourceId of approvedIds) {
+  it("keeps the catalog and five crop guides under their explicit publication approval", () => {
+    for (const resourceId of legacyApprovedIds) {
       const audit = getPublicResourceMasterAudit(resourceId);
       expect(audit?.status).toBe("approved");
       expect(audit?.auditedAt).toBe("2026-08-20");
@@ -33,24 +42,24 @@ describe("public resource master audits", () => {
     }
   });
 
-  it("makes all six approved masters publishable through their same-origin download routes", () => {
+  it("approves the four Casa Jardin masters as reconstructed public binaries without claiming historical identity", () => {
+    for (const resourceId of homeGardenApprovedIds) {
+      const audit = getPublicResourceMasterAudit(resourceId);
+      expect(audit?.status).toBe("approved");
+      expect(audit?.auditedAt).toBe("2026-08-21");
+      expect(audit?.blockers).toEqual([]);
+      expect(audit?.authority).toMatch(/reconstruido/i);
+      expect(audit?.findings.join(" ")).toMatch(/no se declara recuperado ni idéntico/i);
+      expect(audit?.findings.join(" ")).toMatch(/precios, checkout|calculadora pública de dosis/i);
+    }
+  });
+
+  it("makes all ten approved masters publishable through same-origin download routes", () => {
     for (const resourceId of approvedIds) {
       const resource = publicResources.find((item) => item.id === resourceId);
       expect(resource?.delivery).toBe("public-download");
       expect(resource?.downloadHref).toBe(`/api/public-resources/${resourceId}`);
       expect(resource && canPublishPublicResourceMaster(resource)).toBe(true);
-    }
-  });
-
-  it("leaves Casa Jardin masters pending until their actual binaries are available", () => {
-    const homeGardenAudits = publicResourceMasterAudits.filter((item) => item.resourceId.startsWith("home-garden-guide-"));
-    expect(homeGardenAudits).toHaveLength(4);
-    for (const audit of homeGardenAudits) {
-      expect(audit.status).toBe("pending");
-      expect(audit.blockers).toEqual([]);
-    }
-    for (const resource of publicResources.filter((item) => item.id.startsWith("home-garden-guide-"))) {
-      expect(canPublishPublicResourceMaster(resource)).toBe(false);
     }
   });
 });

--- a/src/data/public-resource-master-audits.ts
+++ b/src/data/public-resource-master-audits.ts
@@ -26,6 +26,13 @@ const explicitlyApprovedWondergreenMasters = new Set([
   "wondergreen-guide-pastos",
 ]);
 
+const reconstructedHomeGardenMasters = new Set([
+  "home-garden-guide-casa-jardin",
+  "home-garden-guide-mi-huerta",
+  "home-garden-guide-etapas",
+  "home-garden-guide-trasplante",
+]);
+
 const defaultPendingAudit = (resource: PublicResource): PublicResourceMasterAudit => ({
   resourceId: resource.id,
   status: "pending",
@@ -48,9 +55,26 @@ const approvedAudit = (resource: PublicResource): PublicResourceMasterAudit => (
   ],
 });
 
+const approvedReconstructedHomeGardenAudit = (resource: PublicResource): PublicResourceMasterAudit => ({
+  resourceId: resource.id,
+  status: "approved",
+  authority: "Wondergreen Casa & Jardín Truth · master público reconstruido y revisado",
+  auditedAt: "2026-08-21",
+  blockers: [],
+  findings: [
+    "El binario histórico del handoff no se declara recuperado ni idéntico: este es un master público reconstruido desde el contenido web gobernado y los activos Wondergreen aprobados.",
+    "El master reconstruido fue renderizado y revisado visualmente antes de publicación; conserva los guardrails vigentes de Casa & Jardín y no introduce precios, checkout ni una calculadora pública de dosis.",
+    "La entrega pública se realiza mediante una ruta same-origin de Greenatics sin exponer enlaces privados de SharePoint.",
+  ],
+});
+
 export const publicResourceMasterAudits: readonly PublicResourceMasterAudit[] = publicResources
   .filter((resource) => Boolean(resource.masterLabel))
-  .map((resource) => explicitlyApprovedWondergreenMasters.has(resource.id) ? approvedAudit(resource) : defaultPendingAudit(resource));
+  .map((resource) => {
+    if (explicitlyApprovedWondergreenMasters.has(resource.id)) return approvedAudit(resource);
+    if (reconstructedHomeGardenMasters.has(resource.id)) return approvedReconstructedHomeGardenAudit(resource);
+    return defaultPendingAudit(resource);
+  });
 
 export function getPublicResourceMasterAudit(resourceId: string) {
   return publicResourceMasterAudits.find((audit) => audit.resourceId === resourceId);

--- a/src/data/public-resources.test.ts
+++ b/src/data/public-resources.test.ts
@@ -31,7 +31,7 @@ describe("public knowledge resource registry", () => {
     }
   });
 
-  it("integrates the four governed Casa Jardin guide masters into the central library without inventing downloads", () => {
+  it("publishes the four governed Casa Jardin guide masters through same-origin downloads", () => {
     const homeGarden = publicResources.filter((resource) => resource.id.startsWith("home-garden-guide-"));
     expect(homeGarden).toHaveLength(4);
     expect(homeGarden.map((resource) => resource.href).sort()).toEqual([
@@ -41,9 +41,10 @@ describe("public knowledge resource registry", () => {
       "/casa-jardin/guias#trasplante",
     ]);
     for (const resource of homeGarden) {
-      expect(resource.delivery).toBe("web-native-master-pending");
-      expect(resource.downloadHref).toBeUndefined();
-      expect(resource.masterSource).toBe("validated-handoff");
+      expect(resource.delivery).toBe("public-download");
+      expect(resource.downloadHref).toBe(`/api/public-resources/${resource.id}`);
+      expect(resource.masterSource).toBe("internal-document-library");
+      expect(resource.sourceAuthority).toMatch(/reconstruido 2026-08-21/i);
     }
   });
 
@@ -68,7 +69,7 @@ describe("public knowledge resource registry", () => {
     expect(serialized).not.toMatch(/sharepoint|graph\.microsoft/i);
 
     const downloadable = publicResources.filter((item) => item.delivery === "public-download");
-    expect(downloadable).toHaveLength(6);
+    expect(downloadable).toHaveLength(10);
     for (const resource of downloadable) {
       expect(resource.downloadHref).toMatch(/^\/api\/public-resources\//);
       expect(resource.downloadHref).not.toMatch(/sharepoint|graph\.microsoft/i);

--- a/src/data/public-resources.ts
+++ b/src/data/public-resources.ts
@@ -24,18 +24,27 @@ export type PublicResource = {
 const publicDownload = (resourceId: string) => `/api/public-resources/${resourceId}`;
 const publicMedia = (assetId: string) => `/api/public-media/${assetId}`;
 
+const homeGardenMasterPages: Record<string, number> = {
+  "casa-jardin": 12,
+  "mi-huerta": 8,
+  etapas: 5,
+  trasplante: 8,
+};
+
 const homeGardenPublicResources: PublicResource[] = homeGardenGuides.map((guide) => ({
   id: `home-garden-guide-${guide.id}`,
   kind: "guide",
-  statusLabel: "Casa & Jardín",
+  statusLabel: "Guía + PDF",
   title: guide.title,
-  copy: `${guide.summary} La lectura web está disponible dentro de Casa, Jardín y Vivero; el PDF maestro del handoff se conserva como fuente y todavía no se expone como descarga pública.`,
+  copy: `${guide.summary} La lectura web permanece como autoridad navegable y se acompaña por un master público reconstruido desde el contenido gobernado y los activos Wondergreen aprobados.`,
   href: `/casa-jardin/guias#${guide.id}`,
   cta: "Abrir guía",
-  delivery: "web-native-master-pending",
-  sourceAuthority: "Wondergreen Casa & Jardín Truth · handoff validado",
-  masterLabel: `${guide.title} · PDF maestro validado`,
-  masterSource: "validated-handoff",
+  delivery: "public-download",
+  sourceAuthority: "Wondergreen Casa & Jardín Truth · master público reconstruido 2026-08-21",
+  masterLabel: `${guide.title} · ${homeGardenMasterPages[guide.id]} páginas · master público reconstruido`,
+  masterSource: "internal-document-library",
+  downloadHref: publicDownload(`home-garden-guide-${guide.id}`),
+  downloadLabel: "Descargar guía PDF",
 }));
 
 export const publicResources: PublicResource[] = [

--- a/src/lib/sharepoint/public-resource-download.test.ts
+++ b/src/lib/sharepoint/public-resource-download.test.ts
@@ -18,7 +18,7 @@ const env = {
 };
 
 describe("public Wondergreen resource proxy", () => {
-  it("exposes exactly the six explicitly approved PDFs", () => {
+  it("exposes exactly the ten explicitly approved PDFs", () => {
     expect(publicWondergreenPdfs.map((item) => item.id)).toEqual([
       "wondergreen-product-master",
       "wondergreen-guide-cafe",
@@ -26,8 +26,13 @@ describe("public Wondergreen resource proxy", () => {
       "wondergreen-guide-aguacate",
       "wondergreen-guide-limon-tahiti",
       "wondergreen-guide-pastos",
+      "home-garden-guide-casa-jardin",
+      "home-garden-guide-mi-huerta",
+      "home-garden-guide-etapas",
+      "home-garden-guide-trasplante",
     ]);
     expect(getPublicWondergreenPdf("home-garden-guide-green-plants")).toBeNull();
+    expect(getPublicWondergreenPdf("home-garden-guide-casa-jardin")?.filename).toBe("guia-casa-jardin.pdf");
   });
 
   it("registers the real Wondergreen visuals reused by Casa Jardin", () => {

--- a/src/lib/sharepoint/public-resource-download.ts
+++ b/src/lib/sharepoint/public-resource-download.ts
@@ -6,7 +6,11 @@ export type PublicWondergreenPdfId =
   | "wondergreen-guide-cacao"
   | "wondergreen-guide-aguacate"
   | "wondergreen-guide-limon-tahiti"
-  | "wondergreen-guide-pastos";
+  | "wondergreen-guide-pastos"
+  | "home-garden-guide-casa-jardin"
+  | "home-garden-guide-mi-huerta"
+  | "home-garden-guide-etapas"
+  | "home-garden-guide-trasplante";
 
 export type PublicWondergreenMediaId =
   | "catalogo-cover"
@@ -40,6 +44,10 @@ export const publicWondergreenPdfs: readonly PublicGraphAsset<PublicWondergreenP
   { id: "wondergreen-guide-aguacate", itemId: "01VAJGQOVFGMMQPE7Q65EIUBBM4JGFUNK2", filename: "guia-wondergreen-aguacate.pdf", contentType: "application/pdf" },
   { id: "wondergreen-guide-limon-tahiti", itemId: "01VAJGQOXZBLJD7F62J5G2SURIXBMWM7MW", filename: "guia-wondergreen-citricos.pdf", contentType: "application/pdf" },
   { id: "wondergreen-guide-pastos", itemId: "01VAJGQOVR7Q3XBPIMRFAIDSYCGUIQM26F", filename: "guia-wondergreen-pastos-y-praderas.pdf", contentType: "application/pdf" },
+  { id: "home-garden-guide-casa-jardin", itemId: "01VAJGQOTJ4PZZOEPK4JFYP6TSAEZ7K4L2", filename: "guia-casa-jardin.pdf", contentType: "application/pdf" },
+  { id: "home-garden-guide-mi-huerta", itemId: "01VAJGQOSREI6AY43HKJEJ2J7QPPUT2INU", filename: "guia-mi-huerta.pdf", contentType: "application/pdf" },
+  { id: "home-garden-guide-etapas", itemId: "01VAJGQOTYKZXRHRQ43VCLVVV4KDLYT3PG", filename: "guia-rapida-etapas.pdf", contentType: "application/pdf" },
+  { id: "home-garden-guide-trasplante", itemId: "01VAJGQOX4IPEFYGPP2VA2OMQSKULETUKZ", filename: "guia-trasplante.pdf", contentType: "application/pdf" },
 ]);
 
 export const publicWondergreenMedia: readonly PublicGraphAsset<PublicWondergreenMediaId>[] = Object.freeze([


### PR DESCRIPTION
## Objetivo
Publicar cuatro guías Casa & Jardín como PDFs descargables same-origin, manteniendo la lectura web como autoridad navegable y sin abrir ecommerce ni dosis.

## Masters públicos reconstruidos
Se publican cuatro binarios actuales, reconstruidos desde el contenido gobernado de `develop` y activos Wondergreen aprobados:
- Guía Wondergreen Casa & Jardín · 12 páginas
- Guía Mi Huerta · 8 páginas
- Guía rápida de etapas · 5 páginas
- Guía de trasplante · 8 páginas

Los 33 folios finales fueron renderizados y revisados visualmente antes de publicación. No se afirma que estos binarios sean una copia byte a byte de los PDFs históricos del handoff; la auditoría deja esa distinción explícita.

## Cambios
- amplía el allowlist server-side de `/api/public-resources/:id` de 6 a 10 PDFs;
- registra los cuatro item IDs privados solo en código server-side;
- Biblioteca pasa las cuatro guías de `web-native-master-pending` a `public-download`;
- `/casa-jardin/guias` ofrece cuatro CTAs de descarga same-origin;
- auditoría pública marca estos cuatro masters reconstruidos como aprobados el 2026-08-21;
- actualiza unit tests y E2E para exigir las rutas exactas y ausencia de URLs SharePoint/Graph.

## Guardrails
- `/casa-jardin` y sus guías continúan `noindex`;
- sin precios ni PVP;
- sin checkout;
- sin calculadora pública de dosis ni equivalencias del dosificador;
- Trasplanta & Arranca continúa bloqueado;
- no cambia Product Truth, Crop Truth, RLS ni OPS;
- no se expone ninguna URL privada de SharePoint o Graph.

## Gate
Merge únicamente con CI final 4/4 verde sobre la cabeza exacta, branch 0 behind y 0 review threads pendientes.