### PR TITLE
feat(home-garden): publicar portadas visuales de guías

### DIFF
--- a/e2e/home-garden-guide-visual-band.spec.ts
+++ b/e2e/home-garden-guide-visual-band.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+const guides = [
+  {
+    title: "Guía Wondergreen Casa & Jardín",
+    cover: "/api/public-media/home-garden-casa-jardin-cover",
+    download: "/api/public-resources/home-garden-guide-casa-jardin",
+  },
+  {
+    title: "Guía Mi Huerta",
+    cover: "/api/public-media/home-garden-mi-huerta-cover",
+    download: "/api/public-resources/home-garden-guide-mi-huerta",
+  },
+  {
+    title: "Guía rápida de etapas",
+    cover: "/api/public-media/home-garden-etapas-cover",
+    download: "/api/public-resources/home-garden-guide-etapas",
+  },
+  {
+    title: "Guía de trasplante",
+    cover: "/api/public-media/home-garden-trasplante-cover",
+    download: "/api/public-resources/home-garden-guide-trasplante",
+  },
+] as const;
+
+test("Casa Jardin exposes the four published guides with real covers and PDFs", async ({ page }) => {
+  await page.goto("/casa-jardin");
+
+  const library = page.getByRole("region", { name: "Cuatro guías. Dos formas de usarlas.", exact: true });
+  await expect(library).toBeVisible();
+
+  for (const guide of guides) {
+    await expect(library.getByRole("img", { name: `Portada publicada de ${guide.title}`, exact: true })).toHaveAttribute("src", guide.cover);
+    await expect(library.getByRole("link", { name: `Abrir PDF ${guide.title}`, exact: true })).toHaveAttribute("href", guide.download);
+  }
+
+  const downloadHrefs = await library.getByRole("link", { name: "Descargar PDF ↓", exact: true }).evaluateAll((links) => links.map((link) => link.getAttribute("href")));
+  expect(downloadHrefs.sort()).toEqual(guides.map((guide) => guide.download).sort());
+  await expect(library.getByText(/Masters públicos reconstruidos y gobernados/i)).toBeVisible();
+});
+
+test("guide visual library stays on the Casa Jardin landing only", async ({ page }) => {
+  await page.goto("/casa-jardin/guias");
+  await expect(page.getByRole("heading", { name: "Cuatro guías. Dos formas de usarlas.", exact: true })).toHaveCount(0);
+});

