### PR TITLE
feat(home-garden): visualizar composición de kits

### DIFF
--- a/e2e/home-garden-kit-visual-band.spec.ts
+++ b/e2e/home-garden-kit-visual-band.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+const kits = [
+  "Kit Plantas Verdes",
+  "Kit Plantas con Flor",
+  "Kit Mi Huerta",
+  "Kit Casa Completa",
+  "Casa Completa XL",
+] as const;
+
+const stageVisuals = [
+  ["Línea Wondergreen 2Grow dentro del kit", "/api/public-media/wondergreen-2grow"],
+  ["Línea Wondergreen 2Balance dentro del kit", "/api/public-media/wondergreen-2balance"],
+  ["Línea Wondergreen 2Bloom dentro del kit", "/api/public-media/wondergreen-2bloom"],
+  ["Línea Wondergreen 2Fruit dentro del kit", "/api/public-media/wondergreen-2fruit"],
+] as const;
+
+test("Casa Jardin closes with visual kit compositions built from real Wondergreen stages", async ({ page }) => {
+  await page.goto("/casa-jardin");
+
+  await expect(page.getByRole("heading", { name: "Cada kit reúne etapas. No mezcla necesidades.", exact: true })).toBeVisible();
+
+  for (const kit of kits) {
+    await expect(page.getByRole("heading", { name: kit, exact: true }).last()).toBeVisible();
+    await expect(page.getByLabel(`Composición visual ${kit}`, { exact: true })).toBeVisible();
+  }
+
+  for (const [alt, src] of stageVisuals) {
+    await expect(page.getByRole("img", { name: alt, exact: true }).first()).toHaveAttribute("src", src);
+  }
+
+  await expect(page.getByText("Kit educativo bloqueado", { exact: true })).toBeVisible();
+  await expect(page.getByText(/Trasplanta & Arranca continúa fuera del catálogo/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: /Descargar guía de trasplante PDF/i })).toHaveAttribute("href", "/api/public-resources/home-garden-guide-trasplante");
+
+  await expect(page.getByRole("button", { name: /comprar/i })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: /comprar/i })).toHaveCount(0);
+  await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
+});
+
+test("visual kit band does not repeat inside a kit detail route", async ({ page }) => {
+  await page.goto("/casa-jardin/kits/mi-huerta");
+  await expect(page.getByRole("heading", { name: "Cada kit reúne etapas. No mezcla necesidades.", exact: true })).toHaveCount(0);
+});

