### PR TITLE
feat(public): shell V2 con nueva navegación Greenatics

### DIFF
--- a/e2e/public-editorial-home.spec.ts
+++ b/e2e/public-editorial-home.spec.ts
@@ -49,10 +49,11 @@ test("public HOME exposes all five governed crop programs", async ({ page }) => 
 
 test("public HOME keeps its primary routes explicit and separate from OPS", async ({ page }) => {
   await page.goto("/");
+  const main = page.getByRole("main");
 
-  await expect(page.getByRole("link", { name: "Descubrir Wondergreen" })).toHaveAttribute("href", "/wondergreen");
-  await expect(page.getByRole("link", { name: "Explorar soluciones", exact: true }).first()).toHaveAttribute("href", "/soluciones");
-  await expect(page.getByRole("link", { name: "Casa & Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
-  await expect(page.getByRole("link", { name: "Contactar a Greenatics" })).toHaveAttribute("href", "/contacto");
-  await expect(page.getByRole("link", { name: "Acceder a la app interna" })).toHaveAttribute("href", "/app");
+  await expect(main.getByRole("link", { name: "Descubrir Wondergreen" })).toHaveAttribute("href", "/wondergreen");
+  await expect(main.getByRole("link", { name: "Explorar soluciones", exact: true }).first()).toHaveAttribute("href", "/soluciones");
+  await expect(main.getByRole("link", { name: "Casa & Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
+  await expect(main.getByRole("link", { name: "Contactar a Greenatics" })).toHaveAttribute("href", "/contacto");
+  await expect(main.getByRole("link", { name: "Acceder a la app interna" })).toHaveAttribute("href", "/app");
 });

--- a/e2e/public-editorial-sections.spec.ts
+++ b/e2e/public-editorial-sections.spec.ts
@@ -6,7 +6,14 @@ for (const route of ["/soluciones", "/proyectos"]) {
 
     await expect(page.getByRole("banner")).toHaveCount(1);
     await expect(page.getByRole("contentinfo")).toHaveCount(1);
-    await expect(page.getByRole("navigation", { name: "Navegación pública" })).toHaveCount(1);
+
+    const viewport = page.viewportSize();
+    if (viewport && viewport.width < 900) {
+      await expect(page.getByRole("button", { name: "Abrir navegación" })).toBeVisible();
+    } else {
+      await expect(page.getByRole("navigation", { name: "Navegación pública" })).toHaveCount(1);
+    }
+
     await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", new RegExp(`${route.replace("/", "\\/")}$`));
   });
 }

--- a/e2e/public-shell-seo.spec.ts
+++ b/e2e/public-shell-seo.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page, type TestInfo } from "@playwright/test";
 
 const shellRoutes = [
   "/", "/wondergreen", "/wondergreen/cultivos", "/wondergreen/cultivos/cafe",
@@ -9,23 +9,68 @@ const shellRoutes = [
   "/biblioteca", "/biblioteca/guia-deficiencias", "/nosotros", "/contacto",
 ];
 
-test("public home uses the shared navigation and real routes", async ({ page }) => {
+function isMobile(testInfo: TestInfo) {
+  return testInfo.project.name === "mobile-chromium";
+}
+
+async function openMobileShell(page: Page) {
+  const toggle = page.getByRole("button", { name: "Abrir navegación" });
+  await expect(toggle).toBeVisible();
+  await toggle.click();
+  const dialog = page.getByRole("dialog", { name: "Navegación Greenatics" });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+test("public home uses the canonical shell V2 and real routes", async ({ page }, testInfo) => {
   await page.goto("/");
   const header = page.getByRole("banner");
   const footer = page.getByRole("contentinfo");
-  const nav = header.getByRole("navigation", { name: "Navegación pública" });
-  await expect(nav).toBeVisible();
-  await expect(nav.getByRole("link", { name: "Soluciones" })).toHaveAttribute("href", "/soluciones");
-  await expect(nav.getByRole("link", { name: "Wondergreen" })).toHaveAttribute("href", "/wondergreen");
-  await expect(nav.getByRole("link", { name: "Casa y Jardín" })).toHaveAttribute("href", "/casa-jardin");
-  await expect(nav.getByRole("link", { name: "Proyectos" })).toHaveAttribute("href", "/proyectos");
-  await expect(nav.getByRole("link", { name: "Impacto" })).toHaveAttribute("href", "/impacto");
-  await expect(header.getByRole("link", { name: "Contacto" })).toHaveAttribute("href", "/contacto");
-  await expect(header.getByRole("link", { name: "Acceder a Greenatics" })).toHaveAttribute("href", "/app");
-  await expect(footer.getByRole("link", { name: "Casa y Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
+
+  if (isMobile(testInfo)) {
+    const dialog = await openMobileShell(page);
+    await expect(dialog.getByRole("button", { name: /Soluciones/ })).toBeVisible();
+    await expect(dialog.getByRole("link", { name: "Wondergreen", exact: true })).toHaveAttribute("href", "/wondergreen");
+    await expect(dialog.getByRole("link", { name: "Casa & Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
+    await expect(dialog.getByRole("button", { name: /Recursos/ })).toBeVisible();
+    await expect(dialog.getByRole("link", { name: "Nosotros", exact: true })).toHaveAttribute("href", "/nosotros");
+    await expect(dialog.getByRole("link", { name: "Hablar con nosotros", exact: true })).toHaveAttribute("href", "/contacto");
+    await expect(dialog.getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
+  } else {
+    const nav = header.getByRole("navigation", { name: "Navegación pública" });
+    await expect(nav).toBeVisible();
+    await expect(nav.getByRole("link", { name: "Soluciones", exact: true })).toHaveAttribute("href", "/soluciones");
+    await expect(nav.getByRole("link", { name: "Wondergreen", exact: true })).toHaveAttribute("href", "/wondergreen");
+    await expect(nav.getByRole("link", { name: "Casa & Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
+    await expect(nav.getByRole("link", { name: "Recursos", exact: true })).toHaveAttribute("href", "/biblioteca");
+    await expect(nav.getByRole("link", { name: "Nosotros", exact: true })).toHaveAttribute("href", "/nosotros");
+    await expect(header.getByRole("link", { name: "Hablar con nosotros", exact: true })).toHaveAttribute("href", "/contacto");
+    await expect(header.getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
+  }
+
+  await expect(footer.getByRole("link", { name: "Casa & Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
+  await expect(footer.getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
 });
 
-test("Casa y Jardín is functional but remains non-indexed until B2C validation closes", async ({ page }) => {
+test("Resources groups Biblioteca, Proyectos and Impacto without returning them to the primary nav", async ({ page }, testInfo) => {
+  await page.goto("/");
+
+  if (isMobile(testInfo)) {
+    const dialog = await openMobileShell(page);
+    await dialog.getByRole("button", { name: /Recursos/ }).click();
+    await expect(dialog.getByRole("link", { name: /Biblioteca/ })).toHaveAttribute("href", "/biblioteca");
+    await expect(dialog.getByRole("link", { name: /Proyectos \/ Casos/ })).toHaveAttribute("href", "/proyectos");
+    await expect(dialog.getByRole("link", { name: /Impacto/ })).toHaveAttribute("href", "/impacto");
+  } else {
+    const header = page.getByRole("banner");
+    await header.getByRole("button", { name: "Abrir menú Recursos" }).click();
+    await expect(header.getByRole("link", { name: /Biblioteca/ })).toHaveAttribute("href", "/biblioteca");
+    await expect(header.getByRole("link", { name: /Proyectos \/ Casos/ })).toHaveAttribute("href", "/proyectos");
+    await expect(header.getByRole("link", { name: /Impacto/ })).toHaveAttribute("href", "/impacto");
+  }
+});
+
+test("Casa & Jardín is functional but remains non-indexed until B2C validation closes", async ({ page }) => {
   await page.goto("/casa-jardin");
   await expect(page.getByRole("heading", { name: "Nutrición por etapas para tus plantas." })).toBeVisible();
   await expect(page.getByText("CRECE", { exact: true }).first()).toBeVisible();
@@ -35,30 +80,43 @@ test("Casa y Jardín is functional but remains non-indexed until B2C validation 
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
 });
 
-test("nested public routes inherit the same shell", async ({ page }) => {
+test("nested public routes inherit the same shell", async ({ page }, testInfo) => {
   await page.goto("/soluciones/diagnostico-caracterizacion");
   const header = page.getByRole("banner");
   const footer = page.getByRole("contentinfo");
-  await expect(header.getByRole("navigation", { name: "Navegación pública" })).toBeVisible();
+
+  if (isMobile(testInfo)) {
+    await expect(header.getByRole("button", { name: "Abrir navegación" })).toBeVisible();
+  } else {
+    await expect(header.getByRole("navigation", { name: "Navegación pública" })).toBeVisible();
+  }
+
   await expect(page.getByRole("heading", { name: /Diagnóstico y caracterización/i })).toBeVisible();
   await expect(footer.getByText(/Centro Empresarial Alcalá/)).toBeVisible();
-  await expect(footer.getByRole("link", { name: "Casa y Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
-  await expect(footer.getByRole("link", { name: "GREENATICS OPS" })).toHaveAttribute("href", "/app");
+  await expect(footer.getByRole("link", { name: "Casa & Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
+  await expect(footer.getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
 });
 
-test("every governed public route renders exactly one shared shell", async ({ page }) => {
+test("every governed public route renders exactly one shared shell", async ({ page }, testInfo) => {
   for (const route of shellRoutes) {
     await page.goto(route);
+    const header = page.getByRole("banner");
     const footer = page.getByRole("contentinfo");
     await expect(page.locator("header"), `${route} should have one header`).toHaveCount(1);
     await expect(page.locator("footer"), `${route} should have one footer`).toHaveCount(1);
-    await expect(page.getByRole("navigation", { name: "Navegación pública" }), `${route} should expose the shared navigation`).toBeVisible();
-    await expect(footer.getByRole("link", { name: "Casa y Jardín", exact: true }), `${route} should expose the household route in the shared footer`).toHaveAttribute("href", "/casa-jardin");
-    await expect(footer.getByRole("link", { name: "GREENATICS OPS" }), `${route} should expose the OPS bridge`).toHaveAttribute("href", "/app");
+
+    if (isMobile(testInfo)) {
+      await expect(header.getByRole("button", { name: "Abrir navegación" }), `${route} should expose the mobile shell trigger`).toBeVisible();
+    } else {
+      await expect(header.getByRole("navigation", { name: "Navegación pública" }), `${route} should expose the shared navigation`).toBeVisible();
+    }
+
+    await expect(footer.getByRole("link", { name: "Casa & Jardín", exact: true }), `${route} should expose the household route in the shared footer`).toHaveAttribute("href", "/casa-jardin");
+    await expect(footer.getByRole("link", { name: "Ingresar", exact: true }), `${route} should expose the digital bridge`).toHaveAttribute("href", "/app");
   }
 });
 
-test("sitemap exposes indexed routes while Casa and Jardín remains reserved", async ({ request }) => {
+test("sitemap exposes indexed routes while Casa & Jardín remains reserved", async ({ request }) => {
   const sitemap = await request.get("/sitemap.xml");
   expect(sitemap.ok()).toBe(true);
   const sitemapText = await sitemap.text();

--- a/e2e/public-shell-v2.spec.ts
+++ b/e2e/public-shell-v2.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+test("desktop shell exposes the approved Soluciones mega-menu and closes with Escape", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop-chromium", "desktop shell contract");
+  await page.goto("/");
+
+  const header = page.getByRole("banner");
+  const nav = header.getByRole("navigation", { name: "Navegación pública" });
+  await expect(nav.getByRole("link", { name: "Soluciones", exact: true })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Wondergreen", exact: true })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Casa & Jardín", exact: true })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Recursos", exact: true })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Nosotros", exact: true })).toBeVisible();
+
+  await header.getByRole("button", { name: "Abrir menú Soluciones" }).click();
+  const menu = header.getByRole("group", { name: "Menú Soluciones" });
+  await expect(menu).toBeVisible();
+  await expect(menu.getByRole("link", { name: /ESP \/ Prestador/ })).toHaveAttribute("href", "/soluciones/esp-municipios");
+  await expect(menu.getByRole("link", { name: /Municipio/ }).first()).toHaveAttribute("href", "/soluciones/esp-municipios");
+  await expect(menu.getByRole("link", { name: /Empresa \/ Gran generador/ })).toHaveAttribute("href", "/soluciones/empresas-grandes-generadores");
+  await expect(menu.getByRole("link", { name: /Propiedad horizontal \/ Institución/ })).toHaveAttribute("href", "/soluciones/propiedad-horizontal-redes");
+  await expect(menu.getByRole("link", { name: /Planta \/ Operador/ })).toHaveAttribute("href", "/soluciones/infraestructura-plantas");
+  await expect(menu.getByRole("link", { name: /Diagnóstico inicial Greenatics/ })).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
+
+  await page.keyboard.press("Escape");
+  await expect(menu).toHaveCount(0);
+});
+
+test("mobile shell uses a two-level drawer and returns focus after Escape", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "mobile-chromium", "mobile shell contract");
+  await page.goto("/");
+
+  const trigger = page.getByRole("button", { name: "Abrir navegación" });
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+
+  const dialog = page.getByRole("dialog", { name: "Navegación Greenatics" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("link", { name: "Wondergreen", exact: true })).toBeVisible();
+  await expect(dialog.getByRole("link", { name: "Casa & Jardín", exact: true })).toBeVisible();
+  await expect(dialog.getByRole("link", { name: "Hablar con nosotros", exact: true })).toHaveAttribute("href", "/contacto");
+  await expect(dialog.getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
+
+  await dialog.getByRole("button", { name: /Soluciones/ }).click();
+  await expect(dialog.getByText("Por organización", { exact: true })).toBeVisible();
+  await expect(dialog.getByRole("link", { name: /ESP \/ Prestador/ })).toHaveAttribute("href", "/soluciones/esp-municipios");
+  await expect(dialog.getByRole("link", { name: /Iniciar por diagnóstico/ })).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+  await expect(trigger).toBeFocused();
+});

--- a/e2e/public-solutions.spec.ts
+++ b/e2e/public-solutions.spec.ts
@@ -7,6 +7,18 @@ async function jsonLdByType(page: import("@playwright/test").Page, type: string)
     .filter((payload) => payload["@type"] === type);
 }
 
+async function clickDigitalBridge(page: import("@playwright/test").Page) {
+  const header = page.getByRole("banner");
+  const desktopEntry = header.getByRole("link", { name: "Ingresar", exact: true });
+  if (await desktopEntry.isVisible()) {
+    await desktopEntry.click();
+    return;
+  }
+
+  await header.getByRole("button", { name: "Abrir navegación" }).click();
+  await page.getByRole("dialog", { name: "Navegación Greenatics" }).getByRole("link", { name: "Ingresar", exact: true }).click();
+}
+
 test("solutions hub exposes strategic programs, decision modules, six commercial lines and governed services", async ({ page }) => {
   await page.goto("/soluciones");
 
@@ -145,9 +157,9 @@ test("specialized organics service does not present Greenatics as public-service
   await expect(page.getByText(/ni convierte automáticamente a Greenatics en prestador frente al usuario/i)).toBeVisible();
 });
 
-test("public solutions route keeps the bridge to OPS", async ({ page }) => {
+test("public solutions route keeps the bridge to the Greenatics digital space", async ({ page }) => {
   await page.goto("/soluciones");
-  await page.getByRole("banner").getByRole("link", { name: "Acceder a Greenatics" }).click();
+  await clickDigitalBridge(page);
   await expect(page).toHaveURL(/\/app$/);
   await expect(page.getByRole("heading", { name: "Operación de hoy" })).toBeVisible();
 });

--- a/e2e/public-web.spec.ts
+++ b/e2e/public-web.spec.ts
@@ -1,11 +1,20 @@
 import { test, expect } from "@playwright/test";
 
-test("public home presents Greenatics and links to OPS", async ({ page }) => {
+async function digitalEntry(page: import("@playwright/test").Page) {
+  const header = page.getByRole("banner");
+  const desktopEntry = header.getByRole("link", { name: "Ingresar", exact: true });
+  if (await desktopEntry.isVisible()) return desktopEntry;
+
+  await header.getByRole("button", { name: "Abrir navegación" }).click();
+  return page.getByRole("dialog", { name: "Navegación Greenatics" }).getByRole("link", { name: "Ingresar", exact: true });
+}
+
+test("public home presents Greenatics and exposes the digital bridge", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByRole("heading", { name: /Transformar residuos en vida/i })).toBeVisible();
   await expect(page.getByRole("img", { name: "Greenatics" }).first()).toBeVisible();
-  await expect(page.getByRole("link", { name: "Acceder a Greenatics" })).toHaveAttribute("href", "/app");
+  await expect(await digitalEntry(page)).toHaveAttribute("href", "/app");
   await expect(page.getByRole("heading", { name: "Más que NPK." })).toBeVisible();
   await expect(page.getByText("5", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("referencias líquidas", { exact: true })).toBeVisible();
@@ -27,7 +36,7 @@ test("Wondergreen exposes fertilizers, bioinputs and technology narrative", asyn
 
 test("public-to-internal bridge lands on OPS home", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("link", { name: "Acceder a Greenatics" }).click();
+  await (await digitalEntry(page)).click();
   await expect(page).toHaveURL(/\/app$/);
   await expect(page.getByRole("heading", { name: "Operación de hoy" })).toBeVisible();
 });

--- a/e2e/wondergreen-editorial.spec.ts
+++ b/e2e/wondergreen-editorial.spec.ts
@@ -1,13 +1,18 @@
 import { test, expect } from "@playwright/test";
 
-test("Wondergreen uses the canonical public shell without duplicate chrome", async ({ page }) => {
+test("Wondergreen uses the canonical public shell without duplicate chrome", async ({ page }, testInfo) => {
   await page.goto("/wondergreen");
 
-  await expect(page.getByRole("banner")).toHaveCount(1);
+  const header = page.getByRole("banner");
+  await expect(header).toHaveCount(1);
   await expect(page.getByRole("contentinfo")).toHaveCount(1);
-  await expect(page.getByRole("navigation", { name: "Navegación pública" })).toBeVisible();
+  if (testInfo.project.name === "mobile-chromium") {
+    await expect(header.getByRole("button", { name: "Abrir navegación" })).toBeVisible();
+  } else {
+    await expect(header.getByRole("navigation", { name: "Navegación pública" })).toBeVisible();
+  }
   await expect(page.getByRole("navigation", { name: "Navegación Wondergreen" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "GREENATICS OPS" })).toHaveAttribute("href", "/app");
+  await expect(page.getByRole("contentinfo").getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
 });
 
 test("Wondergreen subnavigation connects products, crops, Casa Jardin and knowledge", async ({ page }) => {

--- a/src/components/public-header.tsx
+++ b/src/components/public-header.tsx
@@ -24,8 +24,8 @@ function isCurrentPath(pathname: string, href: string) {
 function isPrimaryActive(pathname: string, label: string, href: string) {
   if (label === "Soluciones") return pathname.startsWith("/soluciones");
   if (label === "Recursos") {
-    return ["/biblioteca", "/proyectos", "/impacto", "/recursos"].some((prefix) =>
-      pathname === prefix || pathname.startsWith(`${prefix}/`),
+    return ["/biblioteca", "/proyectos", "/impacto", "/recursos"].some(
+      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
     );
   }
   return isCurrentPath(pathname, href);
@@ -49,12 +49,6 @@ export function PublicHeader() {
   const mobileMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setDesktopMenu(null);
-    setMobileOpen(false);
-    setMobilePanel(null);
-  }, [pathname]);
-
-  useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       if (event.key !== "Escape") return;
       if (mobileOpen) {
@@ -75,8 +69,7 @@ export function PublicHeader() {
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     requestAnimationFrame(() => {
-      const first = mobileMenuRef.current?.querySelector<HTMLElement>("button, a[href]");
-      first?.focus();
+      mobileMenuRef.current?.querySelector<HTMLElement>("button, a[href]")?.focus();
     });
     return () => {
       document.body.style.overflow = previousOverflow;
@@ -124,15 +117,11 @@ export function PublicHeader() {
           </Link>
           <div className={styles.mobileSectionLabel}>Por organización</div>
           <div className={styles.mobileLinkList}>
-            {publicSolutionAudiences.map((item) => (
-              <MenuLink key={item.label} item={item} onNavigate={closeMobile} />
-            ))}
+            {publicSolutionAudiences.map((item) => <MenuLink key={item.label} item={item} onNavigate={closeMobile} />)}
           </div>
           <div className={styles.mobileSectionLabel}>Por necesidad</div>
           <div className={styles.mobileLinkList}>
-            {publicSolutionNeeds.map((item) => (
-              <MenuLink key={item.label} item={item} onNavigate={closeMobile} />
-            ))}
+            {publicSolutionNeeds.map((item) => <MenuLink key={item.label} item={item} onNavigate={closeMobile} />)}
           </div>
           <Link className={styles.mobileDiagnostic} href="/soluciones/diagnostico-caracterizacion" onClick={closeMobile}>
             <span>No sé por dónde empezar</span>
@@ -154,9 +143,7 @@ export function PublicHeader() {
             <strong>Aprender, ver experiencia y consultar impacto.</strong>
           </div>
           <div className={styles.mobileLinkList}>
-            {publicResourceNav.map((item) => (
-              <MenuLink key={item.label} item={item} onNavigate={closeMobile} />
-            ))}
+            {publicResourceNav.map((item) => <MenuLink key={item.label} item={item} onNavigate={closeMobile} />)}
           </div>
         </>
       );
@@ -210,9 +197,10 @@ export function PublicHeader() {
         <nav className={styles.desktopNav} aria-label="Navegación pública">
           {publicPrimaryNav.map((item) => {
             const active = isPrimaryActive(pathname, item.label, item.href);
+            const exact = isCurrentPath(pathname, item.href);
             if (!item.menu) {
               return (
-                <Link className={active ? styles.navActive : undefined} href={item.href} key={item.label} aria-current={active ? "page" : undefined}>
+                <Link className={active ? styles.navActive : undefined} href={item.href} key={item.label} aria-current={exact ? "page" : undefined}>
                   {item.label}
                 </Link>
               );
@@ -230,7 +218,7 @@ export function PublicHeader() {
                 }}
               >
                 <div className={styles.navMenuTrigger}>
-                  <Link className={active ? styles.navActive : undefined} href={item.href} aria-current={active ? "page" : undefined}>
+                  <Link className={active ? styles.navActive : undefined} href={item.href} aria-current={exact ? "page" : undefined}>
                     {item.label}
                   </Link>
                   <button
@@ -254,15 +242,11 @@ export function PublicHeader() {
                     </div>
                     <div className={styles.megaColumn}>
                       <span className={styles.megaLabel}>¿Quién eres?</span>
-                      {publicSolutionAudiences.map((menuItem) => (
-                        <MenuLink key={menuItem.label} item={menuItem} onNavigate={() => setDesktopMenu(null)} />
-                      ))}
+                      {publicSolutionAudiences.map((item) => <MenuLink key={item.label} item={item} onNavigate={() => setDesktopMenu(null)} />)}
                     </div>
                     <div className={styles.megaColumn}>
                       <span className={styles.megaLabel}>¿Qué necesitas resolver?</span>
-                      {publicSolutionNeeds.map((menuItem) => (
-                        <MenuLink key={menuItem.label} item={menuItem} onNavigate={() => setDesktopMenu(null)} />
-                      ))}
+                      {publicSolutionNeeds.map((item) => <MenuLink key={item.label} item={item} onNavigate={() => setDesktopMenu(null)} />)}
                     </div>
                     <Link className={styles.megaDiagnostic} href="/soluciones/diagnostico-caracterizacion" onClick={() => setDesktopMenu(null)}>
                       <span>No sé por dónde empezar</span>
@@ -279,9 +263,7 @@ export function PublicHeader() {
                       <strong>Conocimiento, experiencia e impacto en un mismo lugar.</strong>
                     </div>
                     <div className={styles.megaColumn}>
-                      {publicResourceNav.map((menuItem) => (
-                        <MenuLink key={menuItem.label} item={menuItem} onNavigate={() => setDesktopMenu(null)} />
-                      ))}
+                      {publicResourceNav.map((item) => <MenuLink key={item.label} item={item} onNavigate={() => setDesktopMenu(null)} />)}
                     </div>
                   </div>
                 ) : null}

--- a/src/components/public-header.tsx
+++ b/src/components/public-header.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import {
+  publicPrimaryNav,
+  publicResourceNav,
+  publicSolutionAudiences,
+  publicSolutionNeeds,
+  type PublicMenuItem,
+} from "@/data/public-navigation";
+import styles from "./public-shell.module.css";
+
+type DesktopMenu = "solutions" | "resources" | null;
+type MobilePanel = "solutions" | "resources" | null;
+
+function isCurrentPath(pathname: string, href: string) {
+  if (href === "/") return pathname === "/";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+function isPrimaryActive(pathname: string, label: string, href: string) {
+  if (label === "Soluciones") return pathname.startsWith("/soluciones");
+  if (label === "Recursos") {
+    return ["/biblioteca", "/proyectos", "/impacto", "/recursos"].some((prefix) =>
+      pathname === prefix || pathname.startsWith(`${prefix}/`),
+    );
+  }
+  return isCurrentPath(pathname, href);
+}
+
+function MenuLink({ item, onNavigate }: { item: PublicMenuItem; onNavigate: () => void }) {
+  return (
+    <Link className={styles.menuLink} href={item.href} onClick={onNavigate}>
+      <strong>{item.label}</strong>
+      <span>{item.description}</span>
+    </Link>
+  );
+}
+
+export function PublicHeader() {
+  const pathname = usePathname();
+  const [desktopMenu, setDesktopMenu] = useState<DesktopMenu>(null);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [mobilePanel, setMobilePanel] = useState<MobilePanel>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setDesktopMenu(null);
+    setMobileOpen(false);
+    setMobilePanel(null);
+  }, [pathname]);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      if (mobileOpen) {
+        setMobileOpen(false);
+        setMobilePanel(null);
+        requestAnimationFrame(() => menuButtonRef.current?.focus());
+        return;
+      }
+      setDesktopMenu(null);
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [mobileOpen]);
+
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    requestAnimationFrame(() => {
+      const first = mobileMenuRef.current?.querySelector<HTMLElement>("button, a[href]");
+      first?.focus();
+    });
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [mobileOpen]);
+
+  function closeMobile() {
+    setMobileOpen(false);
+    setMobilePanel(null);
+  }
+
+  function trapMobileFocus(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "Tab") return;
+    const focusable = Array.from(
+      event.currentTarget.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((element) => element.offsetParent !== null);
+    if (!focusable.length) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function renderMobileMenu() {
+    if (mobilePanel === "solutions") {
+      return (
+        <>
+          <button className={styles.mobileBack} type="button" onClick={() => setMobilePanel(null)}>
+            <span aria-hidden="true">←</span> Volver
+          </button>
+          <div className={styles.mobilePanelHead}>
+            <span>Soluciones Greenatics</span>
+            <strong>Empieza por quién eres o por lo que necesitas resolver.</strong>
+          </div>
+          <Link className={styles.mobileFeaturedLink} href="/soluciones" onClick={closeMobile}>
+            Ver todas las soluciones <span aria-hidden="true">→</span>
+          </Link>
+          <div className={styles.mobileSectionLabel}>Por organización</div>
+          <div className={styles.mobileLinkList}>
+            {publicSolutionAudiences.map((item) => (
+              <MenuLink key={item.label} item={item} onNavigate={closeMobile} />
+            ))}
+          </div>
+          <div className={styles.mobileSectionLabel}>Por necesidad</div>
+          <div className={styles.mobileLinkList}>
+            {publicSolutionNeeds.map((item) => (
+              <MenuLink key={item.label} item={item} onNavigate={closeMobile} />
+            ))}
+          </div>
+          <Link className={styles.mobileDiagnostic} href="/soluciones/diagnostico-caracterizacion" onClick={closeMobile}>
+            <span>No sé por dónde empezar</span>
+            <strong>Iniciar por diagnóstico</strong>
+            <span aria-hidden="true">→</span>
+          </Link>
+        </>
+      );
+    }
+
+    if (mobilePanel === "resources") {
+      return (
+        <>
+          <button className={styles.mobileBack} type="button" onClick={() => setMobilePanel(null)}>
+            <span aria-hidden="true">←</span> Volver
+          </button>
+          <div className={styles.mobilePanelHead}>
+            <span>Recursos Greenatics</span>
+            <strong>Aprender, ver experiencia y consultar impacto.</strong>
+          </div>
+          <div className={styles.mobileLinkList}>
+            {publicResourceNav.map((item) => (
+              <MenuLink key={item.label} item={item} onNavigate={closeMobile} />
+            ))}
+          </div>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <div className={styles.mobilePanelHead}>
+          <span>Navegación</span>
+          <strong>Encuentra el universo Greenatics que necesitas.</strong>
+        </div>
+        <div className={styles.mobilePrimaryNav}>
+          {publicPrimaryNav.map((item) => {
+            const active = isPrimaryActive(pathname, item.label, item.href);
+            if (item.menu) {
+              return (
+                <button
+                  className={active ? styles.mobilePrimaryActive : undefined}
+                  key={item.label}
+                  type="button"
+                  onClick={() => setMobilePanel(item.menu ?? null)}
+                >
+                  <span>{item.label}</span>
+                  <span aria-hidden="true">→</span>
+                </button>
+              );
+            }
+            return (
+              <Link className={active ? styles.mobilePrimaryActive : undefined} href={item.href} key={item.label} onClick={closeMobile}>
+                <span>{item.label}</span>
+                <span aria-hidden="true">→</span>
+              </Link>
+            );
+          })}
+        </div>
+        <div className={styles.mobileActions}>
+          <Link className={styles.mobileTalk} href="/contacto" onClick={closeMobile}>Hablar con nosotros</Link>
+          <a className={styles.mobileEnter} href="/app" onClick={closeMobile}>Ingresar</a>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <header className={styles.header}>
+      <div className={styles.headerInner}>
+        <Link className={styles.brand} href="/" aria-label="Greenatics, inicio">
+          <Image src="/brand/greenatics-horizontal.webp" alt="Greenatics" width={360} height={66} priority sizes="(max-width: 720px) 180px, 205px" />
+        </Link>
+
+        <nav className={styles.desktopNav} aria-label="Navegación pública">
+          {publicPrimaryNav.map((item) => {
+            const active = isPrimaryActive(pathname, item.label, item.href);
+            if (!item.menu) {
+              return (
+                <Link className={active ? styles.navActive : undefined} href={item.href} key={item.label} aria-current={active ? "page" : undefined}>
+                  {item.label}
+                </Link>
+              );
+            }
+
+            const open = desktopMenu === item.menu;
+            return (
+              <div
+                className={styles.navMenuGroup}
+                key={item.label}
+                onMouseEnter={() => setDesktopMenu(item.menu ?? null)}
+                onMouseLeave={() => setDesktopMenu(null)}
+                onBlur={(event) => {
+                  if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setDesktopMenu(null);
+                }}
+              >
+                <div className={styles.navMenuTrigger}>
+                  <Link className={active ? styles.navActive : undefined} href={item.href} aria-current={active ? "page" : undefined}>
+                    {item.label}
+                  </Link>
+                  <button
+                    type="button"
+                    aria-label={`Abrir menú ${item.label}`}
+                    aria-expanded={open}
+                    aria-haspopup="true"
+                    onClick={() => setDesktopMenu(open ? null : item.menu ?? null)}
+                    onFocus={() => setDesktopMenu(item.menu ?? null)}
+                  >
+                    <span aria-hidden="true">⌄</span>
+                  </button>
+                </div>
+
+                {open && item.menu === "solutions" ? (
+                  <div className={`${styles.megaMenu} ${styles.solutionsMenu}`} role="group" aria-label="Menú Soluciones">
+                    <div className={styles.megaIntro}>
+                      <span>Soluciones Greenatics</span>
+                      <strong>Empieza por tu contexto. Después profundizamos en el servicio.</strong>
+                      <Link href="/soluciones" onClick={() => setDesktopMenu(null)}>Ver todas las soluciones →</Link>
+                    </div>
+                    <div className={styles.megaColumn}>
+                      <span className={styles.megaLabel}>¿Quién eres?</span>
+                      {publicSolutionAudiences.map((menuItem) => (
+                        <MenuLink key={menuItem.label} item={menuItem} onNavigate={() => setDesktopMenu(null)} />
+                      ))}
+                    </div>
+                    <div className={styles.megaColumn}>
+                      <span className={styles.megaLabel}>¿Qué necesitas resolver?</span>
+                      {publicSolutionNeeds.map((menuItem) => (
+                        <MenuLink key={menuItem.label} item={menuItem} onNavigate={() => setDesktopMenu(null)} />
+                      ))}
+                    </div>
+                    <Link className={styles.megaDiagnostic} href="/soluciones/diagnostico-caracterizacion" onClick={() => setDesktopMenu(null)}>
+                      <span>No sé por dónde empezar</span>
+                      <strong>Diagnóstico inicial Greenatics</strong>
+                      <span aria-hidden="true">→</span>
+                    </Link>
+                  </div>
+                ) : null}
+
+                {open && item.menu === "resources" ? (
+                  <div className={`${styles.megaMenu} ${styles.resourcesMenu}`} role="group" aria-label="Menú Recursos">
+                    <div className={styles.megaIntro}>
+                      <span>Recursos Greenatics</span>
+                      <strong>Conocimiento, experiencia e impacto en un mismo lugar.</strong>
+                    </div>
+                    <div className={styles.megaColumn}>
+                      {publicResourceNav.map((menuItem) => (
+                        <MenuLink key={menuItem.label} item={menuItem} onNavigate={() => setDesktopMenu(null)} />
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </nav>
+
+        <div className={styles.actions}>
+          <Link className={styles.contact} href="/contacto">Hablar con nosotros</Link>
+          <a className={styles.ops} href="/app">Ingresar</a>
+          <button
+            ref={menuButtonRef}
+            className={styles.menuToggle}
+            type="button"
+            aria-label="Abrir navegación"
+            aria-expanded={mobileOpen}
+            aria-controls="public-mobile-menu"
+            onClick={() => {
+              setMobileOpen((current) => !current);
+              setMobilePanel(null);
+            }}
+          >
+            <span aria-hidden="true" />
+            <span aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      {mobileOpen ? (
+        <>
+          <div className={styles.mobileBackdrop} aria-hidden="true" onClick={closeMobile} />
+          <div
+            ref={mobileMenuRef}
+            className={styles.mobileMenu}
+            id="public-mobile-menu"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Navegación Greenatics"
+            onKeyDown={trapMobileFocus}
+          >
+            <div className={styles.mobileMenuTop}>
+              <Image src="/brand/greenatics-horizontal.webp" alt="Greenatics" width={360} height={66} sizes="180px" />
+              <button type="button" onClick={closeMobile} aria-label="Cerrar navegación">×</button>
+            </div>
+            <div className={styles.mobileMenuBody}>{renderMobileMenu()}</div>
+          </div>
+        </>
+      ) : null}
+    </header>
+  );
+}

--- a/src/components/public-header.tsx
+++ b/src/components/public-header.tsx
@@ -227,7 +227,6 @@ export function PublicHeader() {
                     aria-expanded={open}
                     aria-haspopup="true"
                     onClick={() => setDesktopMenu(open ? null : item.menu ?? null)}
-                    onFocus={() => setDesktopMenu(item.menu ?? null)}
                   >
                     <span aria-hidden="true">⌄</span>
                   </button>

--- a/src/components/public-shell.module.css
+++ b/src/components/public-shell.module.css
@@ -9,7 +9,7 @@
   position: fixed;
   left: 16px;
   top: -80px;
-  z-index: 1000;
+  z-index: 200;
   border-radius: 4px;
   background: #043022;
   color: #fff;
@@ -25,24 +25,24 @@
 .header {
   position: sticky;
   top: 0;
-  z-index: 80;
-  border-top: 4px solid #7db43c;
-  border-bottom: 1px solid rgba(66, 88, 78, 0.16);
-  background: rgba(247, 250, 248, 0.96);
-  backdrop-filter: blur(14px);
+  z-index: 100;
+  border-top: 4px solid #b8d65f;
+  border-bottom: 1px solid rgba(24, 36, 31, 0.12);
+  background: rgba(251, 250, 245, 0.96);
+  backdrop-filter: blur(16px);
 }
 
 .headerInner,
 .footerGrid,
 .footerBottom {
-  width: min(1240px, calc(100% - 48px));
+  width: min(1320px, calc(100% - 56px));
   margin: 0 auto;
 }
 
 .headerInner {
   min-height: 78px;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 30px;
 }
@@ -55,7 +55,8 @@
 }
 
 .brand img,
-.footerBrand img {
+.footerBrand img,
+.mobileMenuTop img {
   display: block;
   width: auto;
   height: 34px;
@@ -63,81 +64,320 @@
   object-fit: contain;
 }
 
-.nav {
+.desktopNav {
   display: flex;
   justify-content: center;
-  align-items: center;
-  gap: 20px;
+  align-items: stretch;
+  gap: 8px;
   min-width: 0;
+  height: 78px;
 }
 
-.nav a,
-.actions a,
-.footerLinks a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.nav a {
+.desktopNav > a,
+.navMenuTrigger > a {
+  position: relative;
   min-height: 44px;
   display: inline-flex;
   align-items: center;
-  font-size: 0.78rem;
-  font-weight: 750;
-  letter-spacing: 0.055em;
-  text-transform: uppercase;
+  color: #263a31;
+  font-size: 0.88rem;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+  text-decoration: none;
   white-space: nowrap;
 }
 
-.nav a:hover,
-.nav a:focus-visible,
-.footerLinks a:hover,
-.footerLinks a:focus-visible {
-  text-decoration: underline;
-  text-underline-offset: 5px;
+.desktopNav > a {
+  padding: 0 10px;
 }
 
-.nav a:focus-visible,
-.actions a:focus-visible,
-.brand:focus-visible,
-.footer a:focus-visible {
-  outline: 3px solid #f4d944;
-  outline-offset: 4px;
+.desktopNav > a::after,
+.navMenuTrigger > a::after {
+  content: "";
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 16px;
+  height: 2px;
+  background: #0a7a4b;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 160ms ease;
 }
 
-.mobileContact {
-  display: none !important;
+.desktopNav > a:hover::after,
+.desktopNav > a:focus-visible::after,
+.navMenuTrigger > a:hover::after,
+.navMenuTrigger > a:focus-visible::after,
+.navActive::after {
+  transform: scaleX(1) !important;
+}
+
+.navMenuGroup {
+  display: flex;
+  align-items: stretch;
+}
+
+.navMenuTrigger {
+  display: flex;
+  align-items: center;
+  min-height: 78px;
+}
+
+.navMenuTrigger > a {
+  padding-left: 10px;
+  padding-right: 2px;
+}
+
+.navMenuTrigger > button {
+  width: 34px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: #5d6c65;
+  cursor: pointer;
+  font: inherit;
+}
+
+.navMenuTrigger > button span {
+  display: inline-block;
+  font-size: 1rem;
+  line-height: 1;
+  transition: transform 160ms ease;
+}
+
+.navMenuTrigger > button[aria-expanded="true"] span {
+  transform: rotate(180deg);
+}
+
+.megaMenu {
+  position: fixed;
+  top: 82px;
+  left: 50%;
+  z-index: 105;
+  width: min(1060px, calc(100vw - 64px));
+  max-height: calc(100vh - 104px);
+  overflow-y: auto;
+  transform: translateX(-50%);
+  border: 1px solid rgba(24, 36, 31, 0.12);
+  border-top: 3px solid #b8d65f;
+  border-radius: 0 0 10px 10px;
+  background: #fbfaf5;
+  box-shadow: 0 26px 80px rgba(11, 36, 28, 0.18);
+  color: #18241f;
+}
+
+.solutionsMenu {
+  display: grid;
+  grid-template-columns: 0.72fr 1fr 1fr;
+  gap: 0;
+  padding: 24px;
+}
+
+.resourcesMenu {
+  width: min(620px, calc(100vw - 64px));
+  display: grid;
+  grid-template-columns: 0.85fr 1.15fr;
+  gap: 0;
+  padding: 24px;
+}
+
+.megaIntro {
+  padding: 8px 26px 8px 8px;
+  border-right: 1px solid rgba(24, 36, 31, 0.11);
+}
+
+.megaIntro > span,
+.megaLabel,
+.mobilePanelHead > span,
+.mobileSectionLabel {
+  display: block;
+  color: #0a7a4b;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.megaIntro > strong {
+  display: block;
+  margin-top: 12px;
+  color: #18241f;
+  font-family: Iowan Old Style, Palatino Linotype, Book Antiqua, Palatino, Georgia, serif;
+  font-size: 1.52rem;
+  font-weight: 500;
+  line-height: 1.13;
+}
+
+.megaIntro > a {
+  display: inline-flex;
+  margin-top: 22px;
+  color: #0a7a4b;
+  font-size: 0.82rem;
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.megaColumn {
+  padding: 8px 18px;
+}
+
+.megaColumn + .megaColumn {
+  border-left: 1px solid rgba(24, 36, 31, 0.08);
+}
+
+.megaLabel {
+  margin: 0 8px 8px;
+}
+
+.menuLink {
+  display: block;
+  border-radius: 5px;
+  padding: 9px 8px;
+  color: inherit;
+  text-decoration: none;
+  transition: background-color 140ms ease, transform 140ms ease;
+}
+
+.menuLink:hover,
+.menuLink:focus-visible {
+  background: #f0ede3;
+  transform: translateX(2px);
+  outline: none;
+}
+
+.menuLink strong {
+  display: block;
+  color: #18241f;
+  font-size: 0.84rem;
+  font-weight: 750;
+  line-height: 1.25;
+}
+
+.menuLink span {
+  display: block;
+  margin-top: 3px;
+  color: #69736d;
+  font-size: 0.71rem;
+  line-height: 1.35;
+}
+
+.megaDiagnostic {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 16px;
+  margin-top: 18px;
+  border-radius: 6px;
+  background: #12372c;
+  color: #fff;
+  padding: 15px 18px;
+  text-decoration: none;
+}
+
+.megaDiagnostic > span:first-child {
+  color: #b8d65f;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.megaDiagnostic strong {
+  font-size: 0.9rem;
+}
+
+.megaDiagnostic > span:last-child {
+  font-size: 1.2rem;
 }
 
 .actions {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
   min-width: 0;
 }
 
 .contact,
-.ops {
+.ops,
+.mobileTalk,
+.mobileEnter {
   min-height: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
+  border-radius: 5px;
   padding: 0 15px;
   font-size: 0.72rem;
   font-weight: 800;
-  letter-spacing: 0.055em;
+  letter-spacing: 0.045em;
+  text-decoration: none;
   text-transform: uppercase;
   white-space: nowrap;
 }
 
 .contact {
-  border: 1px solid rgba(66, 88, 78, 0.22);
+  border: 1px solid #0a7a4b;
+  color: #0a7a4b;
+  background: transparent;
+}
+
+.contact:hover,
+.contact:focus-visible {
+  background: rgba(10, 122, 75, 0.06);
 }
 
 .ops {
-  background: #063d2c;
-  color: #fff !important;
+  background: #0b241c;
+  color: #fff;
+}
+
+.ops:hover,
+.ops:focus-visible {
+  background: #12372c;
+}
+
+.menuToggle {
+  width: 44px;
+  height: 44px;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid rgba(24, 36, 31, 0.18);
+  border-radius: 5px;
+  background: transparent;
+  color: #18241f;
+  cursor: pointer;
+}
+
+.menuToggle > span {
+  width: 18px;
+  height: 1.5px;
+  background: currentColor;
+}
+
+.desktopNav a:focus-visible,
+.navMenuTrigger button:focus-visible,
+.actions a:focus-visible,
+.menuToggle:focus-visible,
+.brand:focus-visible,
+.footer a:focus-visible,
+.mobileMenu a:focus-visible,
+.mobileMenu button:focus-visible {
+  outline: 3px solid #ddc952;
+  outline-offset: 3px;
+}
+
+.mobileBackdrop,
+.mobileMenu {
+  display: none;
 }
 
 .main {
@@ -146,7 +386,7 @@
 
 .footer {
   margin-top: 0;
-  border-top: 8px solid #7db43c;
+  border-top: 8px solid #b8d65f;
   background: #043022;
   color: rgba(255, 255, 255, 0.84);
 }
@@ -196,6 +436,13 @@
   align-items: center;
   color: rgba(255, 255, 255, 0.74);
   font-size: 0.88rem;
+  text-decoration: none;
+}
+
+.footerLinks a:hover,
+.footerLinks a:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 5px;
 }
 
 .footerBottom {
@@ -209,26 +456,222 @@
   letter-spacing: 0.04em;
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 1100px) {
   .headerInner {
-    grid-template-columns: auto auto;
+    grid-template-columns: auto 1fr auto;
+    gap: 18px;
   }
 
-  .nav {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    justify-content: flex-start;
-    overflow-x: auto;
-    padding: 0 0 10px;
-    scrollbar-width: none;
-  }
-
-  .nav::-webkit-scrollbar {
+  .desktopNav {
     display: none;
   }
 
-  .actions {
-    justify-self: end;
+  .menuToggle {
+    display: inline-flex;
+  }
+
+  .mobileBackdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 108;
+    display: block;
+    background: rgba(5, 20, 15, 0.48);
+    backdrop-filter: blur(2px);
+  }
+
+  .mobileMenu {
+    position: fixed;
+    inset: 0 0 0 auto;
+    z-index: 110;
+    width: min(92vw, 470px);
+    height: 100dvh;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    background: #fbfaf5;
+    color: #18241f;
+    box-shadow: -24px 0 70px rgba(11, 36, 28, 0.22);
+  }
+
+  .mobileMenuTop {
+    min-height: 76px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    border-bottom: 1px solid rgba(24, 36, 31, 0.12);
+    padding: 0 22px;
+  }
+
+  .mobileMenuTop img {
+    height: 30px;
+  }
+
+  .mobileMenuTop button {
+    width: 44px;
+    height: 44px;
+    border: 0;
+    background: transparent;
+    color: #18241f;
+    cursor: pointer;
+    font-size: 2rem;
+    line-height: 1;
+  }
+
+  .mobileMenuBody {
+    overflow-y: auto;
+    padding: 24px 22px 34px;
+  }
+
+  .mobilePanelHead {
+    padding: 4px 0 20px;
+  }
+
+  .mobilePanelHead strong {
+    display: block;
+    max-width: 360px;
+    margin-top: 9px;
+    font-family: Iowan Old Style, Palatino Linotype, Book Antiqua, Palatino, Georgia, serif;
+    font-size: 1.7rem;
+    font-weight: 500;
+    line-height: 1.1;
+  }
+
+  .mobileBack {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin: -4px 0 14px;
+    border: 0;
+    background: transparent;
+    color: #0a7a4b;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.82rem;
+    font-weight: 750;
+  }
+
+  .mobileFeaturedLink {
+    min-height: 52px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-top: 1px solid rgba(24, 36, 31, 0.11);
+    border-bottom: 1px solid rgba(24, 36, 31, 0.11);
+    color: #0a7a4b;
+    font-size: 0.88rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
+
+  .mobileSectionLabel {
+    margin: 28px 0 8px;
+  }
+
+  .mobileLinkList {
+    display: grid;
+    gap: 2px;
+  }
+
+  .mobileLinkList .menuLink {
+    border-bottom: 1px solid rgba(24, 36, 31, 0.08);
+    border-radius: 0;
+    padding: 13px 2px;
+  }
+
+  .mobileLinkList .menuLink:hover,
+  .mobileLinkList .menuLink:focus-visible {
+    background: transparent;
+    transform: none;
+  }
+
+  .mobileLinkList .menuLink strong {
+    font-size: 0.92rem;
+  }
+
+  .mobileLinkList .menuLink span {
+    font-size: 0.76rem;
+    line-height: 1.45;
+  }
+
+  .mobileDiagnostic {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 4px 12px;
+    margin-top: 28px;
+    border-radius: 6px;
+    background: #12372c;
+    color: #fff;
+    padding: 17px 18px;
+    text-decoration: none;
+  }
+
+  .mobileDiagnostic > span:first-child {
+    grid-column: 1;
+    color: #b8d65f;
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .mobileDiagnostic strong {
+    grid-column: 1;
+    font-size: 0.94rem;
+  }
+
+  .mobileDiagnostic > span:last-child {
+    grid-column: 2;
+    grid-row: 1 / 3;
+    align-self: center;
+    font-size: 1.25rem;
+  }
+
+  .mobilePrimaryNav {
+    display: grid;
+    border-top: 1px solid rgba(24, 36, 31, 0.12);
+  }
+
+  .mobilePrimaryNav > a,
+  .mobilePrimaryNav > button {
+    min-height: 62px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    border: 0;
+    border-bottom: 1px solid rgba(24, 36, 31, 0.1);
+    background: transparent;
+    color: #18241f;
+    padding: 0 2px;
+    cursor: pointer;
+    font: inherit;
+    font-size: 1rem;
+    font-weight: 700;
+    text-align: left;
+    text-decoration: none;
+  }
+
+  .mobilePrimaryActive {
+    color: #0a7a4b !important;
+  }
+
+  .mobileActions {
+    display: grid;
+    grid-template-columns: 1fr 0.72fr;
+    gap: 10px;
+    margin-top: 28px;
+  }
+
+  .mobileTalk {
+    border: 1px solid #0a7a4b;
+    color: #0a7a4b;
+  }
+
+  .mobileEnter {
+    background: #0b241c;
+    color: #fff;
   }
 }
 
@@ -236,12 +679,12 @@
   .headerInner,
   .footerGrid,
   .footerBottom {
-    width: min(100% - 28px, 1240px);
+    width: min(100% - 28px, 1320px);
   }
 
   .headerInner {
-    min-height: 66px;
-    gap: 12px;
+    min-height: 68px;
+    gap: 10px;
   }
 
   .brand img {
@@ -252,22 +695,10 @@
     display: none;
   }
 
-  .mobileContact {
-    display: inline-flex !important;
-  }
-
   .ops {
     min-height: 40px;
-    padding: 0 11px;
+    padding: 0 12px;
     font-size: 0.66rem;
-  }
-
-  .nav {
-    gap: 20px;
-  }
-
-  .nav a {
-    font-size: 0.72rem;
   }
 
   .footerGrid {
@@ -286,7 +717,23 @@
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 520px) {
+  .ops {
+    display: none;
+  }
+
+  .mobileMenu {
+    width: 100vw;
+  }
+
+  .mobileMenuBody {
+    padding-inline: 18px;
+  }
+
+  .mobileActions {
+    grid-template-columns: 1fr;
+  }
+
   .footerGrid {
     grid-template-columns: 1fr;
   }
@@ -302,23 +749,21 @@
   }
 
   .brand img {
-    height: 24px;
+    height: 25px;
   }
 
-  .ops {
-    min-height: 38px;
-    padding: 0 8px;
-    font-size: 0.6rem;
-    letter-spacing: 0.035em;
-  }
-
-  .nav {
-    gap: 16px;
+  .menuToggle {
+    width: 40px;
+    height: 40px;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .skipLink {
+  .skipLink,
+  .desktopNav > a::after,
+  .navMenuTrigger > a::after,
+  .navMenuTrigger > button span,
+  .menuLink {
     transition: none;
   }
 }

--- a/src/components/public-shell.tsx
+++ b/src/components/public-shell.tsx
@@ -1,7 +1,8 @@
 import Image from "next/image";
 import Link from "next/link";
 import { OrganizationJsonLd } from "@/components/organization-json-ld";
-import { publicFooterNav, publicNav, publicSite } from "@/data/public-site";
+import { PublicHeader } from "@/components/public-header";
+import { publicFooterNav, publicSite } from "@/data/public-site";
 import styles from "./public-shell.module.css";
 
 type PublicShellProps = {
@@ -21,25 +22,7 @@ export function PublicShell({ children, ownsMain = true }: PublicShellProps) {
       <OrganizationJsonLd />
       <a className={styles.skipLink} href="#public-main">Saltar al contenido</a>
 
-      <header className={styles.header}>
-        <div className={styles.headerInner}>
-          <Link className={styles.brand} href="/" aria-label="Greenatics, inicio">
-            <Image src="/brand/greenatics-horizontal.webp" alt="Greenatics" width={360} height={66} priority sizes="(max-width: 720px) 180px, 205px" />
-          </Link>
-
-          <nav className={styles.nav} aria-label="Navegación pública">
-            {publicNav.map((item) => (
-              <Link key={item.href} href={item.href}>{item.label}</Link>
-            ))}
-            <Link className={styles.mobileContact} href="/contacto">Contacto</Link>
-          </nav>
-
-          <div className={styles.actions}>
-            <Link className={styles.contact} href="/contacto">Contacto</Link>
-            <a className={styles.ops} href="/app">Acceder a Greenatics</a>
-          </div>
-        </div>
-      </header>
+      <PublicHeader />
 
       {content}
 

--- a/src/data/public-navigation.ts
+++ b/src/data/public-navigation.ts
@@ -1,0 +1,120 @@
+export type PublicPrimaryNavItem = {
+  href: string;
+  label: string;
+  menu?: "solutions" | "resources";
+};
+
+export type PublicMenuItem = {
+  label: string;
+  description: string;
+  href: string;
+  canonicalHref?: string;
+};
+
+export const publicPrimaryNav: readonly PublicPrimaryNavItem[] = [
+  { href: "/soluciones", label: "Soluciones", menu: "solutions" },
+  { href: "/wondergreen", label: "Wondergreen" },
+  { href: "/casa-jardin", label: "Casa & Jardín" },
+  { href: "/biblioteca", label: "Recursos", menu: "resources" },
+  { href: "/nosotros", label: "Nosotros" },
+] as const;
+
+/**
+ * Transitional hrefs keep every menu destination live while the new audience
+ * landings are implemented. canonicalHref documents the approved IA target.
+ */
+export const publicSolutionAudiences: readonly PublicMenuItem[] = [
+  {
+    label: "ESP / Prestador",
+    description: "Preparación, regulación, rutas, operación, infraestructura y datos.",
+    href: "/soluciones/esp-municipios",
+    canonicalHref: "/soluciones/esp",
+  },
+  {
+    label: "Municipio",
+    description: "Planeación, PGIRS, activos, proyectos y fortalecimiento territorial.",
+    href: "/soluciones/esp-municipios",
+    canonicalHref: "/soluciones/municipios",
+  },
+  {
+    label: "Empresa / Gran generador",
+    description: "Caracterización, PMIRS, logística, tratamiento y trazabilidad.",
+    href: "/soluciones/empresas-grandes-generadores",
+    canonicalHref: "/soluciones/empresas",
+  },
+  {
+    label: "Propiedad horizontal / Institución",
+    description: "Diagnóstico por unidad, PMIRS, redes e información comparable.",
+    href: "/soluciones/propiedad-horizontal-redes",
+    canonicalHref: "/soluciones/propiedad-horizontal",
+  },
+  {
+    label: "Planta / Operador",
+    description: "Prefactibilidad, rehabilitación, optimización, dirección y datos.",
+    href: "/soluciones/infraestructura-plantas",
+    canonicalHref: "/soluciones/plantas",
+  },
+] as const;
+
+export const publicSolutionNeeds: readonly PublicMenuItem[] = [
+  {
+    label: "Entender mis residuos",
+    description: "Línea base, generación, caracterización y brechas.",
+    href: "/soluciones/diagnostico-caracterizacion",
+  },
+  {
+    label: "Organizar la gestión",
+    description: "Planes, responsables, actividades, indicadores y seguimiento.",
+    href: "/soluciones/pmirs",
+  },
+  {
+    label: "Gestión jurídica y regulatoria",
+    description: "Obligaciones, decisiones regulatorias y acciones concretas.",
+    href: "/soluciones",
+    canonicalHref: "/soluciones/juridica-regulacion",
+  },
+  {
+    label: "Mejorar rutas y logística",
+    description: "Usuarios, frecuencias, tiempos, capacidad, recorridos y destino.",
+    href: "/soluciones/rutas-selectivas",
+  },
+  {
+    label: "Evaluar o recuperar una planta",
+    description: "Decidir, diseñar, rehabilitar u optimizar infraestructura.",
+    href: "/soluciones/infraestructura-plantas",
+  },
+  {
+    label: "Mejorar la operación",
+    description: "Dirección técnica, protocolos, mantenimiento y control.",
+    href: "/soluciones/direccion-operacion",
+  },
+  {
+    label: "Organizar datos y trazabilidad",
+    description: "Registros, evidencia, indicadores y GREENATICS OPS.",
+    href: "/soluciones/trazabilidad-datos",
+  },
+  {
+    label: "Valorizar y desarrollar productos",
+    description: "Calidad, destinos y nuevas rutas de aprovechamiento.",
+    href: "/soluciones/residuos-organicos",
+    canonicalHref: "/soluciones/valorizacion-productos",
+  },
+] as const;
+
+export const publicResourceNav: readonly PublicMenuItem[] = [
+  {
+    label: "Biblioteca",
+    description: "Guías, manuales, programas por cultivo y recursos técnicos.",
+    href: "/biblioteca",
+  },
+  {
+    label: "Proyectos / Casos",
+    description: "Experiencia documentada, contexto y aprendizajes transferibles.",
+    href: "/proyectos",
+  },
+  {
+    label: "Impacto",
+    description: "Indicadores publicados únicamente cuando cuentan con gobierno y fuente.",
+    href: "/impacto",
+  },
+] as const;

--- a/src/data/public-site.test.ts
+++ b/src/data/public-site.test.ts
@@ -16,8 +16,8 @@ describe("public site contact configuration", () => {
     expect(publicSite.legacyIndexedDomain).toBe("https://greenatics.org");
   });
 
-  it("reserves Casa y Jardín in the primary navigation without promoting the placeholder to the sitemap", () => {
-    expect(publicNav).toContainEqual({ href: "/casa-jardin", label: "Casa y Jardín" });
+  it("reserves Casa & Jardín in the primary navigation without promoting the placeholder to the sitemap", () => {
+    expect(publicNav).toContainEqual({ href: "/casa-jardin", label: "Casa & Jardín" });
     expect(publicReservedRoutes).toContain("/casa-jardin");
     expect([...publicStaticRoutes]).not.toContain("/casa-jardin");
   });

--- a/src/data/public-site.ts
+++ b/src/data/public-site.ts
@@ -1,11 +1,13 @@
 import { protectedOpsRoutePrefixes } from "@/lib/ops-access-policy";
 
+export { publicPrimaryNav as publicNav } from "./public-navigation";
+
 export const publicSite = {
   name: "Greenatics",
   publicDomainTarget: "https://greenatics.com.co",
   legacyIndexedDomain: "https://greenatics.org",
   description:
-    "Greenatics conecta aprovechamiento de residuos orgánicos, tecnología, operación, Wondergreen, conocimiento y datos para devolver valor al territorio y al suelo.",
+    "Greenatics conecta gestión de residuos, ingeniería, operación, Wondergreen, conocimiento y datos para devolver valor al territorio y al suelo.",
   office: {
     line1: "Cra 43b # 14–51 · Oficina 204",
     line2: "Centro Empresarial Alcalá",
@@ -15,43 +17,32 @@ export const publicSite = {
     "https://outlook.office.com/bookwithme/user/661b1e2305fb4f36ac3022c32feba931@greenatics.com.co/meetingtype/e8FmGdFQVkiR3lb6KlHLUA2?anonymous&ep=owaSlotsCopyLink",
 } as const;
 
-export const publicNav = [
-  { href: "/soluciones", label: "Soluciones" },
-  { href: "/wondergreen", label: "Wondergreen" },
-  { href: "/casa-jardin", label: "Casa y Jardín" },
-  { href: "/proyectos", label: "Proyectos" },
-  { href: "/impacto", label: "Impacto" },
-  { href: "/biblioteca", label: "Conocimiento" },
-  { href: "/nosotros", label: "Nosotros" },
-] as const;
-
 export const publicFooterNav = [
   {
     title: "Explorar",
     links: [
       { href: "/soluciones", label: "Soluciones" },
-      { href: "/proyectos", label: "Proyectos" },
+      { href: "/biblioteca", label: "Recursos" },
+      { href: "/proyectos", label: "Proyectos / casos" },
       { href: "/impacto", label: "Impacto" },
-      { href: "/#tecnologia", label: "Tecnología" },
     ],
   },
   {
-    title: "Agro",
+    title: "Wondergreen",
     links: [
       { href: "/wondergreen", label: "Wondergreen" },
-      { href: "/casa-jardin", label: "Casa y Jardín" },
+      { href: "/casa-jardin", label: "Casa & Jardín" },
       { href: "/wondergreen/productos", label: "Productos" },
       { href: "/wondergreen/cultivos", label: "Cultivos" },
-      { href: "/biblioteca/manual-uso-wondergreen", label: "Manual de uso" },
-      { href: "/biblioteca", label: "Biblioteca" },
+      { href: "/biblioteca", label: "Guías y biblioteca" },
     ],
   },
   {
     title: "Greenatics",
     links: [
       { href: "/nosotros", label: "Nosotros" },
-      { href: "/contacto", label: "Contacto" },
-      { href: "/app", label: "GREENATICS OPS" },
+      { href: "/contacto", label: "Hablar con nosotros" },
+      { href: "/app", label: "Ingresar" },
     ],
   },
 ] as const;


### PR DESCRIPTION
## Objetivo
Implementa el Bloque 1 de la evolución UX pública: shell global, navegación simplificada y arquitectura preparada para las nuevas audiencias sin romper rutas existentes.

## Cambios
- Header público V2 con navegación principal reducida: Soluciones, Wondergreen, Casa & Jardín, Recursos y Nosotros.
- Mega-menú de Soluciones por organización y por necesidad.
- Recursos agrupa Biblioteca, Proyectos/ Casos e Impacto.
- CTA global `Hablar con nosotros` y acceso `Ingresar`.
- Drawer móvil real con segundo nivel, cierre por Escape, bloqueo de scroll y manejo de foco.
- Estados activos y foco visible.
- Navegación desacoplada en `public-navigation.ts`.
- Hrefs transitorios mantienen destinos actuales vivos mientras se construyen las nuevas landings; `canonicalHref` documenta la IA aprobada.
- Footer alineado con la nueva arquitectura.

## Alcance deliberado
Este PR no reescribe Home, Soluciones ni las páginas de audiencia. Tampoco publica RED ni crea nuevas promesas comerciales. Es únicamente el shell sobre el cual se implementarán los bloques posteriores.

## Validación esperada
- build/typecheck/lint
- navegación desktop y móvil
- teclado/focus/Escape
- rutas públicas existentes sin 404 desde el nuevo shell
- responsive en 1280, 1024, 768, 390 px