### PR TITLE
feat(public): Casa & Jardín V2 orientada por contexto y seguridad

### DIFF
--- a/src/app/casa-jardin/casa-jardin-v2.module.css
+++ b/src/app/casa-jardin/casa-jardin-v2.module.css
@@ -1,0 +1,243 @@
+.page {
+  --forest: #12372c;
+  --forest-deep: #0b241c;
+  --green: #0a7a4b;
+  --lime: #b8d65f;
+  --sun: #ddc952;
+  --ink: #18241f;
+  --muted: #69736d;
+  --paper: #fbfaf5;
+  --cream: #f0ede3;
+  --white: #ffffff;
+  --line: rgba(24, 36, 31, 0.16);
+  --line-dark: rgba(255, 255, 255, 0.18);
+  --display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Baskerville, Georgia, serif;
+  --sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: var(--ink);
+  background: var(--paper);
+  font-family: var(--sans);
+  line-height: 1.55;
+}
+
+.page *, .page *::before, .page *::after { box-sizing: border-box; }
+.page a { color: inherit; text-decoration: none; }
+.page a:focus-visible, .page summary:focus-visible { outline: 3px solid var(--sun); outline-offset: 4px; }
+.container { width: min(1240px, calc(100% - 48px)); margin: 0 auto; }
+.page h1, .page h2, .page h3 { margin: 0; font-family: var(--display); font-weight: 600; letter-spacing: -0.035em; line-height: 1.02; }
+.page h1 { font-size: clamp(4rem, 7.1vw, 7.3rem); }
+.page h2 { font-size: clamp(2.8rem, 4.8vw, 5rem); }
+.page h3 { font-size: clamp(1.55rem, 2.25vw, 2.3rem); }
+.page p { margin: 0; }
+
+.eyebrow { display: inline-block; margin-bottom: 15px; color: var(--green); font-size: .72rem; font-weight: 800; letter-spacing: .15em; text-transform: uppercase; }
+.eyebrowLight { color: #d8ed9c; }
+.index { color: var(--green); font-size: .7rem; font-weight: 800; letter-spacing: .12em; }
+
+.subnav { position: sticky; top: var(--public-header-height, 72px); z-index: 20; background: rgba(251, 250, 245, .94); border-bottom: 1px solid var(--line); backdrop-filter: blur(14px); }
+.subnav .container { min-height: 52px; display: flex; align-items: center; justify-content: space-between; gap: 28px; }
+.subnav .container > span { color: var(--forest); font-family: var(--display); font-size: 1.05rem; font-weight: 700; }
+.subnav .container > div { display: flex; align-items: center; gap: 22px; min-width: 0; overflow-x: auto; scrollbar-width: none; }
+.subnav .container > div::-webkit-scrollbar { display: none; }
+.subnav a { min-height: 44px; display: inline-flex; align-items: center; color: #56635c; font-size: .76rem; font-weight: 750; white-space: nowrap; }
+.subnav a:hover { color: var(--green); }
+
+.hero { position: relative; overflow: hidden; background: var(--cream); border-bottom: 1px solid var(--line); }
+.heroAccent { height: 8px; background: var(--lime); }
+.heroGrid { min-height: 760px; display: grid; grid-template-columns: minmax(0, 1.03fr) minmax(400px, .97fr); gap: 72px; align-items: center; padding: 74px 0 90px; }
+.heroCopy { min-width: 0; }
+.hero h1 { max-width: 800px; }
+.lead { max-width: 760px; margin-top: 28px; color: #4d5a53; font-size: clamp(1.06rem, 1.5vw, 1.26rem); line-height: 1.68; }
+.actions { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-top: 30px; }
+.button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; padding: 0 20px; border: 1px solid transparent; border-radius: 4px; font-size: .8rem; font-weight: 800; letter-spacing: .04em; text-transform: uppercase; transition: transform 160ms ease, background-color 160ms ease, border-color 160ms ease; }
+.button:hover { transform: translateY(-2px); }
+.primary { background: var(--green); color: var(--white) !important; }
+.ghost { border-color: var(--line); }
+.light { background: var(--paper); color: var(--forest-deep) !important; }
+.outlineLight { border-color: rgba(255,255,255,.42); color: var(--white) !important; }
+.textLink { min-height: 44px; display: inline-flex; align-items: center; color: var(--green) !important; font-weight: 800; border-bottom: 1px solid currentColor; }
+.heroTruth { max-width: 760px; margin-top: 42px; padding-top: 16px; border-top: 1px solid var(--line); display: grid; grid-template-columns: 160px 1fr; gap: 18px; align-items: start; }
+.heroTruth span { color: var(--green); font-size: .68rem; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+.heroTruth strong { color: #536059; font-size: .82rem; line-height: 1.6; }
+.heroVisual { position: relative; min-height: 610px; background: var(--forest); border-left: 8px solid var(--sun); display: grid; align-items: center; overflow: hidden; }
+.heroVisual img { display: block; width: 100%; height: 100%; object-fit: contain; object-position: center; padding: 20px; }
+.heroCaption { position: absolute; inset: auto 24px 24px 24px; padding: 14px 16px; background: rgba(11,36,28,.9); color: white; border-top: 1px solid rgba(216,237,156,.48); }
+.heroCaption strong { display: block; font-family: var(--display); font-size: 1.2rem; }
+.heroCaption small { display: block; margin-top: 3px; color: #c3d0c8; }
+
+.method { background: var(--forest-deep); color: var(--white); }
+.methodGrid { min-height: 76px; display: grid; grid-template-columns: repeat(5, 1fr); }
+.methodGrid > div { padding: 14px 16px; border-right: 1px solid var(--line-dark); display: flex; align-items: center; gap: 12px; }
+.methodGrid > div:last-child { border-right: 0; }
+.methodGrid span { color: #d8ed9c; font-size: .66rem; font-weight: 800; }
+.methodGrid strong { font-size: .76rem; letter-spacing: .09em; }
+
+.section { padding: 112px 0; }
+.sectionSoft { background: var(--cream); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.sectionHead { display: grid; grid-template-columns: minmax(0, 1.18fr) minmax(300px, .82fr); gap: 70px; align-items: end; margin-bottom: 48px; }
+.sectionHead p { color: var(--muted); font-size: 1.03rem; line-height: 1.72; }
+
+.contextGrid { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.contextItem { min-height: 300px; padding: 26px 28px 28px 0; border-right: 1px solid var(--line); display: flex; flex-direction: column; }
+.contextItem:not(:first-child) { padding-left: 28px; }
+.contextItem:last-child { border-right: 0; }
+.contextItem h3 { margin-top: 44px; }
+.contextItem p { margin-top: 16px; color: var(--muted); font-size: .94rem; line-height: 1.68; }
+.contextItem a { margin-top: auto; padding-top: 28px; color: var(--green); font-size: .82rem; font-weight: 800; }
+
+.safety { padding: 122px 0; background: var(--paper); }
+.safetyGrid { display: grid; grid-template-columns: minmax(0, .84fr) minmax(420px, 1.16fr); gap: 72px; align-items: start; }
+.safetyIntro { position: sticky; top: 154px; }
+.safetyIntro p { margin-top: 24px; max-width: 650px; color: var(--muted); font-size: 1.02rem; line-height: 1.72; }
+.safetyIntro .actions { margin-top: 28px; }
+.trafficList { border-top: 1px solid var(--line); }
+.trafficItem { min-height: 166px; display: grid; grid-template-columns: 84px 1fr; gap: 24px; align-items: center; padding: 26px 0; border-bottom: 1px solid var(--line); }
+.trafficLevel { width: 64px; aspect-ratio: 1; border-radius: 50%; display: grid; place-items: center; background: var(--cream); color: var(--forest); font-size: .6rem; font-weight: 900; letter-spacing: .08em; }
+.trafficItem:nth-child(1) .trafficLevel { box-shadow: inset 0 0 0 9px rgba(10,122,75,.24); }
+.trafficItem:nth-child(2) .trafficLevel { box-shadow: inset 0 0 0 9px rgba(221,201,82,.34); }
+.trafficItem:nth-child(3) .trafficLevel { box-shadow: inset 0 0 0 9px rgba(145,82,57,.24); }
+.trafficItem h3 { font-size: clamp(1.45rem, 2vw, 2rem); }
+.trafficItem p { margin-top: 8px; color: var(--muted); line-height: 1.65; }
+
+.stages { padding: 122px 0 0; background: var(--cream); border-top: 1px solid var(--line); }
+.stagesIntro { max-width: 1020px; padding-bottom: 58px; }
+.stagesIntro p { max-width: 760px; margin-top: 24px; color: var(--muted); font-size: 1.03rem; line-height: 1.72; }
+.stageRow { min-height: 430px; display: grid; grid-template-columns: 86px minmax(260px, .72fr) minmax(300px, .92fr) minmax(300px, .86fr); gap: 36px; align-items: center; padding: 54px 0; border-top: 1px solid var(--line); }
+.stageNumber { align-self: start; padding-top: 9px; color: var(--green); font-family: var(--display); font-size: 1.9rem; }
+.stageIdentity small { color: var(--green); font-size: .68rem; font-weight: 800; letter-spacing: .11em; text-transform: uppercase; }
+.stageIdentity h3 { margin-top: 10px; font-size: clamp(2.5rem, 4vw, 4.5rem); }
+.formula { display: inline-block; margin-top: 13px; color: #536059; font-size: .82rem; font-weight: 800; letter-spacing: .08em; }
+.stageVisual { min-height: 310px; display: grid; place-items: center; background: var(--paper); border: 1px solid var(--line); overflow: hidden; }
+.stageVisual img { width: 100%; height: 310px; object-fit: contain; display: block; }
+.compostVisual { width: 100%; height: 310px; padding: 30px; display: flex; flex-direction: column; justify-content: flex-end; background: linear-gradient(145deg, #2b4734, #132d23); color: white; }
+.compostVisual span { color: #d8ed9c; font-size: .68rem; font-weight: 800; }
+.compostVisual strong { margin-top: 12px; font-family: var(--display); font-size: 3rem; }
+.compostVisual small { margin-top: 5px; color: #bdc9c1; }
+.stageCopy p { color: var(--muted); font-size: .98rem; line-height: 1.7; }
+.stageCopy p + p { margin-top: 15px; }
+.stageCopy a { display: inline-flex; margin-top: 24px; color: var(--green); font-size: .82rem; font-weight: 800; }
+
+.diagnostic { padding: 120px 0; background: var(--forest); color: white; }
+.diagnosticGrid { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(360px, .95fr); gap: 80px; align-items: center; }
+.diagnostic h2 { max-width: 760px; }
+.diagnostic p { max-width: 700px; margin-top: 24px; color: #c3d0c8; font-size: 1.03rem; line-height: 1.72; }
+.decisionList { border-top: 1px solid var(--line-dark); }
+.decisionItem { padding: 19px 0; border-bottom: 1px solid var(--line-dark); display: grid; grid-template-columns: 38px 1fr; gap: 18px; align-items: start; }
+.decisionItem span { color: #d8ed9c; font-size: .68rem; font-weight: 800; }
+.decisionItem strong { display: block; font-family: var(--display); font-size: 1.2rem; }
+.decisionItem small { display: block; margin-top: 4px; color: #aebdb4; line-height: 1.5; }
+
+.kits { padding: 122px 0; }
+.kitList { border-top: 1px solid var(--line); }
+.kitRow { display: grid; grid-template-columns: 74px minmax(230px, .75fr) minmax(260px, .9fr) minmax(300px, 1.15fr); gap: 28px; padding: 36px 0; border-bottom: 1px solid var(--line); align-items: start; }
+.kitRow > span { color: var(--green); font-family: var(--display); font-size: 1.55rem; }
+.kitIdentity small { color: var(--green); font-size: .68rem; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; }
+.kitIdentity h3 { margin-top: 7px; }
+.kitPromise { color: #46534c; font-family: var(--display); font-size: 1.45rem; line-height: 1.25; }
+.kitContents ul { margin: 0; padding-left: 18px; color: var(--muted); font-size: .85rem; line-height: 1.65; }
+.kitContents p { margin-top: 13px; color: var(--muted); font-size: .78rem; line-height: 1.55; }
+.kitContents a { display: inline-flex; margin-top: 16px; color: var(--green); font-size: .82rem; font-weight: 800; }
+.status { display: inline-flex; margin-top: 12px; padding: 5px 8px; border: 1px solid var(--line); color: #5d6963; font-size: .64rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.guardrail { margin-top: 28px; padding: 22px 24px; border-left: 4px solid var(--sun); background: var(--cream); }
+.guardrail strong { color: var(--forest); }
+.guardrail p { margin-top: 6px; color: var(--muted); font-size: .85rem; line-height: 1.62; }
+
+.application { padding: 116px 0; background: var(--forest-deep); color: white; }
+.application .sectionHead p { color: #b7c4bc; }
+.applicationFlow { display: grid; grid-template-columns: repeat(4, 1fr); border-top: 1px solid var(--line-dark); border-bottom: 1px solid var(--line-dark); }
+.applicationFlow article { min-height: 220px; padding: 25px 24px 24px 0; border-right: 1px solid var(--line-dark); }
+.applicationFlow article:not(:first-child) { padding-left: 24px; }
+.applicationFlow article:last-child { border-right: 0; }
+.applicationFlow strong { color: #d8ed9c; font-size: .75rem; letter-spacing: .07em; }
+.applicationFlow p { margin-top: 44px; color: #c1cec6; font-size: .9rem; line-height: 1.66; }
+
+.guides { padding: 120px 0; background: var(--cream); }
+.guideGrid { display: grid; grid-template-columns: repeat(5, 1fr); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.guideCard { min-height: 310px; padding: 24px 22px 24px 0; border-right: 1px solid var(--line); display: flex; flex-direction: column; }
+.guideCard:not(:first-child) { padding-left: 22px; }
+.guideCard:last-child { border-right: 0; }
+.guideCard > span { color: var(--green); font-size: .66rem; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; }
+.guideCard h3 { margin-top: 36px; font-size: 1.65rem; }
+.guideCard p { margin-top: 14px; color: var(--muted); font-size: .84rem; line-height: 1.62; }
+.guideCard a { margin-top: auto; padding-top: 20px; color: var(--green); font-size: .8rem; font-weight: 800; }
+.catalogGuide { background: var(--forest); color: white; padding-right: 22px; }
+.catalogGuide > span, .catalogGuide a { color: #d8ed9c; }
+.catalogGuide p { color: #bdcac2; }
+
+.faqSection { padding: 110px 0; }
+.faq { border-top: 1px solid var(--line); }
+.faq details { border-bottom: 1px solid var(--line); }
+.faq summary { cursor: pointer; list-style: none; padding: 24px 4px 24px 0; font-family: var(--display); font-size: 1.25rem; font-weight: 600; }
+.faq summary::-webkit-details-marker { display: none; }
+.faq details p { max-width: 900px; padding: 0 0 24px; color: var(--muted); line-height: 1.68; }
+
+.release { padding: 118px 0; background: var(--paper); border-top: 1px solid var(--line); }
+.releaseGrid { display: grid; grid-template-columns: minmax(0, .92fr) minmax(420px, 1.08fr); gap: 76px; }
+.releaseCopy p { margin-top: 22px; color: var(--muted); font-size: 1.02rem; line-height: 1.72; }
+.releaseStatus { border-top: 1px solid var(--line); }
+.releaseGroup { padding: 24px 0; border-bottom: 1px solid var(--line); }
+.releaseGroup > strong { display: block; margin-bottom: 13px; color: var(--forest); font-family: var(--display); font-size: 1.45rem; }
+.releaseGroup ul { margin: 0; padding-left: 18px; color: var(--muted); font-size: .85rem; line-height: 1.65; }
+.releaseGroup li + li { margin-top: 7px; }
+
+@media (max-width: 1080px) {
+  .heroGrid { grid-template-columns: 1fr 390px; gap: 42px; }
+  .page h1 { font-size: clamp(3.6rem, 6.8vw, 6rem); }
+  .stageRow { grid-template-columns: 70px minmax(220px,.7fr) minmax(280px,1fr); }
+  .stageCopy { grid-column: 2 / -1; padding-bottom: 8px; }
+  .guideGrid { grid-template-columns: repeat(2, 1fr); }
+  .guideCard { border-bottom: 1px solid var(--line); min-height: 260px; padding: 22px !important; }
+  .guideCard:last-child { grid-column: 1 / -1; }
+}
+
+@media (max-width: 820px) {
+  .container { width: min(100% - 32px, 1240px); }
+  .subnav .container { align-items: stretch; flex-direction: column; gap: 0; padding: 8px 0 0; }
+  .subnav .container > span { padding: 3px 0; }
+  .subnav .container > div { width: 100%; gap: 18px; }
+  .heroGrid { min-height: 0; grid-template-columns: 1fr; gap: 42px; padding: 58px 0 64px; }
+  .heroVisual { min-height: 520px; }
+  .heroTruth { grid-template-columns: 1fr; gap: 5px; }
+  .methodGrid { grid-template-columns: repeat(5, minmax(120px,1fr)); overflow-x: auto; }
+  .methodGrid > div { min-width: 120px; }
+  .section, .safety, .kits, .guides, .faqSection, .release, .application { padding: 82px 0; }
+  .sectionHead, .safetyGrid, .diagnosticGrid, .releaseGrid { grid-template-columns: 1fr; gap: 36px; }
+  .sectionHead { margin-bottom: 38px; }
+  .safetyIntro { position: static; }
+  .contextGrid { grid-template-columns: 1fr; }
+  .contextItem, .contextItem:not(:first-child) { min-height: 230px; padding: 26px 0; border-right: 0; border-bottom: 1px solid var(--line); }
+  .contextItem:last-child { border-bottom: 0; }
+  .contextItem h3 { margin-top: 24px; }
+  .stageRow { min-height: 0; grid-template-columns: 52px 1fr; gap: 22px; padding: 42px 0; }
+  .stageIdentity { align-self: start; }
+  .stageVisual, .stageCopy { grid-column: 2; }
+  .stageVisual { min-height: 280px; }
+  .stageVisual img, .compostVisual { height: 280px; }
+  .kitRow { grid-template-columns: 52px 1fr; gap: 22px; }
+  .kitPromise, .kitContents { grid-column: 2; }
+  .applicationFlow { grid-template-columns: 1fr 1fr; }
+  .applicationFlow article, .applicationFlow article:not(:first-child) { padding: 24px; border-bottom: 1px solid var(--line-dark); }
+  .guideGrid { grid-template-columns: 1fr; }
+  .guideCard:last-child { grid-column: auto; }
+}
+
+@media (max-width: 520px) {
+  .page h1 { font-size: clamp(3rem, 16vw, 4.7rem); }
+  .page h2 { font-size: clamp(2.35rem, 12vw, 3.8rem); }
+  .heroVisual { min-height: 430px; }
+  .heroVisual img { padding: 8px; }
+  .heroCaption { inset: auto 14px 14px; }
+  .actions { align-items: stretch; flex-direction: column; }
+  .button, .textLink { width: 100%; }
+  .trafficItem { grid-template-columns: 66px 1fr; }
+  .trafficLevel { width: 54px; }
+  .stageRow, .kitRow { grid-template-columns: 1fr; }
+  .stageNumber, .stageVisual, .stageCopy, .kitPromise, .kitContents { grid-column: 1; }
+  .stageVisual { min-height: 250px; }
+  .stageVisual img, .compostVisual { height: 250px; }
+  .applicationFlow { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button { transition: none; }
+  .button:hover { transform: none; }
+}

--- a/src/app/casa-jardin/layout.tsx
+++ b/src/app/casa-jardin/layout.tsx
@@ -4,8 +4,8 @@ import { HomeGardenGuideVisualBand } from "@/components/home-garden-guide-visual
 import { HomeGardenKitVisualBand } from "@/components/home-garden-kit-visual-band";
 
 export const metadata: Metadata = {
-  title: "Casa y Jardín | Greenatics",
-  description: "Espacio reservado para la futura línea Greenatics de soluciones para casa, jardín y autocultivo.",
+  title: "Casa y Jardín | Wondergreen · Greenatics",
+  description: "Sistema Wondergreen para plantas, jardín, huerta y vivero: diagnóstico orientativo, nutrición por etapas, productos, kits en pre-lanzamiento y guías prácticas.",
   alternates: { canonical: "/casa-jardin" },
   robots: {
     index: false,

--- a/src/app/casa-jardin/page.tsx
+++ b/src/app/casa-jardin/page.tsx
@@ -15,22 +15,15 @@ import {
   pendingHomeGardenLaunchItems,
   readyHomeGardenLaunchItems,
 } from "@/data/home-garden-readiness";
-import styles from "./casa-jardin.module.css";
+import styles from "./casa-jardin-v2.module.css";
 
 export const metadata: Metadata = {
   title: "Casa, Jardín y Vivero | Wondergreen · Greenatics",
-  description: "Nutrición por etapas para plantas, jardín, huerta y vivero: observa, identifica, elige, aplica y revisa con el sistema Wondergreen Casa & Jardín.",
+  description:
+    "Nutrición por etapas para plantas, jardín, huerta y vivero: observa, identifica, elige, aplica y revisa con el sistema Wondergreen Casa & Jardín.",
   alternates: { canonical: "/casa-jardin" },
   robots: { index: false, follow: true },
 };
-
-const plantQuestions = [
-  ["Está creciendo o sacando brotes", "CRECE", "2Grow Sólido 15-3-3"],
-  ["Está estable y quieres mantenerla", "EQUILIBRA", "2Balance Sólido 7-7-7"],
-  ["Está formando botones o flores", "FLORECE", "2Bloom Sólido 3-8-3"],
-  ["Está en fruto o etapa productiva", "FRUCTIFICA", "2Fruit Sólido 3-3-8"],
-  ["Vas a preparar o recuperar sustrato", "COMPOST", "Materia orgánica + acondicionamiento"],
-] as const;
 
 const stageVisuals: Record<string, { src: string; alt: string }> = {
   crece: { src: "/api/public-media/wondergreen-2grow", alt: "Línea Wondergreen 2Grow para crecimiento y recuperación" },
@@ -39,147 +32,242 @@ const stageVisuals: Record<string, { src: string; alt: string }> = {
   fructifica: { src: "/api/public-media/wondergreen-2fruit", alt: "Línea Wondergreen 2Fruit para llenado y maduración" },
 };
 
+const contexts = [
+  {
+    number: "01",
+    title: "Plantas en casa",
+    copy: "Interior, balcón o terraza: identifica etapa y condición antes de decidir si la planta necesita nutrición, equilibrio o simplemente corregir manejo.",
+    href: "/casa-jardin/diagnostico",
+    cta: "Empezar diagnóstico",
+  },
+  {
+    number: "02",
+    title: "Mi huerta",
+    copy: "Suelo, crecimiento, transición reproductiva y fruto se leen como etapas distintas. La secuencia orienta; no significa aplicar todos los productos juntos.",
+    href: "/casa-jardin/guias#mi-huerta",
+    cta: "Abrir Mi Huerta",
+  },
+  {
+    number: "03",
+    title: "Jardín o vivero",
+    copy: "Cuando conviven muchas plantas, la lógica común ayuda a ordenar decisiones sin asumir que todas están en la misma etapa o condición.",
+    href: "#etapas",
+    cta: "Ver etapas",
+  },
+] as const;
+
+const diagnosticQuestions = [
+  ["01", "¿Qué planta es?", "Tipo de planta y contexto de uso."],
+  ["02", "¿Qué está haciendo?", "Creciendo, estable, floreciendo, fructificando o en una condición mixta."],
+  ["03", "¿Cómo está?", "Humedad, drenaje, raíces, estrés y señales sanitarias antes de fertilizar."],
+  ["04", "¿Cuántas y de qué tamaño?", "Cantidad y tamaño de matera se capturan sin convertirlos todavía en una dosis automática."],
+] as const;
+
 export default function CasaJardinPage() {
   return (
     <div className={styles.page}>
+      <nav className={styles.subnav} aria-label="Navegación Casa y Jardín">
+        <div className={styles.container}>
+          <span>Casa & Jardín</span>
+          <div>
+            <a href="#contextos">Para quién</a>
+            <a href="#seguridad">Antes de aplicar</a>
+            <a href="#etapas">Etapas</a>
+            <a href="#diagnostico">Diagnóstico</a>
+            <a href="#kits">Kits</a>
+            <a href="#guias">Guías</a>
+            <a href="#lanzamiento">Estado</a>
+          </div>
+        </div>
+      </nav>
+
       <main>
-        <section className={styles.hero}>
+        <section className={styles.hero} aria-labelledby="home-garden-title">
+          <div className={styles.heroAccent} aria-hidden="true" />
           <div className={`${styles.container} ${styles.heroGrid}`}>
-            <div>
+            <div className={styles.heroCopy}>
               <span className={styles.eyebrow}>Wondergreen · Casa, jardín y vivero</span>
-              <h1>Nutrición por etapas para tus plantas.</h1>
-              <p className={styles.lead}>Tu planta cambia. Su nutrición también. Observa qué está haciendo, identifica su condición y elige la etapa que necesita. Casa & Jardín lleva la lógica Wondergreen a hogares, huertas, jardines y viveros con una ruta simple: suelo, crecimiento, equilibrio, floración y fruto.</p>
+              <h1 id="home-garden-title">Nutrición por etapas para tus plantas.</h1>
+              <p className={styles.lead}>
+                Tu planta cambia. Su nutrición también. Casa & Jardín traduce la lógica Wondergreen a una ruta doméstica sencilla: primero observa la planta y el suelo; después identifica la etapa; solo entonces eliges el siguiente paso.
+              </p>
               <div className={styles.actions}>
                 <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Encontrar un punto de partida</Link>
                 <a className={`${styles.button} ${styles.ghost}`} href="#etapas">Ver las etapas</a>
-                <a className={`${styles.button} ${styles.ghost}`} href="/api/public-resources/wondergreen-product-master" target="_blank" rel="noreferrer">Descargar catálogo Wondergreen ↓</a>
+                <a className={styles.textLink} href="/api/public-resources/wondergreen-product-master" target="_blank" rel="noreferrer">Descargar catálogo Wondergreen ↓</a>
+              </div>
+              <div className={styles.heroTruth}>
+                <span>Pre-lanzamiento</span>
+                <strong>La arquitectura de producto, diagnóstico y guías puede recorrerse. PVP, checkout y dosis domésticas universales permanecen bloqueados hasta cerrar sus dependencias.</strong>
               </div>
             </div>
-            <aside className={styles.heroVisual}>
-              <div className={styles.heroVisualLabel}>El sistema Wondergreen, de un vistazo.</div>
-              <Image className={styles.heroSystemImage} src="/api/public-media/wondergreen-system-stages" width={760} height={1074} alt="Sistema Wondergreen por etapas: compost, 2Grow, 2Balance, 2Bloom, 2Fruit y bioinsumos" priority unoptimized />
+
+            <aside className={styles.heroVisual} aria-label="Sistema Wondergreen Casa y Jardín">
+              <Image
+                src="/api/public-media/wondergreen-system-stages"
+                width={760}
+                height={1074}
+                alt="Sistema Wondergreen por etapas: compost, 2Grow, 2Balance, 2Bloom, 2Fruit y bioinsumos"
+                priority
+                unoptimized
+              />
+              <div className={styles.heroCaption}>
+                <strong>Una sola lógica. Distintas etapas.</strong>
+                <small>COMPOST · CRECE · EQUILIBRA · FLORECE · FRUCTIFICA</small>
+              </div>
             </aside>
           </div>
         </section>
 
-        <section className={styles.path} aria-label="Método Wondergreen Casa y Jardín">
-          <div className={`${styles.container} ${styles.pathGrid}`}>
-            {homeGardenMethod.map((step, index) => <div key={step}><span>{String(index + 1).padStart(2, "0")}</span><strong>{step}</strong></div>)}
+        <section className={styles.method} aria-label="Método Wondergreen Casa y Jardín">
+          <div className={`${styles.container} ${styles.methodGrid}`}>
+            {homeGardenMethod.map((step, index) => (
+              <div key={step}><span>{String(index + 1).padStart(2, "0")}</span><strong>{step}</strong></div>
+            ))}
           </div>
         </section>
 
-        <section className={styles.section} id="etapas">
+        <section className={`${styles.section} ${styles.sectionSoft}`} id="contextos">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>4 etapas + suelo</span><h2>No necesita más. Necesita lo correcto.</h2></div>
-              <p>CRECE, EQUILIBRA, FLORECE y FRUCTIFICA traducen para uso doméstico cuatro referencias sólidas Wondergreen ya existentes. COMPOST prepara y acondiciona el sistema de suelo. Aquí puedes conocer el sistema y sus formatos propuestos antes de que la tienda esté activa.</p>
+              <div><span className={styles.eyebrow}>Tres contextos</span><h2>La misma lógica, plantas muy distintas.</h2></div>
+              <p>Casa & Jardín no parte de una receta universal. Cambian la especie, el ambiente, el tamaño, la etapa y el problema; por eso la web te lleva primero al contexto que más se parece al tuyo.</p>
             </div>
-            <div className={styles.productGrid}>
-              {homeGardenProducts.map((product) => {
-                const visual = stageVisuals[product.id];
-                return (
-                  <article className={`${styles.card} ${styles[product.accent]} ${visual ? styles.cardWithVisual : ""}`} key={product.id}>
-                    <div className={styles.stageBar} aria-hidden="true" />
-                    {visual ? (
-                      <div className={styles.productVisual}>
-                        <Image src={visual.src} width={760} height={1074} alt={visual.alt} sizes="(max-width: 820px) 88vw, (max-width: 1100px) 30vw, 18vw" unoptimized />
-                      </div>
-                    ) : (
-                      <div className={styles.compostVisual} aria-label="Compost como base del sistema">
-                        <span>01</span><strong>COMPOST</strong><small>Suelo · materia orgánica · acondicionamiento</small>
-                      </div>
-                    )}
+            <div className={styles.contextGrid}>
+              {contexts.map((item) => (
+                <article className={styles.contextItem} key={item.number}>
+                  <span className={styles.index}>{item.number}</span>
+                  <h3>{item.title}</h3>
+                  <p>{item.copy}</p>
+                  {item.href.startsWith("/") ? <Link href={item.href}>{item.cta} →</Link> : <a href={item.href}>{item.cta} →</a>}
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.safety} id="seguridad">
+          <div className={`${styles.container} ${styles.safetyGrid}`}>
+            <div className={styles.safetyIntro}>
+              <span className={styles.eyebrow}>Antes del producto</span>
+              <h2>A veces, la mejor dosis es no fertilizar todavía.</h2>
+              <p>Una hoja amarilla, una planta marchita o un sustrato muy húmedo no son diagnósticos nutricionales por sí solos. El sistema primero revisa agua, drenaje, raíces, estrés y sanidad.</p>
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Iniciar diagnóstico</Link>
+              </div>
+            </div>
+            <div className={styles.trafficList}>
+              {homeGardenTrafficLight.map((item) => (
+                <article className={styles.trafficItem} key={item.level}>
+                  <span className={styles.trafficLevel}>{item.level}</span>
+                  <div><h3>{item.title}</h3><p>{item.copy}</p></div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.stages} id="etapas" aria-labelledby="stages-title">
+          <div className={styles.container}>
+            <div className={styles.stagesIntro}>
+              <span className={styles.eyebrow}>4 etapas + suelo</span>
+              <h2 id="stages-title">No necesita más. Necesita lo correcto.</h2>
+              <p>COMPOST prepara la base. CRECE, EQUILIBRA, FLORECE y FRUCTIFICA traducen cuatro referencias sólidas Wondergreen ya existentes a una lectura doméstica por etapa. Los formatos pequeños siguen siendo propuestos hasta cerrar su habilitación comercial y regulatoria.</p>
+            </div>
+
+            {homeGardenProducts.map((product, index) => {
+              const visual = stageVisuals[product.id];
+              return (
+                <article className={styles.stageRow} key={product.id}>
+                  <span className={styles.stageNumber}>{String(index + 1).padStart(2, "0")}</span>
+                  <div className={styles.stageIdentity}>
                     <small>{product.id === "prepara" ? "Base del sistema" : "Etapa nutricional"}</small>
                     <h3>{product.consumerName}</h3>
                     <span className={styles.formula}>{product.formula ?? "Compost"}</span>
+                  </div>
+                  <div className={styles.stageVisual}>
+                    {visual ? (
+                      <Image src={visual.src} width={760} height={1074} alt={visual.alt} sizes="(max-width: 820px) 80vw, 28vw" unoptimized />
+                    ) : (
+                      <div className={styles.compostVisual} aria-label="Compost como base del sistema"><span>Suelo primero</span><strong>COMPOST</strong><small>Materia orgánica · acondicionamiento</small></div>
+                    )}
+                  </div>
+                  <div className={styles.stageCopy}>
                     <p>{product.role}</p>
                     <p><strong>{product.prompt}</strong></p>
                     <Link href={`/casa-jardin/productos/${product.id}`}>Ver etapa y formatos propuestos →</Link>
-                  </article>
-                );
-              })}
-            </div>
-          </div>
-        </section>
-
-        <section className={`${styles.section} ${styles.soft}`}>
-          <div className={styles.container}>
-            <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Antes del producto</span><h2>¿Qué está haciendo tu planta?</h2></div>
-              <p>La entrada correcta no es “qué fertilizante compro”, sino “qué etapa y condición estoy observando”. Si hay estrés severo, exceso de agua, raíces comprometidas o daño sanitario, la respuesta puede ser no fertilizar todavía.</p>
-            </div>
-            <div className={styles.decisionGrid}>
-              {plantQuestions.map(([situation, result, technical]) => (
-                <article className={styles.decisionCard} key={situation}>
-                  <span className={styles.eyebrow}>Si observas</span>
-                  <h3>{situation}</h3>
-                  <p><strong>{result}</strong> · {technical}</p>
+                  </div>
                 </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className={styles.diagnostic} id="diagnostico">
+          <div className={`${styles.container} ${styles.diagnosticGrid}`}>
+            <div>
+              <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Diagnóstico orientativo</span>
+              <h2>Deja de fertilizar a ciegas.</h2>
+              <p>El diagnóstico no intenta adivinar una dosis. Ordena la observación, detecta señales de seguridad y te lleva a una etapa o a una revisión previa cuando todavía no corresponde fertilizar.</p>
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.light}`} href="/casa-jardin/diagnostico">Abrir diagnóstico</Link>
+                <a className={`${styles.button} ${styles.outlineLight}`} href="#guias">Consultar guías</a>
+              </div>
+            </div>
+            <div className={styles.decisionList}>
+              {diagnosticQuestions.map(([number, title, copy]) => (
+                <div className={styles.decisionItem} key={number}><span>{number}</span><div><strong>{title}</strong><small>{copy}</small></div></div>
               ))}
-              <article className={styles.decisionCard}>
-                <span className={styles.eyebrow}>Si “se ve mal”</span>
-                <h3>No empieces fertilizando.</h3>
-                <p>Primero revisa agua, drenaje, raíces, luz y sanidad. Una hoja amarilla o una planta marchita no son diagnósticos nutricionales por sí solos.</p>
-              </article>
             </div>
           </div>
         </section>
 
-        <section className={styles.section} id="kits">
+        <section className={styles.kits} id="kits">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>Kits Casa & Jardín · pre-lanzamiento</span><h2>Compra la lógica del sistema, no una mezcla de productos.</h2></div>
-              <p>Los cinco kits visibles conservan la composición V1 del handoff. Aún no tienen checkout ni PVP público: faltan cerrar dosificador, empaque, etiquetas, stock, logística y condición regulatoria de las presentaciones domésticas.</p>
+              <p>Los kits visibles conservan la composición V1 ya gobernada. No tienen checkout ni PVP público: dosificador, empaque, etiquetado, stock, logística y condición regulatoria de las presentaciones domésticas todavía deben cerrarse.</p>
             </div>
-            <div className={styles.kitGrid}>
-              {visibleHomeGardenKits.map((kit) => (
-                <article className={styles.kitCard} key={kit.id}>
-                  <span className={styles.eyebrow}>{kit.audience}</span>
-                  <h3>{kit.name}</h3>
-                  <p><strong>{kit.promise}</strong></p>
-                  <ul>{kit.contents.map((content) => <li key={content}>{content}</li>)}</ul>
-                  <p>{kit.guardrail}</p>
-                  <Link href={`/casa-jardin/kits/${kit.id}`}>Ver composición y ruta →</Link>
-                  <div className={styles.status}>Pre-lanzamiento · compra deshabilitada</div>
+            <div className={styles.kitList}>
+              {visibleHomeGardenKits.map((kit, index) => (
+                <article className={styles.kitRow} key={kit.id}>
+                  <span>{String(index + 1).padStart(2, "0")}</span>
+                  <div className={styles.kitIdentity}><small>{kit.audience}</small><h3>{kit.name}</h3><div className={styles.status}>Pre-lanzamiento · compra deshabilitada</div></div>
+                  <p className={styles.kitPromise}>{kit.promise}</p>
+                  <div className={styles.kitContents}>
+                    <ul>{kit.contents.map((content) => <li key={content}>{content}</li>)}</ul>
+                    <p>{kit.guardrail}</p>
+                    <Link href={`/casa-jardin/kits/${kit.id}`}>Ver composición y ruta →</Link>
+                  </div>
                 </article>
               ))}
             </div>
             <div className={styles.guardrail}>
               <strong>Trasplanta & Arranca no aparece como kit disponible.</strong>
-              <p>El handoff lo bloquea expresamente hasta validar el componente radicular/bioinsumo. Sí mantenemos la guía educativa de trasplante, porque su lógica es primero drenaje, raíces, estabilidad y observación.</p>
+              <p>Permanece bloqueado hasta validar el componente radicular/bioinsumo. La guía educativa de trasplante sí puede consultarse porque prioriza drenaje, raíces, estabilidad y observación antes de decidir nutrición.</p>
             </div>
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.dark}`}>
+        <section className={styles.application}>
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Cómo aplicar</span><h2>Ni de más. Ni a ojo.</h2></div>
-              <p>La frecuencia y equivalencia doméstica del dosificador todavía no están reconciliadas. Publicarlas hoy como universales sería convertir una herramienta orientativa en una receta sin validar.</p>
+              <div><span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Cómo aplicar</span><h2>Ni de más. Ni a ojo.</h2></div>
+              <p>La frecuencia y equivalencia doméstica del dosificador todavía no están reconciliadas. Publicarlas como universales hoy sería convertir una herramienta orientativa en una receta sin validar.</p>
             </div>
-            <div className={styles.flow}>
-              {homeGardenApplication.map((item, index) => <article key={item.step}><strong>{String(index + 1).padStart(2, "0")} · {item.step}</strong><p>{item.copy}</p></article>)}
-            </div>
-          </div>
-        </section>
-
-        <section className={styles.section}>
-          <div className={styles.container}>
-            <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Semáforo antes de aplicar</span><h2>A veces, la mejor dosis es no fertilizar todavía.</h2></div>
-              <p>El sistema debe ayudar a detener una mala decisión, no solo recomendar un producto. Este semáforo es la regla de seguridad central del diagnóstico Casa & Jardín.</p>
-            </div>
-            <div className={styles.trafficGrid}>
-              {homeGardenTrafficLight.map((item) => <article className={styles.trafficCard} key={item.level}><span className={styles.level}>{item.level}</span><h3>{item.title}</h3><p>{item.copy}</p></article>)}
+            <div className={styles.applicationFlow}>
+              {homeGardenApplication.map((item, index) => (
+                <article key={item.step}><strong>{String(index + 1).padStart(2, "0")} · {item.step}</strong><p>{item.copy}</p></article>
+              ))}
             </div>
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.soft}`} id="guias">
+        <section className={styles.guides} id="guias">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>Conocimiento práctico</span><h2>Guías para mirar mejor antes de decidir.</h2></div>
-              <p>Casa & Jardín, Mi Huerta, etapas y trasplante ya están disponibles como lectura web. El catálogo general Wondergreen también puede descargarse completo desde esta página.</p>
+              <p>Casa & Jardín, Mi Huerta, etapas y trasplante ya están disponibles como lectura web. El catálogo general Wondergreen también puede descargarse desde esta página.</p>
             </div>
             <div className={styles.guideGrid}>
               {homeGardenGuides.map((guide) => (
@@ -190,61 +278,52 @@ export default function CasaJardinPage() {
                   <Link href={`/casa-jardin/guias#${guide.id}`}>Abrir guía →</Link>
                 </article>
               ))}
-              <article className={`${styles.guideCard} ${styles.catalogGuideCard}`}>
+              <article className={`${styles.guideCard} ${styles.catalogGuide}`}>
                 <span>PDF descargable</span>
                 <h3>Catálogo Wondergreen</h3>
-                <p>Consulta el sistema completo, organominerales, líquidos, bioinsumos, presentaciones y narrativa de las líneas Wondergreen.</p>
+                <p>Sistema completo, organominerales, líquidos, bioinsumos, presentaciones y narrativa de las líneas Wondergreen.</p>
                 <a href="/api/public-resources/wondergreen-product-master" target="_blank" rel="noreferrer">Descargar catálogo PDF ↓</a>
               </article>
             </div>
           </div>
         </section>
 
-        <section className={styles.section}>
-          <div className={styles.container}>
-            <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Diagnóstico orientativo</span><h2>Deja de fertilizar a ciegas.</h2></div>
-              <p>El diagnóstico pregunta tipo de planta, etapa, condición, cantidad y tamaños de matera. Si detecta una señal de seguridad, detiene la recomendación. El tamaño se captura para una futura recomendación de formato, pero todavía no se convierte en dosis.</p>
-            </div>
-            <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Iniciar diagnóstico</Link></div>
-          </div>
-        </section>
-
-        <section className={`${styles.section} ${styles.soft}`}>
+        <section className={styles.faqSection}>
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>Preguntas frecuentes</span><h2>Lo que el sistema sí puede —y no puede— decirte.</h2></div>
-              <p>Las respuestas conservan los límites del handoff: nutrición por etapa, sin promesas de floración, rendimiento o diagnósticos automáticos a partir de un solo síntoma.</p>
+              <p>Las respuestas conservan los límites técnicos: nutrición por etapa, sin promesas de floración, rendimiento o diagnósticos automáticos a partir de un solo síntoma.</p>
             </div>
             <div className={styles.faq}>{homeGardenFaq.map((item) => <details key={item.q}><summary>{item.q}</summary><p>{item.a}</p></details>)}</div>
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.release}`}>
+        <section className={styles.release} id="lanzamiento">
           <div className={`${styles.container} ${styles.releaseGrid}`}>
-            <div>
+            <div className={styles.releaseCopy}>
               <span className={styles.eyebrow}>Estado de lanzamiento</span>
               <h2>El catálogo puede recorrerse. La tienda todavía no.</h2>
-              <p className={styles.lead}>Productos, formatos propuestos, kits, diagnóstico y guías ya tienen arquitectura navegable. La compra y los precios se habilitan únicamente cuando sus dependencias estén reconciliadas.</p>
+              <p>Productos, formatos propuestos, kits, diagnóstico y guías ya tienen arquitectura navegable. Compra, precios y cobertura se habilitan únicamente cuando sus dependencias estén reconciliadas.</p>
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen">Ver Wondergreen técnico</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/contacto">Hablar con Greenatics</Link>
+              </div>
             </div>
-            <div>
-              <strong>Ya está gobernado</strong>
-              <ul>{readyHomeGardenLaunchItems.map((item) => <li key={item.id}><strong>{item.publicLabel}.</strong> {item.publicCopy}</li>)}</ul>
-
-              <strong>Falta cerrar antes de activar ecommerce</strong>
-              <ul>{pendingHomeGardenLaunchItems.map((item) => <li key={item.id}><strong>{item.publicLabel}.</strong> {item.publicCopy}</li>)}</ul>
-
+            <div className={styles.releaseStatus}>
+              <div className={styles.releaseGroup}>
+                <strong>Ya está gobernado</strong>
+                <ul>{readyHomeGardenLaunchItems.map((item) => <li key={item.id}><strong>{item.publicLabel}.</strong> {item.publicCopy}</li>)}</ul>
+              </div>
+              <div className={styles.releaseGroup}>
+                <strong>Falta cerrar antes de activar ecommerce</strong>
+                <ul>{pendingHomeGardenLaunchItems.map((item) => <li key={item.id}><strong>{item.publicLabel}.</strong> {item.publicCopy}</li>)}</ul>
+              </div>
               {blockedHomeGardenLaunchItems.map((item) => (
                 <div className={styles.guardrail} key={item.id}>
                   <strong>{item.publicLabel} · bloqueado</strong>
                   <p>{item.publicCopy}</p>
                 </div>
               ))}
-
-              <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen">Ver Wondergreen técnico</Link>
-                <Link className={`${styles.button} ${styles.ghost}`} href="/contacto">Hablar con Greenatics</Link>
-              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Objetivo
Reestructura la landing pública de Casa & Jardín para que la entrada doméstica a Wondergreen sea más clara, editorial y segura: contexto → observación → seguridad → etapa → diagnóstico → producto/kit → guía, sin adelantar ecommerce, precios ni dosis universales.

## Cambios principales
- Nuevo hero editorial conservando el sistema real Wondergreen por etapas y el catálogo técnico descargable.
- Subnavegación propia de Casa & Jardín: Para quién, Antes de aplicar, Etapas, Diagnóstico, Kits, Guías y Estado.
- Tres contextos de entrada: plantas en casa, Mi Huerta y jardín/vivero.
- El semáforo de seguridad sube antes del portafolio: la web puede detener la decisión de fertilizar cuando hay señales de agua, raíces, estrés o sanidad.
- Las cinco etapas se presentan como una secuencia editorial con los visuales reales 2Grow, 2Balance, 2Bloom y 2Fruit, más COMPOST como base del sistema.
- Diagnóstico orientativo convertido en bloque protagonista: tipo de planta, etapa, condición y tamaño/cantidad, sin cálculo automático de dosis.
- Kits en pre-lanzamiento pasan de mosaico a recorrido editorial por audiencia, promesa, composición y guardrail.
- Guías, FAQ y estado de lanzamiento se conservan y se integran a la narrativa comercial.
- Se mantiene el Visual Band real de guías y kits desde el layout.

## Guardrails
- `robots: noindex, follow` permanece activo mientras no cierre la validación B2C.
- No se publica PVP, checkout, ahorro, cobertura ni dosis doméstica universal.
- `Trasplanta & Arranca` continúa bloqueado como SKU.
- Los formatos domésticos siguen marcados como propuestos hasta cerrar empaque, etiqueta, stock, dosificación y condición regulatoria.
- No se promete floración, rendimiento, calibre ni cosecha.

## Sistema visual
- Mismo lenguaje de Home/Wondergreen V2: papel/crema, verde profundo, acento lima/amarillo, serif editorial + sans UI, líneas finas y más aire.
- Se reduce la sensación de catálogo de tarjetas y se priorizan recorridos, bandas y listas editoriales.

## Validación esperada
- typecheck / lint / unit / build
- database gates
- Playwright desktop y mobile
- visuales reales Wondergreen sin regresiones
- diagnóstico y safety gates intactos
- ausencia de compra/PVP confirmada