--- a/e2e/home-garden-kit-visual-band.spec.ts
+++ b/e2e/home-garden-kit-visual-band.spec.ts
@@ -9,10 +9,10 @@ const kits = [
 ] as const;
 
 const stageVisuals = [
-  ["Línea Wondergreen 2Grow dentro del kit", "/api/public-media/wondergreen-2grow"],
-  ["Línea Wondergreen 2Balance dentro del kit", "/api/public-media/wondergreen-2balance"],
-  ["Línea Wondergreen 2Bloom dentro del kit", "/api/public-media/wondergreen-2bloom"],
-  ["Línea Wondergreen 2Fruit dentro del kit", "/api/public-media/wondergreen-2fruit"],
+  ["Miniatura CRECE 2Grow dentro del kit", "/api/public-media/wondergreen-2grow"],
+  ["Miniatura EQUILIBRA 2Balance dentro del kit", "/api/public-media/wondergreen-2balance"],
+  ["Miniatura FLORECE 2Bloom dentro del kit", "/api/public-media/wondergreen-2bloom"],
+  ["Miniatura FRUCTIFICA 2Fruit dentro del kit", "/api/public-media/wondergreen-2fruit"],
 ] as const;
 
 test("Casa Jardin closes with visual kit compositions built from real Wondergreen stages", async ({ page }) => {
@@ -21,8 +21,9 @@ test("Casa Jardin closes with visual kit compositions built from real Wondergree
   await expect(page.getByRole("heading", { name: "Cada kit reúne etapas. No mezcla necesidades.", exact: true })).toBeVisible();
 
   for (const kit of kits) {
-    await expect(page.getByRole("heading", { name: kit, exact: true }).last()).toBeVisible();
-    await expect(page.getByLabel(`Composición visual ${kit}`, { exact: true })).toBeVisible();
+    const composition = page.getByLabel(`Composición visual ${kit}`, { exact: true });
+    await expect(composition).toBeVisible();
+    await expect(page.getByText(kit, { exact: true }).last()).toBeVisible();
   }
 
   for (const [alt, src] of stageVisuals) {

--- a/src/app/casa-jardin/layout.tsx
+++ b/src/app/casa-jardin/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+import { HomeGardenKitVisualBand } from "@/components/home-garden-kit-visual-band";
 
 export const metadata: Metadata = {
   title: "Casa y Jardín | Greenatics",
@@ -12,5 +13,10 @@ export const metadata: Metadata = {
 };
 
 export default function CasaJardinLayout({ children }: { children: React.ReactNode }) {
-  return <PublicShell ownsMain={false}>{children}</PublicShell>;
+  return (
+    <PublicShell ownsMain={false}>
+      {children}
+      <HomeGardenKitVisualBand />
+    </PublicShell>
+  );
 }

--- a/src/components/home-garden-kit-visual-band.module.css
+++ b/src/components/home-garden-kit-visual-band.module.css
@@ -32,7 +32,7 @@
 
 .cardBody { padding: 28px 30px 26px; }
 .audience { display: block; color: var(--green); font-size: .67rem; font-weight: 900; letter-spacing: .09em; text-transform: uppercase; }
-.cardBody h3 { margin: 12px 0 10px; font-family: var(--display); font-size: 2.2rem; font-weight: 600; line-height: 1; }
+.kitName { display: block; margin: 12px 0 10px; font-family: var(--display); font-size: 2.2rem; font-weight: 600; line-height: 1; }
 .promise { margin: 0 0 20px; color: var(--muted); line-height: 1.65; }
 .pathway { padding: 12px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); color: var(--forest) !important; font-size: .75rem; font-weight: 900; letter-spacing: .04em; }
 .cardBody a { display: inline-block; margin-top: 12px; color: var(--forest); font-weight: 850; text-decoration: none; }
@@ -56,7 +56,7 @@
   .visualStrip { min-height: 250px; padding: 12px; }
   .card { grid-template-rows: 250px 1fr auto; }
   .cardBody { padding: 24px 22px; }
-  .cardBody h3 { font-size: 1.9rem; }
+  .kitName { font-size: 1.9rem; }
   .status { padding: 14px 22px; }
   .guardrail { padding: 22px; }
 }

--- a/src/components/home-garden-kit-visual-band.module.css
+++ b/src/components/home-garden-kit-visual-band.module.css
@@ -1,0 +1,62 @@
+.section {
+  --forest: #063d2c;
+  --green: #2f7d32;
+  --lime: #7db43c;
+  --paper: #f7faf8;
+  --cream: #f6f3e9;
+  --ink: #17382d;
+  --muted: #5c7168;
+  --line: rgba(6, 61, 44, .15);
+  padding: 96px 0 104px;
+  background: #f1f4ec;
+  color: var(--ink);
+  border-top: 1px solid var(--line);
+}
+
+.container { width: min(1180px, calc(100% - 40px)); margin: 0 auto; }
+.heading { display: grid; grid-template-columns: minmax(0, 1fr) minmax(300px, .56fr); gap: 52px; align-items: end; margin-bottom: 42px; }
+.eyebrow { color: var(--green); font-size: .72rem; font-weight: 900; letter-spacing: .12em; text-transform: uppercase; }
+.heading h2 { max-width: 780px; margin: 12px 0 0; font-family: var(--display); font-size: clamp(2.5rem, 4.8vw, 4.8rem); font-weight: 600; line-height: .98; letter-spacing: -.035em; }
+.heading p { margin: 0; color: var(--muted); line-height: 1.72; }
+
+.grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+.card { min-height: 590px; display: grid; grid-template-rows: 300px 1fr auto; background: #fff; border: 1px solid var(--line); overflow: hidden; }
+.visualStrip { display: grid; grid-auto-flow: column; grid-auto-columns: minmax(0, 1fr); gap: 1px; padding: 18px; background: var(--forest); overflow: hidden; }
+.stageVisual { position: relative; min-width: 0; overflow: hidden; background: var(--cream); border: 1px solid rgba(255,255,255,.16); }
+.stageVisual img { width: 100%; height: 100%; display: block; object-fit: cover; object-position: top center; }
+.stageVisual > span:not(:first-child), .stageVisual > span:only-child { position: absolute; left: 10px; right: 10px; bottom: 10px; padding: 7px 8px; background: rgba(6,61,44,.88); color: #fff; font-size: .64rem; font-weight: 900; letter-spacing: .06em; text-align: center; }
+.compostVisual { display: flex; flex-direction: column; justify-content: end; gap: 6px; padding: 18px 14px; background: linear-gradient(160deg,#e7ddc7,#f7f2e7 62%,#dce9d2); }
+.compostVisual span { color: #8b6d46; font-family: var(--display); font-size: 3rem; line-height: .85; }
+.compostVisual strong { color: #5f492f; font-size: .95rem; letter-spacing: .05em; }
+.compostVisual small { color: #745f45; }
+
+.cardBody { padding: 28px 30px 26px; }
+.audience { display: block; color: var(--green); font-size: .67rem; font-weight: 900; letter-spacing: .09em; text-transform: uppercase; }
+.cardBody h3 { margin: 12px 0 10px; font-family: var(--display); font-size: 2.2rem; font-weight: 600; line-height: 1; }
+.promise { margin: 0 0 20px; color: var(--muted); line-height: 1.65; }
+.pathway { padding: 12px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); color: var(--forest) !important; font-size: .75rem; font-weight: 900; letter-spacing: .04em; }
+.cardBody a { display: inline-block; margin-top: 12px; color: var(--forest); font-weight: 850; text-decoration: none; }
+.status { padding: 16px 30px; background: #edf5e8; color: var(--green); border-top: 1px solid var(--line); font-size: .7rem; font-weight: 900; letter-spacing: .09em; text-transform: uppercase; }
+
+.guardrail { display: grid; grid-template-columns: 1fr 1fr auto; gap: 26px; align-items: center; margin-top: 28px; padding: 24px 26px; background: #fff8d9; border-left: 6px solid #f4d944; }
+.guardrail span { display: block; color: #8a7317; font-size: .67rem; font-weight: 900; text-transform: uppercase; letter-spacing: .09em; margin-bottom: 7px; }
+.guardrail strong { color: var(--forest); line-height: 1.35; }
+.guardrail p { margin: 0; color: var(--muted); line-height: 1.6; }
+.guardrail a { color: var(--forest); font-weight: 850; text-decoration: none; white-space: nowrap; }
+
+@media (max-width: 900px) {
+  .heading, .guardrail { grid-template-columns: 1fr; }
+  .grid { grid-template-columns: 1fr; }
+  .card { min-height: 0; }
+}
+
+@media (max-width: 620px) {
+  .section { padding: 72px 0 78px; }
+  .container { width: min(100% - 28px, 1180px); }
+  .visualStrip { min-height: 250px; padding: 12px; }
+  .card { grid-template-rows: 250px 1fr auto; }
+  .cardBody { padding: 24px 22px; }
+  .cardBody h3 { font-size: 1.9rem; }
+  .status { padding: 14px 22px; }
+  .guardrail { padding: 22px; }
+}

--- a/src/components/home-garden-kit-visual-band.tsx
+++ b/src/components/home-garden-kit-visual-band.tsx
@@ -7,10 +7,10 @@ import { visibleHomeGardenKits, type HomeGardenStage } from "@/data/home-garden"
 import styles from "./home-garden-kit-visual-band.module.css";
 
 const stageVisuals: Partial<Record<HomeGardenStage, { src: string; alt: string; label: string }>> = {
-  crece: { src: "/api/public-media/wondergreen-2grow", alt: "Línea Wondergreen 2Grow", label: "CRECE" },
-  equilibra: { src: "/api/public-media/wondergreen-2balance", alt: "Línea Wondergreen 2Balance", label: "EQUILIBRA" },
-  florece: { src: "/api/public-media/wondergreen-2bloom", alt: "Línea Wondergreen 2Bloom", label: "FLORECE" },
-  fructifica: { src: "/api/public-media/wondergreen-2fruit", alt: "Línea Wondergreen 2Fruit", label: "FRUCTIFICA" },
+  crece: { src: "/api/public-media/wondergreen-2grow", alt: "Miniatura CRECE 2Grow", label: "CRECE" },
+  equilibra: { src: "/api/public-media/wondergreen-2balance", alt: "Miniatura EQUILIBRA 2Balance", label: "EQUILIBRA" },
+  florece: { src: "/api/public-media/wondergreen-2bloom", alt: "Miniatura FLORECE 2Bloom", label: "FLORECE" },
+  fructifica: { src: "/api/public-media/wondergreen-2fruit", alt: "Miniatura FRUCTIFICA 2Fruit", label: "FRUCTIFICA" },
 };
 
 function StageVisual({ stage }: { stage: HomeGardenStage }) {
@@ -60,7 +60,7 @@ export function HomeGardenKitVisualBand() {
               </div>
               <div className={styles.cardBody}>
                 <span className={styles.audience}>{kit.audience}</span>
-                <h3>{kit.name}</h3>
+                <strong className={styles.kitName}>{kit.name}</strong>
                 <p className={styles.promise}>{kit.promise}</p>
                 <p className={styles.pathway}>{kit.pathway.map((stage) => stage.toUpperCase()).join(" → ")}</p>
                 <Link href={`/casa-jardin/kits/${kit.id}`}>Ver composición exacta y guardrails →</Link>

--- a/src/components/home-garden-kit-visual-band.tsx
+++ b/src/components/home-garden-kit-visual-band.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { visibleHomeGardenKits, type HomeGardenStage } from "@/data/home-garden";
+import styles from "./home-garden-kit-visual-band.module.css";
+
+const stageVisuals: Partial<Record<HomeGardenStage, { src: string; alt: string; label: string }>> = {
+  crece: { src: "/api/public-media/wondergreen-2grow", alt: "Línea Wondergreen 2Grow", label: "CRECE" },
+  equilibra: { src: "/api/public-media/wondergreen-2balance", alt: "Línea Wondergreen 2Balance", label: "EQUILIBRA" },
+  florece: { src: "/api/public-media/wondergreen-2bloom", alt: "Línea Wondergreen 2Bloom", label: "FLORECE" },
+  fructifica: { src: "/api/public-media/wondergreen-2fruit", alt: "Línea Wondergreen 2Fruit", label: "FRUCTIFICA" },
+};
+
+function StageVisual({ stage }: { stage: HomeGardenStage }) {
+  if (stage === "prepara") {
+    return (
+      <div className={`${styles.stageVisual} ${styles.compostVisual}`} aria-label="COMPOST · base del sistema">
+        <span>01</span>
+        <strong>COMPOST</strong>
+        <small>Suelo</small>
+      </div>
+    );
+  }
+
+  const visual = stageVisuals[stage];
+  if (!visual) return null;
+  return (
+    <div className={styles.stageVisual}>
+      <Image src={visual.src} alt={`${visual.alt} dentro del kit`} width={760} height={1074} sizes="120px" unoptimized />
+      <span>{visual.label}</span>
+    </div>
+  );
+}
+
+export function HomeGardenKitVisualBand() {
+  const pathname = usePathname();
+  if (pathname !== "/casa-jardin") return null;
+
+  return (
+    <section className={styles.section} aria-labelledby="home-garden-kit-visual-title">
+      <div className={styles.container}>
+        <div className={styles.heading}>
+          <div>
+            <span className={styles.eyebrow}>Kits Wondergreen · composición visual</span>
+            <h2 id="home-garden-kit-visual-title">Cada kit reúne etapas. No mezcla necesidades.</h2>
+          </div>
+          <p>
+            Estas composiciones usan los artes reales del sistema Wondergreen para mostrar qué etapas contiene cada propuesta.
+            No son fotografías finales de empaque ni habilitan compra, precio o dosis.
+          </p>
+        </div>
+
+        <div className={styles.grid}>
+          {visibleHomeGardenKits.map((kit) => (
+            <article className={styles.card} key={kit.id}>
+              <div className={styles.visualStrip} aria-label={`Composición visual ${kit.name}`}>
+                {kit.pathway.map((stage, index) => <StageVisual stage={stage} key={`${kit.id}-${stage}-${index}`} />)}
+              </div>
+              <div className={styles.cardBody}>
+                <span className={styles.audience}>{kit.audience}</span>
+                <h3>{kit.name}</h3>
+                <p className={styles.promise}>{kit.promise}</p>
+                <p className={styles.pathway}>{kit.pathway.map((stage) => stage.toUpperCase()).join(" → ")}</p>
+                <Link href={`/casa-jardin/kits/${kit.id}`}>Ver composición exacta y guardrails →</Link>
+              </div>
+              <div className={styles.status}>Pre-lanzamiento · compra deshabilitada</div>
+            </article>
+          ))}
+        </div>
+
+        <div className={styles.guardrail}>
+          <div>
+            <span>Kit educativo bloqueado</span>
+            <strong>Trasplanta & Arranca continúa fuera del catálogo de kits disponibles.</strong>
+          </div>
+          <p>
+            La guía de trasplante sí está publicada. El kit no se muestra como disponible hasta reconciliar el componente radicular/bioinsumo.
+          </p>
+          <a href="/api/public-resources/home-garden-guide-trasplante" target="_blank" rel="noreferrer">Descargar guía de trasplante PDF ↓</a>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Objetivo
Dar una lectura visual clara de los cinco kits Casa & Jardín usando únicamente los artes reales Wondergreen ya publicados, sin crear packshots ficticios ni abrir ecommerce.

## Cambios
- añade una franja visual exclusiva de `/casa-jardin`;
- muestra la composición por etapas de Plantas Verdes, Plantas con Flor, Mi Huerta, Casa Completa y Casa Completa XL;
- reutiliza 2Grow, 2Balance, 2Bloom y 2Fruit desde `/api/public-media/*`;
- representa COMPOST como base del sistema sin inventar un empaque no recuperado;
- enlaza cada kit a su ficha gobernada;
- mantiene Trasplanta & Arranca fuera del catálogo y enlaza solo su guía educativa PDF;
- la franja no se repite en rutas de detalle;
- añade E2E específico.

## Guardrails
- sin precios/PVP;
- sin checkout;
- sin dosis calculadas;
- no se afirma que las composiciones sean fotografías finales de empaque;
- no cambia Product Truth, Crop Truth, RLS ni OPS;
- Casa & Jardín continúa `noindex`.

## Gate
Merge únicamente con CI final 4/4 verde, branch 0 behind y 0 review threads pendientes.