### PR TITLE
fix(resources): publicar PDFs e imágenes sin Graph en Vercel

### DIFF
--- a/.github/workflows/publish-public-assets-once-20260821.yml
+++ b/.github/workflows/publish-public-assets-once-20260821.yml
@@ -1,0 +1,184 @@
+name: publish-public-assets-once-20260821
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - .github/workflows/publish-public-assets-once-20260821.yml
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: greenatics-hosted-pilot-production
+  cancel-in-progress: false
+
+jobs:
+  publish-public-assets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      PILOT_PREVIEW_MODE: full-ops
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      DEPLOY_GIT_REF: develop
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+      SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+      PILOT_DIRECTOR_PLANTS: TAM,YAR
+
+    steps:
+      - name: Checkout canonical develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Resolve exact deployment commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          test "${#sha}" -eq 40
+          echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
+          echo "Public asset publication from develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark publication pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+            -d "{\"state\":\"pending\",\"context\":\"greenatics/vercel-publication\",\"description\":\"Publicando assets públicos en greenatics-ops\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null
+
+      - name: Require deployment secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in VERCEL_TOKEN VERCEL_ORG_ID NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY SUPABASE_SECRET_KEY; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is not configured."
+              exit 1
+            fi
+          done
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Canonical quality gate
+        run: |
+          npm run typecheck
+          npm run lint
+          npm test
+          npm run build
+
+      - name: Certify hosted backend
+        run: npm run pilot:backend-preflight -- --plants TAM,YAR
+
+      - name: Deploy full OPS Preview
+        id: preview
+        run: npm run pilot:vercel-preview
+
+      - name: Certify protected Preview
+        env:
+          DEPLOYMENT_URL: ${{ steps.preview.outputs.deployment_url }}
+          VERCEL_PROJECT_ID: ${{ steps.preview.outputs.project_id }}
+        run: npm run pilot:vercel-preflight
+
+      - name: Deploy stable production
+        id: production
+        run: node scripts/vercel-ops-production-deploy.mjs
+
+      - name: Certify stable origin
+        env:
+          APP_BASE_URL: ${{ steps.production.outputs.deployment_url }}
+        run: |
+          npm run pilot:preflight -- \
+            --base-url "$APP_BASE_URL" \
+            --mode full-ops \
+            --expected-branch "$DEPLOY_GIT_REF" \
+            --expected-commit "$DEPLOY_GIT_SHA"
+
+      - name: Certify public pages and binary assets
+        env:
+          APP_BASE_URL: ${{ steps.production.outputs.deployment_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="${APP_BASE_URL%/}"
+
+          check_html() {
+            local path="$1" marker="$2" outfile="$3"
+            curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --max-time 45 "$base$path" -o "$outfile"
+            test "$(wc -c < "$outfile")" -gt 500
+            grep -Fq "$marker" "$outfile"
+          }
+
+          check_html "/" "Greenatics" /tmp/home.html
+          check_html "/casa-jardin" "Encontrar un punto de partida" /tmp/casa.html
+          check_html "/casa-jardin/guias" "Wondergreen" /tmp/guias.html
+          check_html "/biblioteca" "Biblioteca" /tmp/biblioteca.html
+
+          curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --max-time 90 \
+            "$base/api/public-resources/home-garden-guide-casa-jardin" -o /tmp/guia.pdf
+          test "$(head -c 4 /tmp/guia.pdf)" = "%PDF"
+          test "$(wc -c < /tmp/guia.pdf)" -gt 100000
+
+          curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --max-time 90 \
+            "$base/api/public-media/home-garden-casa-jardin-cover" -o /tmp/cover.webp
+          test "$(head -c 4 /tmp/cover.webp)" = "RIFF"
+          test "$(dd if=/tmp/cover.webp bs=1 skip=8 count=4 2>/dev/null)" = "WEBP"
+          test "$(wc -c < /tmp/cover.webp)" -gt 5000
+
+          echo "Public smoke PASS: HTML + PDF + WebP." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publication summary
+        env:
+          OPS_ORIGIN: ${{ steps.production.outputs.deployment_url }}
+        run: |
+          echo "Stable public origin: $OPS_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published commit: $DEPLOY_GIT_SHA" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark publication success
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+            -d "{\"state\":\"success\",\"context\":\"greenatics/vercel-publication\",\"description\":\"greenatics-ops publicado con PDF e imágenes\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null
+
+      - name: Mark publication failure
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+            -d "{\"state\":\"failure\",\"context\":\"greenatics/vercel-publication\",\"description\":\"Falló publicación o smoke de assets públicos\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null

--- a/src/app/api/public-media/[assetId]/route.ts
+++ b/src/app/api/public-media/[assetId]/route.ts
@@ -1,4 +1,4 @@
-import { downloadPublicWondergreenMedia, getPublicWondergreenMedia } from "@/lib/sharepoint/public-resource-download";
+import { getPublicWondergreenMedia } from "@/lib/sharepoint/public-resource-download";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -11,23 +11,12 @@ export async function GET(
   const approved = getPublicWondergreenMedia(assetId);
   if (!approved) return new Response("Recurso no encontrado.", { status: 404 });
 
-  try {
-    const download = await downloadPublicWondergreenMedia(assetId);
-    if (!download) return new Response("Recurso no encontrado.", { status: 404 });
-
-    const headers = new Headers({
-      "content-type": download.asset.contentType,
+  return new Response(null, {
+    status: 307,
+    headers: {
+      location: approved.downloadUrl,
       "cache-control": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
       "x-content-type-options": "nosniff",
-    });
-    if (download.contentLength) headers.set("content-length", download.contentLength);
-    if (download.etag) headers.set("etag", download.etag);
-
-    return new Response(download.body, { status: 200, headers });
-  } catch {
-    return new Response("El recurso visual no está disponible temporalmente.", {
-      status: 503,
-      headers: { "cache-control": "no-store" },
-    });
-  }
+    },
+  });
 }

--- a/src/app/api/public-resources/[resourceId]/route.ts
+++ b/src/app/api/public-resources/[resourceId]/route.ts
@@ -1,4 +1,4 @@
-import { downloadPublicWondergreenPdf, getPublicWondergreenPdf } from "@/lib/sharepoint/public-resource-download";
+import { getPublicWondergreenPdf } from "@/lib/sharepoint/public-resource-download";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -11,24 +11,12 @@ export async function GET(
   const approved = getPublicWondergreenPdf(resourceId);
   if (!approved) return new Response("Recurso no encontrado.", { status: 404 });
 
-  try {
-    const download = await downloadPublicWondergreenPdf(resourceId);
-    if (!download) return new Response("Recurso no encontrado.", { status: 404 });
-
-    const headers = new Headers({
-      "content-type": "application/pdf",
-      "content-disposition": `inline; filename="${download.asset.filename}"`,
+  return new Response(null, {
+    status: 307,
+    headers: {
+      location: approved.downloadUrl,
       "cache-control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
       "x-content-type-options": "nosniff",
-    });
-    if (download.contentLength) headers.set("content-length", download.contentLength);
-    if (download.etag) headers.set("etag", download.etag);
-
-    return new Response(download.body, { status: 200, headers });
-  } catch {
-    return new Response("El documento no está disponible temporalmente.", {
-      status: 503,
-      headers: { "cache-control": "no-store" },
-    });
-  }
+    },
+  });
 }

--- a/src/lib/sharepoint/public-resource-download.test.ts
+++ b/src/lib/sharepoint/public-resource-download.test.ts
@@ -1,24 +1,22 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-  downloadPublicWondergreenPdf,
   getPublicWondergreenMedia,
   getPublicWondergreenPdf,
   publicWondergreenMedia,
   publicWondergreenPdfs,
 } from "./public-resource-download";
 
-const env = {
-  SHAREPOINT_SITE_HOSTNAME: "example.sharepoint.com",
-  SHAREPOINT_SITE_PATH: "/sites/Greenatics",
-  SHAREPOINT_DRIVE_ID: "drive-123",
-  SHAREPOINT_DOCUMENT_ROOT: "Documentos compartidos",
-  SHAREPOINT_TENANT_ID: "11111111-1111-4111-8111-111111111111",
-  SHAREPOINT_CLIENT_ID: "22222222-2222-4222-8222-222222222222",
-  SHAREPOINT_CLIENT_SECRET: "secret",
-};
+function expectPublicAnonymousDownload(url: string, expectedKind: ":b:" | ":u:") {
+  const parsed = new URL(url);
+  expect(parsed.protocol).toBe("https:");
+  expect(parsed.hostname).toBe("grupopineal-my.sharepoint.com");
+  expect(parsed.pathname).toContain(`/${expectedKind}/g/personal/arendon_greenatics_com_co/`);
+  expect(parsed.searchParams.get("download")).toBe("1");
+  expect(url).not.toMatch(/graph\.microsoft|client_secret|tenant_id|itemId=/i);
+}
 
-describe("public Wondergreen resource proxy", () => {
-  it("exposes exactly the ten explicitly approved PDFs", () => {
+describe("public Wondergreen anonymous resource registry", () => {
+  it("exposes exactly the ten explicitly approved PDFs through anonymous direct downloads", () => {
     expect(publicWondergreenPdfs.map((item) => item.id)).toEqual([
       "wondergreen-product-master",
       "wondergreen-guide-cafe",
@@ -31,70 +29,50 @@ describe("public Wondergreen resource proxy", () => {
       "home-garden-guide-etapas",
       "home-garden-guide-trasplante",
     ]);
+
+    for (const resource of publicWondergreenPdfs) {
+      expect(resource.contentType).toBe("application/pdf");
+      expect(resource.filename).toMatch(/\.pdf$/);
+      expectPublicAnonymousDownload(resource.downloadUrl, ":b:");
+    }
+
     expect(getPublicWondergreenPdf("home-garden-guide-green-plants")).toBeNull();
     expect(getPublicWondergreenPdf("home-garden-guide-casa-jardin")?.filename).toBe("guia-casa-jardin.pdf");
   });
 
-  it("registers the real Wondergreen visuals and published Casa Jardin covers", () => {
+  it("exposes all 16 real Wondergreen visuals through anonymous direct downloads", () => {
     const expectedAssets = [
+      "catalogo-cover",
+      "guia-cafe-cover",
+      "guia-cacao-cover",
+      "guia-aguacate-cover",
+      "guia-citricos-cover",
+      "guia-pastos-cover",
+      "home-garden-casa-jardin-cover",
+      "home-garden-mi-huerta-cover",
+      "home-garden-etapas-cover",
+      "home-garden-trasplante-cover",
       "wondergreen-system-stages",
       "wondergreen-2grow",
       "wondergreen-2balance",
       "wondergreen-2bloom",
       "wondergreen-2fruit",
       "wondergreen-bioinsumos",
-      "home-garden-casa-jardin-cover",
-      "home-garden-mi-huerta-cover",
-      "home-garden-etapas-cover",
-      "home-garden-trasplante-cover",
     ];
 
-    for (const assetId of expectedAssets) {
-      const asset = getPublicWondergreenMedia(assetId);
-      expect(asset).not.toBeNull();
-      expect(asset?.contentType).toBe("image/webp");
-      expect(asset?.filename).toMatch(/\.webp$/);
+    expect(publicWondergreenMedia.map((item) => item.id)).toEqual(expectedAssets);
+    for (const asset of publicWondergreenMedia) {
+      expect(asset.contentType).toBe("image/webp");
+      expect(asset.filename).toMatch(/\.webp$/);
+      expectPublicAnonymousDownload(asset.downloadUrl, ":u:");
     }
-
-    expect(publicWondergreenMedia.map((item) => item.id)).toEqual(expect.arrayContaining(expectedAssets));
     expect(getPublicWondergreenMedia("unknown-home-garden-visual")).toBeNull();
   });
 
-  it("returns null before auth for resources outside the PDF allowlist", async () => {
-    const fetchImpl = vi.fn<typeof fetch>();
-    await expect(downloadPublicWondergreenPdf("unknown", env, fetchImpl)).resolves.toBeNull();
-    expect(fetchImpl).not.toHaveBeenCalled();
-  });
-
-  it("downloads an approved PDF server-side without exposing SharePoint web URLs", async () => {
-    const pdf = new Uint8Array([37, 80, 68, 70]);
-    const fetchImpl = vi.fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "token-123", expires_in: 3600 }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }))
-      .mockResolvedValueOnce(new Response(pdf, {
-        status: 200,
-        headers: { "content-type": "application/pdf", "content-length": String(pdf.byteLength), etag: "pdf-etag" },
-      }));
-
-    const result = await downloadPublicWondergreenPdf("wondergreen-guide-cafe", env, fetchImpl);
-    expect(result?.asset.filename).toBe("guia-wondergreen-cafe.pdf");
-    expect(result?.contentLength).toBe("4");
-    expect(result?.etag).toBe("pdf-etag");
-
-    const graphCall = String(fetchImpl.mock.calls[1]?.[0]);
-    expect(graphCall).toContain("graph.microsoft.com/v1.0/drives/drive-123/items/");
-    expect(graphCall).toContain("/content");
-    expect(graphCall).not.toMatch(/sharepoint\.com/i);
-  });
-
-  it("fails closed when Graph cannot return the binary", async () => {
-    const fetchImpl = vi.fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "token-123", expires_in: 3600 }), { status: 200 }))
-      .mockResolvedValueOnce(new Response("missing", { status: 404 }));
-
-    await expect(downloadPublicWondergreenPdf("wondergreen-product-master", env, fetchImpl))
-      .rejects.toThrow(/download failed with HTTP 404/i);
+  it("contains no runtime Graph credential contract in the public resource registry", () => {
+    const serialized = JSON.stringify({ publicWondergreenPdfs, publicWondergreenMedia });
+    expect(serialized).not.toMatch(/graph\.microsoft\.com/i);
+    expect(serialized).not.toMatch(/SHAREPOINT_(TENANT|CLIENT|DRIVE|SITE|DOCUMENT)/i);
+    expect(serialized).not.toMatch(/itemId/i);
   });
 });

--- a/src/lib/sharepoint/public-resource-download.ts
+++ b/src/lib/sharepoint/public-resource-download.ts
@@ -1,5 +1,3 @@
-import { parseSharePointGraphRuntimeConfig, type SharePointGraphRuntimeConfig } from "./graph-readonly";
-
 export type PublicWondergreenPdfId =
   | "wondergreen-product-master"
   | "wondergreen-guide-cafe"
@@ -30,47 +28,57 @@ export type PublicWondergreenMediaId =
   | "wondergreen-2fruit"
   | "wondergreen-bioinsumos";
 
-type PublicGraphAsset<TId extends string> = Readonly<{
+type PublicHostedAsset<TId extends string> = Readonly<{
   id: TId;
-  itemId: string;
   filename: string;
   contentType: string;
+  downloadUrl: string;
 }>;
 
-const GRAPH_ORIGIN = "https://graph.microsoft.com";
-const TOKEN_SCOPE = "https://graph.microsoft.com/.default";
-const GRAPH_ID = /^[A-Za-z0-9!._-]{3,512}$/;
+const PUBLIC_ONEDRIVE_HOST = "https://grupopineal-my.sharepoint.com";
 
-export const publicWondergreenPdfs: readonly PublicGraphAsset<PublicWondergreenPdfId>[] = Object.freeze([
-  { id: "wondergreen-product-master", itemId: "01VAJGQOVIQ3U2MLVR5FBZQ5U4LYDFOPLH", filename: "catalogo-wondergreen.pdf", contentType: "application/pdf" },
-  { id: "wondergreen-guide-cafe", itemId: "01VAJGQOUUF5DBWLCEB5D2O5YCVPNTAII2", filename: "guia-wondergreen-cafe.pdf", contentType: "application/pdf" },
-  { id: "wondergreen-guide-cacao", itemId: "01VAJGQOUKZOUUY37G45E3XSYD7DTTFXGI", filename: "guia-wondergreen-cacao.pdf", contentType: "application/pdf" },
-  { id: "wondergreen-guide-aguacate", itemId: "01VAJGQOVFGMMQPE7Q65EIUBBM4JGFUNK2", filename: "guia-wondergreen-aguacate.pdf", contentType: "application/pdf" },
-  { id: "wondergreen-guide-limon-tahiti", itemId: "01VAJGQOXZBLJD7F62J5G2SURIXBMWM7MW", filename: "guia-wondergreen-citricos.pdf", contentType: "application/pdf" },
-  { id: "wondergreen-guide-pastos", itemId: "01VAJGQOVR7Q3XBPIMRFAIDSYCGUIQM26F", filename: "guia-wondergreen-pastos-y-praderas.pdf", contentType: "application/pdf" },
-  { id: "home-garden-guide-casa-jardin", itemId: "01VAJGQOTJ4PZZOEPK4JFYP6TSAEZ7K4L2", filename: "guia-casa-jardin.pdf", contentType: "application/pdf" },
-  { id: "home-garden-guide-mi-huerta", itemId: "01VAJGQOSREI6AY43HKJEJ2J7QPPUT2INU", filename: "guia-mi-huerta.pdf", contentType: "application/pdf" },
-  { id: "home-garden-guide-etapas", itemId: "01VAJGQOTYKZXRHRQ43VCLVVV4KDLYT3PG", filename: "guia-rapida-etapas.pdf", contentType: "application/pdf" },
-  { id: "home-garden-guide-trasplante", itemId: "01VAJGQOX4IPEFYGPP2VA2OMQSKULETUKZ", filename: "guia-trasplante.pdf", contentType: "application/pdf" },
+function publicDownloadUrl(sharePath: string) {
+  const url = `${PUBLIC_ONEDRIVE_HOST}${sharePath}?download=1`;
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:" || parsed.hostname !== "grupopineal-my.sharepoint.com") {
+    throw new Error("El host público del recurso Wondergreen no es válido.");
+  }
+  if (parsed.searchParams.get("download") !== "1") {
+    throw new Error("El recurso Wondergreen debe usar descarga binaria directa.");
+  }
+  return parsed.toString();
+}
+
+export const publicWondergreenPdfs: readonly PublicHostedAsset<PublicWondergreenPdfId>[] = Object.freeze([
+  { id: "wondergreen-product-master", filename: "catalogo-wondergreen.pdf", contentType: "application/pdf", downloadUrl: publicDownloadUrl("/:b:/g/personal/arendon_greenatics_com_co/IQDcgWu7j3izTKvOjrT8kjLEAWD-K4YFHC3WyJ906ESswp4") },
+  { id: "wondergreen-guide-cafe", filename: "guia-wondergreen-cafe.pdf", contentType: "application/pdf", downloadUrl: publicDownloadUrl("/:b:/g/personal/arendon_greenatics_com_co/IQBO8IqLVbYUTI8ucVoT0UxAAYcla_Pi3Cw5m_g65JCBl0U") },
+  { id: "wondergreen-guide-cacao", filename: "guia-wondergreen-cacao.pdf", contentType: "application/pdf", downloadUrl: publicDownloadUrl("/:b:/g/personal/arendon_greenatics_com_co/IQDARDgN7SAVTbRpWBh8C_5xAV6apLUuoYIoHZw4DzDwLHQ") },
+  { id: "wondergreen-guide-aguacate", filename: "guia-wondergreen-aguacate.pdf", contentType: "application/pdf", downloadUrl: publicDownloadUrl("/:b:/g/personal/arendon_greenatics_com_co/IQD5xaF3W5lXQbzHdJzlLN6kAURwx3LLlWpYtl3oXX33pvs") },
+  { id: "wondergreen-guide-limon-tahiti", filename: "guia-wondergreen-citricos.pdf", contentType: "application/pdf", downloadUrl: publicDownloadUrl("/:b:/g/personal/arendon_greenatics_com_co/IQAjljZmsVgPTof_vOtSyN9_AaO2dVDm6F8DrSuzD-OUuGg") },
+  { id: "wondergreen-guide-pastos", filename: "guia-wondergreen-pastos-y-praderas.pdf", contentType: "application/pdf", downloadUrl: publicDownloadUrl("/:b:/g/personal/arendon_greenatics_com_co/IQBQJxECHjkBSo6ZJ66_Cm7mAQmtGjQSA3s9t5x-zLXHLKM") },
+  { id: "home-garden-guide-casa-jardin", filename: "guia-casa-jardin.pdf", contentType: "application/pdf", downloadUrl: publicDownloadUrl("/:b:/g/personal/arendon_greenatics_com_co/IQASfZ8Pzy8GSIQ4wXS0XcJuAeQOI7xlmg4mp9w_PHLCRxY") },
+  { id: "home-garden-guide-mi-huerta", filename: "guia-mi-huerta.pdf", contentType: "application/pdf", downloadUrl: publicDownloadUrl("/:b:/g/personal/arendon_greenatics_com_co/IQD2xJ1vPVbSTJKRhNY1xIWHAbeK08PJxlM6Ng1OEt3b_xQ") },
+  { id: "home-garden-guide-etapas", filename: "guia-rapida-etapas.pdf", contentType: "application/pdf", downloadUrl: publicDownloadUrl("/:b:/g/personal/arendon_greenatics_com_co/IQDPTSliVwbYRYkD1LOY0LVyAZwVvTe_5EdfZhus1RTJ49g") },
+  { id: "home-garden-guide-trasplante", filename: "guia-trasplante.pdf", contentType: "application/pdf", downloadUrl: publicDownloadUrl("/:b:/g/personal/arendon_greenatics_com_co/IQBHpW-XGyh0T7QretbKRDqEAZxcCStEseVyT41tMRFdkw8") },
 ]);
 
-export const publicWondergreenMedia: readonly PublicGraphAsset<PublicWondergreenMediaId>[] = Object.freeze([
-  { id: "catalogo-cover", itemId: "01VAJGQOTUKW5ABSKD5FDKW3KXQ2UYYJG5", filename: "catalogo-cover.webp", contentType: "image/webp" },
-  { id: "guia-cafe-cover", itemId: "01VAJGQOWTVFFRPJ43R5EKGPFECG6F57FX", filename: "guia-cafe-cover.webp", contentType: "image/webp" },
-  { id: "guia-cacao-cover", itemId: "01VAJGQOUO66U2N5TGHBEZNUNMIC6366MG", filename: "guia-cacao-cover.webp", contentType: "image/webp" },
-  { id: "guia-aguacate-cover", itemId: "01VAJGQORJQCA46SIRKJBIXBDBFNVU3L4T", filename: "guia-aguacate-cover.webp", contentType: "image/webp" },
-  { id: "guia-citricos-cover", itemId: "01VAJGQOSTVLT43UZJZNHJZ4NTLSIL24SG", filename: "guia-citricos-cover.webp", contentType: "image/webp" },
-  { id: "guia-pastos-cover", itemId: "01VAJGQOQRG24OXXNDEZB2WQVPBUZYIX25", filename: "guia-pastos-cover.webp", contentType: "image/webp" },
-  { id: "home-garden-casa-jardin-cover", itemId: "01VAJGQOVTNRF35QW3JNDI3TBJO5SMWALQ", filename: "guia-casa-jardin-cover.webp", contentType: "image/webp" },
-  { id: "home-garden-mi-huerta-cover", itemId: "01VAJGQOSYF4ZTLATJDFGKERHDNBR6N7CX", filename: "guia-mi-huerta-cover.webp", contentType: "image/webp" },
-  { id: "home-garden-etapas-cover", itemId: "01VAJGQOVWDV5RXVC3KVEJL2ALODJVPRRX", filename: "guia-rapida-etapas-cover.webp", contentType: "image/webp" },
-  { id: "home-garden-trasplante-cover", itemId: "01VAJGQOQBKRDC4M7UW5AZ2SMVITAHRMAO", filename: "guia-trasplante-cover.webp", contentType: "image/webp" },
-  { id: "wondergreen-system-stages", itemId: "01VAJGQOQGN5JPABJ6NBAJXR4PUSLSZGJJ", filename: "wondergreen-system-stages.webp", contentType: "image/webp" },
-  { id: "wondergreen-2grow", itemId: "01VAJGQOXLFZYZPDA7MFFJAF5MRQM7VGJQ", filename: "wondergreen-2grow.webp", contentType: "image/webp" },
-  { id: "wondergreen-2balance", itemId: "01VAJGQOQ4K7CZQDH77RCLX4BBI7MYTRWS", filename: "wondergreen-2balance.webp", contentType: "image/webp" },
-  { id: "wondergreen-2bloom", itemId: "01VAJGQOTFHK6KH3Y7C5DJKBA5OULRMGHO", filename: "wondergreen-2bloom.webp", contentType: "image/webp" },
-  { id: "wondergreen-2fruit", itemId: "01VAJGQOUZYXMXQKDW6BAZFIUFO33MZKVL", filename: "wondergreen-2fruit.webp", contentType: "image/webp" },
-  { id: "wondergreen-bioinsumos", itemId: "01VAJGQOUNL6KJ5VX3MBAYA3BP74SWZRQ2", filename: "wondergreen-bioinsumos.webp", contentType: "image/webp" },
+export const publicWondergreenMedia: readonly PublicHostedAsset<PublicWondergreenMediaId>[] = Object.freeze([
+  { id: "catalogo-cover", filename: "catalogo-cover.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQCI3ajyCrgnRawDdBcPqlVbAZsyaWH3iw_8U1NwXvlPBV8") },
+  { id: "guia-cafe-cover", filename: "guia-cafe-cover.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQDvQrei1O77QKWuINBoJuVsASQh3WrfGsH4cMeFCUV7lwk") },
+  { id: "guia-cacao-cover", filename: "guia-cacao-cover.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQCQm0Oc7miBSJO_AlHBavOgAVikqKpIskCMfgLz2R3dmwg") },
+  { id: "guia-aguacate-cover", filename: "guia-aguacate-cover.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQABSbMd2IwrSajBXjvdOlnUARXIFX8_mr3O_6On_SUq23A") },
+  { id: "guia-citricos-cover", filename: "guia-citricos-cover.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQB41MDxtNPmT6s9Kqha9U8aAZ_H_ouqvhOiC-nF-iHG8fU") },
+  { id: "guia-pastos-cover", filename: "guia-pastos-cover.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQB0mMSAJJTQRa3ZarUROyZgAflzlj-RTURQ7V0bu_SksaI") },
+  { id: "home-garden-casa-jardin-cover", filename: "home-garden-casa-jardin-cover.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQBOIZ_vtgN2RLQoy0TtiOHSAe8byjN1L1f6jJpVC75IQIk") },
+  { id: "home-garden-mi-huerta-cover", filename: "home-garden-mi-huerta-cover.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQDbeD5lq9x3Rb-306BJAHHWAc7yjoJwEFAdRZlr2lacXY8") },
+  { id: "home-garden-etapas-cover", filename: "home-garden-etapas-cover.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQCxKy3wSSh6Q6BHjvNuGNpWAX8B1cykojKNjwAEXeQICKo") },
+  { id: "home-garden-trasplante-cover", filename: "home-garden-trasplante-cover.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQCNIRs8EEKnSKJ0eIwgnNknAWibtUs0UaLgJduv1mceXgY") },
+  { id: "wondergreen-system-stages", filename: "wondergreen-system-stages.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQC6TKqflhX5S5h59TMNCd77AUMCOA_SMh_fJQrs9X-QSdw") },
+  { id: "wondergreen-2grow", filename: "wondergreen-2grow.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQCqrTUPMFPNS56f8saQplOkAbzR7K-BHLSDApstzbdwHR0") },
+  { id: "wondergreen-2balance", filename: "wondergreen-2balance.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQCvT_T5AX6GQbkvEvcplOI7ASjgDg6YtfsFbjawtHfSP6Q") },
+  { id: "wondergreen-2bloom", filename: "wondergreen-2bloom.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQB31j0dbReqRoDAb8BFM1KYAQKtnTWh8SEoRZzLAYyDiDI") },
+  { id: "wondergreen-2fruit", filename: "wondergreen-2fruit.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQBtj_lxYNy6QbDKjE4_TP4kAaN9Vzo9hqw5lkqdHlei2Lg") },
+  { id: "wondergreen-bioinsumos", filename: "wondergreen-bioinsumos.webp", contentType: "image/webp", downloadUrl: publicDownloadUrl("/:u:/g/personal/arendon_greenatics_com_co/IQAioGSAn8F1R6XzPBo_Hop5AebpRx5OVbk_Vm7zQUOiDqs") },
 ]);
 
 export function getPublicWondergreenPdf(resourceId: string) {
@@ -79,68 +87,4 @@ export function getPublicWondergreenPdf(resourceId: string) {
 
 export function getPublicWondergreenMedia(assetId: string) {
   return publicWondergreenMedia.find((asset) => asset.id === assetId) ?? null;
-}
-
-async function getAccessToken(runtime: SharePointGraphRuntimeConfig, fetchImpl: typeof fetch) {
-  const tokenUrl = `https://login.microsoftonline.com/${runtime.auth.tenantId}/oauth2/v2.0/token`;
-  const body = new URLSearchParams({
-    client_id: runtime.auth.clientId,
-    client_secret: runtime.auth.clientSecret,
-    scope: TOKEN_SCOPE,
-    grant_type: "client_credentials",
-  });
-  const response = await fetchImpl(tokenUrl, {
-    method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-    body,
-    cache: "no-store",
-  });
-  if (!response.ok) throw new Error(`Microsoft identity token request failed with HTTP ${response.status}.`);
-  const payload = await response.json() as { access_token?: unknown };
-  const accessToken = typeof payload.access_token === "string" ? payload.access_token.trim() : "";
-  if (!accessToken) throw new Error("Microsoft identity token response was incomplete.");
-  return accessToken;
-}
-
-async function downloadGraphAsset<TId extends string>(
-  asset: PublicGraphAsset<TId>,
-  env: Record<string, string | undefined>,
-  fetchImpl: typeof fetch,
-) {
-  if (!GRAPH_ID.test(asset.itemId)) throw new Error("La referencia pública del recurso no es válida.");
-  const runtime = parseSharePointGraphRuntimeConfig(env);
-  if (!runtime.ok) throw new Error(runtime.error);
-  const accessToken = await getAccessToken(runtime.value, fetchImpl);
-  const url = `${GRAPH_ORIGIN}/v1.0/drives/${encodeURIComponent(runtime.value.source.driveId)}/items/${encodeURIComponent(asset.itemId)}/content`;
-  const response = await fetchImpl(url, {
-    method: "GET",
-    headers: { authorization: `Bearer ${accessToken}`, accept: asset.contentType },
-    cache: "no-store",
-    redirect: "follow",
-  });
-  if (!response.ok || !response.body) throw new Error(`Microsoft Graph document download failed with HTTP ${response.status}.`);
-  return {
-    asset,
-    body: response.body,
-    contentLength: response.headers.get("content-length"),
-    etag: response.headers.get("etag"),
-  } as const;
-}
-
-export async function downloadPublicWondergreenPdf(
-  resourceId: string,
-  env: Record<string, string | undefined> = process.env,
-  fetchImpl: typeof fetch = fetch,
-) {
-  const resource = getPublicWondergreenPdf(resourceId);
-  return resource ? downloadGraphAsset(resource, env, fetchImpl) : null;
-}
-
-export async function downloadPublicWondergreenMedia(
-  assetId: string,
-  env: Record<string, string | undefined> = process.env,
-  fetchImpl: typeof fetch = fetch,
-) {
-  const asset = getPublicWondergreenMedia(assetId);
-  return asset ? downloadGraphAsset(asset, env, fetchImpl) : null;
 }


### PR DESCRIPTION
## Objetivo
Eliminar los 503 de PDFs e imágenes públicas en `greenatics-ops.vercel.app` sin introducir credenciales SharePoint/Graph en Vercel.

## Solución
- 10 PDFs públicos y 16 WebP reales se alojan en OneDrive corporativo con enlaces `anonymous/view`;
- las rutas Greenatics `/api/public-resources/:id` y `/api/public-media/:id` se conservan, pero ahora responden 307 hacia el binario anónimo `?download=1`;
- el frontend no cambia sus URLs ni expone enlaces internos de la biblioteca SharePoint Greenatics;
- se elimina toda autenticación Graph del runtime de recursos públicos;
- el registro valida HTTPS, hostname público exacto y `download=1`.

## Assets
PDFs: catálogo + Café + Cacao + Aguacate + Cítricos + Pastos + 4 guías Casa & Jardín.

Media: 6 portadas agro + 4 portadas Casa & Jardín + sistema por etapas + 2Grow/2Balance/2Bloom/2Fruit + bioinsumos.

## Publicación
Incluye un workflow one-shot nuevo que hace quality/backend → Vercel Preview → Production → smoke real de HOME, Casa & Jardín, Biblioteca, `%PDF` y `RIFF...WEBP`.

## Seguridad
- no usa tenant/client secret en producción pública;
- no cambia RLS/Supabase/Product Truth/Crop Truth;
- no activa precios, checkout ni dosis;
- recursos desconocidos siguen respondiendo 404;
- los maestros internos siguen archivados en SharePoint.

## Gate
Merge solo con CI final 4/4 verde, branch 0 behind y 0 review threads.