--- a/src/app/casa-jardin/layout.tsx
+++ b/src/app/casa-jardin/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+import { HomeGardenGuideVisualBand } from "@/components/home-garden-guide-visual-band";
 import { HomeGardenKitVisualBand } from "@/components/home-garden-kit-visual-band";
 
 export const metadata: Metadata = {
@@ -16,6 +17,7 @@ export default function CasaJardinLayout({ children }: { children: React.ReactNo
   return (
     <PublicShell ownsMain={false}>
       {children}
+      <HomeGardenGuideVisualBand />
       <HomeGardenKitVisualBand />
     </PublicShell>
   );

--- a/src/components/home-garden-guide-visual-band.module.css
+++ b/src/components/home-garden-guide-visual-band.module.css
@@ -1,0 +1,39 @@
+.section {
+  --forest: #063d2c;
+  --green: #2f7d32;
+  --muted: #5c7168;
+  --line: rgba(6, 61, 44, .15);
+  padding: 96px 0 104px;
+  background: #fff;
+  color: #17382d;
+  border-top: 1px solid var(--line);
+}
+.container { width: min(1180px, calc(100% - 40px)); margin: 0 auto; }
+.heading { display: grid; grid-template-columns: minmax(0, 1fr) minmax(300px, .55fr); gap: 52px; align-items: end; margin-bottom: 42px; }
+.eyebrow { color: var(--green); font-size: .72rem; font-weight: 900; letter-spacing: .12em; text-transform: uppercase; }
+.heading h2 { max-width: 760px; margin: 12px 0 0; font-family: var(--display); font-size: clamp(2.5rem, 4.8vw, 4.7rem); font-weight: 600; line-height: .98; letter-spacing: -.035em; }
+.heading p { margin: 0; color: var(--muted); line-height: 1.72; }
+.grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 16px; }
+.card { display: flex; min-width: 0; flex-direction: column; border: 1px solid var(--line); background: #f8faf7; }
+.coverLink { display: block; aspect-ratio: 720/1018; overflow: hidden; background: #eef3ea; }
+.coverLink img { width: 100%; height: 100%; display: block; object-fit: cover; }
+.body { display: flex; flex: 1; flex-direction: column; padding: 22px 20px 20px; }
+.meta { color: var(--green); font-size: .66rem; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
+.title { display: block; margin: 10px 0 12px; font-family: var(--display); font-size: 1.55rem; font-weight: 600; line-height: 1.05; }
+.body p { margin: 0 0 20px; color: var(--muted); font-size: .9rem; line-height: 1.6; }
+.actions { display: grid; gap: 8px; margin-top: auto; padding-top: 14px; border-top: 1px solid var(--line); }
+.actions a { color: var(--forest); font-size: .82rem; font-weight: 850; text-decoration: none; }
+.note { display: grid; grid-template-columns: .9fr 1.4fr auto; gap: 24px; align-items: center; margin-top: 26px; padding: 22px 24px; background: #edf5e8; border-left: 5px solid #7db43c; }
+.note strong { color: var(--forest); }
+.note p { margin: 0; color: var(--muted); line-height: 1.55; }
+.note a { color: var(--forest); font-weight: 850; text-decoration: none; white-space: nowrap; }
+@media (max-width: 1000px) {
+  .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .heading, .note { grid-template-columns: 1fr; }
+}
+@media (max-width: 620px) {
+  .section { padding: 72px 0 78px; }
+  .container { width: min(100% - 28px, 1180px); }
+  .grid { grid-template-columns: 1fr; }
+  .card { max-width: 430px; }
+}

--- a/src/components/home-garden-guide-visual-band.tsx
+++ b/src/components/home-garden-guide-visual-band.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { homeGardenGuides } from "@/data/home-garden";
+import styles from "./home-garden-guide-visual-band.module.css";
+
+const guideAssets = {
+  "casa-jardin": {
+    cover: "/api/public-media/home-garden-casa-jardin-cover",
+    download: "/api/public-resources/home-garden-guide-casa-jardin",
+    meta: "12 páginas · guía integral",
+  },
+  "mi-huerta": {
+    cover: "/api/public-media/home-garden-mi-huerta-cover",
+    download: "/api/public-resources/home-garden-guide-mi-huerta",
+    meta: "8 páginas · huerta por etapas",
+  },
+  etapas: {
+    cover: "/api/public-media/home-garden-etapas-cover",
+    download: "/api/public-resources/home-garden-guide-etapas",
+    meta: "5 páginas · referencia rápida",
+  },
+  trasplante: {
+    cover: "/api/public-media/home-garden-trasplante-cover",
+    download: "/api/public-resources/home-garden-guide-trasplante",
+    meta: "8 páginas · trasplante y estabilidad",
+  },
+} as const;
+
+export function HomeGardenGuideVisualBand() {
+  const pathname = usePathname();
+  if (pathname !== "/casa-jardin") return null;
+
+  return (
+    <section className={styles.section} aria-labelledby="home-garden-guide-visual-title">
+      <div className={styles.container}>
+        <div className={styles.heading}>
+          <div>
+            <span className={styles.eyebrow}>Biblioteca Casa & Jardín</span>
+            <h2 id="home-garden-guide-visual-title">Cuatro guías. Dos formas de usarlas.</h2>
+          </div>
+          <p>
+            Léelas en la web cuando quieras navegar por tema y descarga el PDF cuando necesites llevar el material completo al jardín, la huerta o el vivero.
+          </p>
+        </div>
+
+        <div className={styles.grid}>
+          {homeGardenGuides.map((guide) => {
+            const asset = guideAssets[guide.id];
+            return (
+              <article className={styles.card} key={guide.id}>
+                <a className={styles.coverLink} href={asset.download} target="_blank" rel="noreferrer" aria-label={`Abrir PDF ${guide.title}`}>
+                  <Image
+                    src={asset.cover}
+                    alt={`Portada publicada de ${guide.title}`}
+                    width={720}
+                    height={1018}
+                    sizes="(max-width: 640px) 88vw, (max-width: 1000px) 42vw, 24vw"
+                    unoptimized
+                  />
+                </a>
+                <div className={styles.body}>
+                  <span className={styles.meta}>{asset.meta}</span>
+                  <strong className={styles.title}>{guide.title}</strong>
+                  <p>{guide.summary}</p>
+                  <div className={styles.actions}>
+                    <Link href={`/casa-jardin/guias#${guide.id}`}>Leer en la web →</Link>
+                    <a href={asset.download} target="_blank" rel="noreferrer">Descargar PDF ↓</a>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+
+        <div className={styles.note}>
+          <strong>Masters públicos reconstruidos y gobernados.</strong>
+          <p>Estas portadas provienen directamente de los PDFs publicados. No sustituyen Product Truth, no activan PVP y no convierten las guías en una receta universal.</p>
+          <Link href="/biblioteca#recursos">Ver toda la Biblioteca Greenatics →</Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/home-garden-guide-visual-band.tsx
+++ b/src/components/home-garden-guide-visual-band.tsx
@@ -29,6 +29,13 @@ const guideAssets = {
   },
 } as const;
 
+type GuideAssetId = keyof typeof guideAssets;
+
+function getGuideAsset(id: string) {
+  if (!Object.prototype.hasOwnProperty.call(guideAssets, id)) return null;
+  return guideAssets[id as GuideAssetId];
+}
+
 export function HomeGardenGuideVisualBand() {
   const pathname = usePathname();
   if (pathname !== "/casa-jardin") return null;
@@ -48,7 +55,8 @@ export function HomeGardenGuideVisualBand() {
 
         <div className={styles.grid}>
           {homeGardenGuides.map((guide) => {
-            const asset = guideAssets[guide.id];
+            const asset = getGuideAsset(guide.id);
+            if (!asset) return null;
             return (
               <article className={styles.card} key={guide.id}>
                 <a className={styles.coverLink} href={asset.download} target="_blank" rel="noreferrer" aria-label={`Abrir PDF ${guide.title}`}>

--- a/src/lib/sharepoint/public-resource-download.test.ts
+++ b/src/lib/sharepoint/public-resource-download.test.ts
@@ -35,29 +35,28 @@ describe("public Wondergreen resource proxy", () => {
     expect(getPublicWondergreenPdf("home-garden-guide-casa-jardin")?.filename).toBe("guia-casa-jardin.pdf");
   });
 
-  it("registers the real Wondergreen visuals reused by Casa Jardin", () => {
-    for (const assetId of [
+  it("registers the real Wondergreen visuals and published Casa Jardin covers", () => {
+    const expectedAssets = [
       "wondergreen-system-stages",
       "wondergreen-2grow",
       "wondergreen-2balance",
       "wondergreen-2bloom",
       "wondergreen-2fruit",
       "wondergreen-bioinsumos",
-    ]) {
+      "home-garden-casa-jardin-cover",
+      "home-garden-mi-huerta-cover",
+      "home-garden-etapas-cover",
+      "home-garden-trasplante-cover",
+    ];
+
+    for (const assetId of expectedAssets) {
       const asset = getPublicWondergreenMedia(assetId);
       expect(asset).not.toBeNull();
       expect(asset?.contentType).toBe("image/webp");
       expect(asset?.filename).toMatch(/\.webp$/);
     }
 
-    expect(publicWondergreenMedia.map((item) => item.id)).toEqual(expect.arrayContaining([
-      "wondergreen-system-stages",
-      "wondergreen-2grow",
-      "wondergreen-2balance",
-      "wondergreen-2bloom",
-      "wondergreen-2fruit",
-      "wondergreen-bioinsumos",
-    ]));
+    expect(publicWondergreenMedia.map((item) => item.id)).toEqual(expect.arrayContaining(expectedAssets));
     expect(getPublicWondergreenMedia("unknown-home-garden-visual")).toBeNull();
   });
 

--- a/src/lib/sharepoint/public-resource-download.ts
+++ b/src/lib/sharepoint/public-resource-download.ts
@@ -19,6 +19,10 @@ export type PublicWondergreenMediaId =
   | "guia-aguacate-cover"
   | "guia-citricos-cover"
   | "guia-pastos-cover"
+  | "home-garden-casa-jardin-cover"
+  | "home-garden-mi-huerta-cover"
+  | "home-garden-etapas-cover"
+  | "home-garden-trasplante-cover"
   | "wondergreen-system-stages"
   | "wondergreen-2grow"
   | "wondergreen-2balance"
@@ -57,6 +61,10 @@ export const publicWondergreenMedia: readonly PublicGraphAsset<PublicWondergreen
   { id: "guia-aguacate-cover", itemId: "01VAJGQORJQCA46SIRKJBIXBDBFNVU3L4T", filename: "guia-aguacate-cover.webp", contentType: "image/webp" },
   { id: "guia-citricos-cover", itemId: "01VAJGQOSTVLT43UZJZNHJZ4NTLSIL24SG", filename: "guia-citricos-cover.webp", contentType: "image/webp" },
   { id: "guia-pastos-cover", itemId: "01VAJGQOQRG24OXXNDEZB2WQVPBUZYIX25", filename: "guia-pastos-cover.webp", contentType: "image/webp" },
+  { id: "home-garden-casa-jardin-cover", itemId: "01VAJGQOVTNRF35QW3JNDI3TBJO5SMWALQ", filename: "guia-casa-jardin-cover.webp", contentType: "image/webp" },
+  { id: "home-garden-mi-huerta-cover", itemId: "01VAJGQOSYF4ZTLATJDFGKERHDNBR6N7CX", filename: "guia-mi-huerta-cover.webp", contentType: "image/webp" },
+  { id: "home-garden-etapas-cover", itemId: "01VAJGQOVWDV5RXVC3KVEJL2ALODJVPRRX", filename: "guia-rapida-etapas-cover.webp", contentType: "image/webp" },
+  { id: "home-garden-trasplante-cover", itemId: "01VAJGQOQBKRDC4M7UW5AZ2SMVITAHRMAO", filename: "guia-trasplante-cover.webp", contentType: "image/webp" },
   { id: "wondergreen-system-stages", itemId: "01VAJGQOQGN5JPABJ6NBAJXR4PUSLSZGJJ", filename: "wondergreen-system-stages.webp", contentType: "image/webp" },
   { id: "wondergreen-2grow", itemId: "01VAJGQOXLFZYZPDA7MFFJAF5MRQM7VGJQ", filename: "wondergreen-2grow.webp", contentType: "image/webp" },
   { id: "wondergreen-2balance", itemId: "01VAJGQOQ4K7CZQDH77RCLX4BBI7MYTRWS", filename: "wondergreen-2balance.webp", contentType: "image/webp" },


### PR DESCRIPTION
## Objetivo
Dar una salida editorial visual a las cuatro guías Casa & Jardín usando las portadas reales derivadas de los PDFs públicos reconstruidos.

## Cambios
- incorpora cuatro portadas WebP al allowlist same-origin;
- añade biblioteca visual exclusiva de `/casa-jardin`;
- muestra portada, resumen, lectura web y descarga PDF de las cuatro guías;
- conecta con la Biblioteca Greenatics;
- el bloque no se repite en subrutas;
- añade tests unitarios y E2E específicos.

## Guardrails
- las portadas provienen directamente de los PDFs publicados;
- no se inventan empaques ni claims nuevos;
- no activa PVP, checkout ni dosis;
- Casa & Jardín continúa `noindex`;
- no expone SharePoint/Graph;
- no cambia Product Truth, Crop Truth, RLS ni OPS.

## Gate
Merge únicamente con CI final 4/4 verde, branch 0 behind y 0 review threads pendientes.