### PR TITLE
chore(deploy): publicar Vercel una sola vez

### DIFF
--- a/.github/workflows/publish-once-greenatics-vercel-20260821.yml
+++ b/.github/workflows/publish-once-greenatics-vercel-20260821.yml
@@ -1,0 +1,179 @@
+name: publish-once-greenatics-vercel-20260821
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - .github/workflows/publish-once-greenatics-vercel-20260821.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: greenatics-hosted-pilot-production
+  cancel-in-progress: false
+
+jobs:
+  publish-production-once:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      PILOT_PREVIEW_MODE: full-ops
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      DEPLOY_GIT_REF: develop
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+      SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+      PILOT_DIRECTOR_EMAIL: ${{ secrets.PILOT_DIRECTOR_EMAIL }}
+      PILOT_DIRECTOR_PASSWORD: ${{ secrets.PILOT_DIRECTOR_PASSWORD }}
+      PILOT_OPERATOR_TAM_EMAIL: ${{ secrets.PILOT_OPERATOR_TAM_EMAIL }}
+      PILOT_OPERATOR_TAM_PASSWORD: ${{ secrets.PILOT_OPERATOR_TAM_PASSWORD }}
+      PILOT_OPERATOR_YAR_EMAIL: ${{ secrets.PILOT_OPERATOR_YAR_EMAIL }}
+      PILOT_OPERATOR_YAR_PASSWORD: ${{ secrets.PILOT_OPERATOR_YAR_PASSWORD }}
+      PILOT_DIRECTOR_PLANTS: TAM,YAR
+
+    steps:
+      - name: Checkout canonical develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Resolve exact deployment commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          test "${#sha}" -eq 40
+          echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
+          echo "One-shot Vercel publication from develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require hosted deployment and UAT secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            VERCEL_TOKEN \
+            VERCEL_ORG_ID \
+            NEXT_PUBLIC_SUPABASE_URL \
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
+            SUPABASE_SECRET_KEY \
+            PILOT_DIRECTOR_EMAIL \
+            PILOT_DIRECTOR_PASSWORD \
+            PILOT_OPERATOR_TAM_EMAIL \
+            PILOT_OPERATOR_TAM_PASSWORD \
+            PILOT_OPERATOR_YAR_EMAIL \
+            PILOT_OPERATOR_YAR_PASSWORD
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is not configured for hosted OPS production publication."
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Canonical quality gate
+        run: |
+          npm run typecheck
+          npm run lint
+          npm test
+          npm run build
+
+      - name: Certify hosted backend
+        run: npm run pilot:backend-preflight -- --plants TAM,YAR
+
+      - name: Certify Director vs Operario Tamesis RLS isolation
+        env:
+          PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_TAM_EMAIL }}
+          PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_TAM_PASSWORD }}
+          PILOT_OPERATOR_PLANTS: TAM
+        run: npm run pilot:rls-smoke
+
+      - name: Certify Director vs Operario Yarumal RLS isolation
+        env:
+          PILOT_OPERATOR_EMAIL: ${{ secrets.PILOT_OPERATOR_YAR_EMAIL }}
+          PILOT_OPERATOR_PASSWORD: ${{ secrets.PILOT_OPERATOR_YAR_PASSWORD }}
+          PILOT_OPERATOR_PLANTS: YAR
+        run: npm run pilot:rls-smoke
+
+      - name: Deploy full OPS Preview
+        id: preview
+        run: npm run pilot:vercel-preview
+
+      - name: Certify protected deployed Preview
+        env:
+          DEPLOYMENT_URL: ${{ steps.preview.outputs.deployment_url }}
+          VERCEL_PROJECT_ID: ${{ steps.preview.outputs.project_id }}
+        run: npm run pilot:vercel-preflight
+
+      - name: Deploy stable full OPS production
+        id: production
+        run: node scripts/vercel-ops-production-deploy.mjs
+
+      - name: Certify stable human-accessible OPS origin
+        env:
+          APP_BASE_URL: ${{ steps.production.outputs.deployment_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run pilot:preflight -- \
+            --base-url "$APP_BASE_URL" \
+            --mode full-ops \
+            --expected-branch "$DEPLOY_GIT_REF" \
+            --expected-commit "$DEPLOY_GIT_SHA"
+
+      - name: Certify public editorial routes and assets
+        env:
+          APP_BASE_URL: ${{ steps.production.outputs.deployment_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="${APP_BASE_URL%/}"
+
+          fetch_html() {
+            local path="$1"
+            local expected="$2"
+            local outfile="$3"
+            curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --max-time 45 "$base$path" -o "$outfile"
+            grep -Fq "$expected" "$outfile"
+          }
+
+          fetch_html "/" "Greenatics" /tmp/home.html
+          fetch_html "/casa-jardin" "Nutrición por etapas para tus plantas." /tmp/casa-jardin.html
+          fetch_html "/casa-jardin/guias" "Guía Wondergreen Casa & Jardín" /tmp/casa-jardin-guias.html
+          fetch_html "/biblioteca" "Biblioteca" /tmp/biblioteca.html
+
+          curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --max-time 60 \
+            "$base/api/public-resources/home-garden-guide-casa-jardin" -o /tmp/guia-casa-jardin.pdf
+          test "$(head -c 4 /tmp/guia-casa-jardin.pdf)" = "%PDF"
+          test -s /tmp/guia-casa-jardin.pdf
+
+          curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --max-time 60 \
+            "$base/api/public-media/home-garden-casa-jardin-cover" -o /tmp/guia-casa-jardin-cover.webp
+          test "$(head -c 4 /tmp/guia-casa-jardin-cover.webp)" = "RIFF"
+          test "$(dd if=/tmp/guia-casa-jardin-cover.webp bs=1 skip=8 count=4 2>/dev/null)" = "WEBP"
+          test -s /tmp/guia-casa-jardin-cover.webp
+
+          echo "Public editorial smoke: HOME, Casa & Jardin, Guias, Biblioteca, PDF and WebP PASS." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publication summary
+        shell: bash
+        env:
+          OPS_ORIGIN: ${{ steps.production.outputs.deployment_url }}
+          UNIQUE_ORIGIN: ${{ steps.production.outputs.unique_deployment_url }}
+        run: |
+          echo "Stable OPS/public origin: $OPS_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
+          echo "Unique deployment: $UNIQUE_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published develop commit: $DEPLOY_GIT_SHA" >> "$GITHUB_STEP_SUMMARY"
+          echo "Quality, backend, TAM/YAR RLS, Preview, Production and public resource smoke passed." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-once-greenatics-vercel-20260821.yml
+++ b/.github/workflows/publish-once-greenatics-vercel-20260821.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 concurrency:
   group: greenatics-hosted-pilot-production
@@ -54,6 +55,21 @@ jobs:
           test "${#sha}" -eq 40
           echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
           echo "One-shot Vercel publication from develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark publication pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+            -d "{\"state\":\"pending\",\"context\":\"greenatics/vercel-publication\",\"description\":\"Publicando develop en greenatics-ops\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null
 
       - name: Require hosted deployment and UAT secrets
         shell: bash
@@ -177,3 +193,35 @@ jobs:
           echo "Unique deployment: $UNIQUE_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
           echo "Published develop commit: $DEPLOY_GIT_SHA" >> "$GITHUB_STEP_SUMMARY"
           echo "Quality, backend, TAM/YAR RLS, Preview, Production and public resource smoke passed." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark publication success
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+            -d "{\"state\":\"success\",\"context\":\"greenatics/vercel-publication\",\"description\":\"greenatics-ops publicado y certificado\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null
+
+      - name: Mark publication failure
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+            -d "{\"state\":\"failure\",\"context\":\"greenatics/vercel-publication\",\"description\":\"Falló publicación o smoke de producción\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null


### PR DESCRIPTION
## Objetivo
Publicar el `develop` canónico actual en el proyecto estable `greenatics-ops` de Vercel usando los mismos scripts, secretos y gates del workflow de producción existente, sin alterar su carácter manual.

## Cómo funciona
- este workflow solo se dispara cuando **este mismo archivo** entra a `develop`;
- hace checkout de `develop` y fija el SHA exacto a desplegar;
- ejecuta quality/build, backend preflight y RLS TAM/YAR;
- despliega Preview y lo certifica;
- despliega producción estable `greenatics-ops`;
- certifica branch + commit en el origen estable;
- además prueba HOME, Casa & Jardín, Guías, Biblioteca, un PDF público real y una portada WebP real.

## Guardrails
- no cambia `main`;
- no cambia Product Truth, Crop Truth, RLS ni Supabase;
- no crea usuarios ni modifica memberships;
- no habilita precios, checkout ni dosis;
- no modifica el workflow `hosted-pilot-production-refresh` existente;
- después de una publicación verde se retirará este archivo one-shot.

## Gate
Merge únicamente con CI final 4/4 verde, branch 0 behind y 0 review threads pendientes.