### PR TITLE
feat(public): Recursos V2 integra biblioteca, casos e impacto

### DIFF
--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -9,6 +9,17 @@ const approvedDownloadIds = [
   "wondergreen-guide-pastos",
 ];
 
+test("public resources hub exposes library, projects and impact as distinct layers", async ({ page }) => {
+  await page.goto("/biblioteca");
+
+  await expect(page.getByRole("heading", { name: "Conocimiento, casos y evidencia para decidir mejor." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Biblioteca técnica", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Proyectos / casos", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Impacto", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Ver casos →", exact: true })).toHaveAttribute("href", "/proyectos");
+  await expect(page.getByRole("link", { name: "Ver impacto →", exact: true })).toHaveAttribute("href", "/impacto");
+});
+
 test("public library exposes Wondergreen guides with same-origin PDF downloads", async ({ page }) => {
   await page.goto("/biblioteca");
 
@@ -47,7 +58,7 @@ test("public library routes by user intent before product selection", async ({ p
   await expect(page.getByRole("link", { name: /Comprobar criterios/ })).toHaveAttribute("href", "/biblioteca/criterios-nutricionales");
   await expect(page.getByRole("link", { name: /Abrir manual de uso/ })).toHaveAttribute("href", "/biblioteca/manual-uso-wondergreen");
   await expect(page.getByRole("link", { name: /Ver Product Master/ })).toHaveAttribute("href", "/wondergreen/productos");
-  await expect(page.getByRole("link", { name: /Ir a descargas/ })).toHaveAttribute("href", "#recursos");
+  await expect(page.getByRole("link", { name: /Ir a descargas/ })).toHaveAttribute("href", "#biblioteca");
 });
 
 test("deficiency guide prevents symptom-only diagnosis and links to crop programs", async ({ page }) => {

--- a/src/app/biblioteca/layout.tsx
+++ b/src/app/biblioteca/layout.tsx
@@ -3,8 +3,8 @@ import { PublicShell } from "@/components/public-shell";
 import { publicSocialMetadata } from "@/lib/public-social-metadata";
 
 const social = publicSocialMetadata({
-  title: "Biblioteca | Greenatics",
-  description: "Guías, programas por cultivo y herramientas técnicas de Greenatics y Wondergreen convertidas en conocimiento navegable.",
+  title: "Recursos | Greenatics",
+  description: "Biblioteca técnica, proyectos documentados, impacto, guías y herramientas de Greenatics y Wondergreen reunidas para tomar mejores decisiones.",
   path: "/biblioteca",
 });
 

--- a/src/app/biblioteca/page.tsx
+++ b/src/app/biblioteca/page.tsx
@@ -3,13 +3,37 @@ import Image from "next/image";
 import Link from "next/link";
 import { getPublicResourceMasterAudit } from "@/data/public-resource-master-audits";
 import { publicResources, type PublicResource } from "@/data/public-resources";
-import styles from "./library.module.css";
-import refresh from "./library-refresh.module.css";
+import styles from "./resources-v2.module.css";
 
 export const metadata: Metadata = {
-  title: "Biblioteca | Greenatics",
-  description: "Guías, programas por cultivo, Casa & Jardín, manuales y herramientas técnicas de Greenatics y Wondergreen convertidas en conocimiento navegable.",
+  title: "Recursos | Greenatics",
+  description: "Biblioteca técnica, proyectos documentados, impacto, guías, programas por cultivo y herramientas de Greenatics y Wondergreen reunidas para tomar mejores decisiones.",
+  alternates: { canonical: "/biblioteca" },
 };
+
+const resourceUniverses = [
+  {
+    number: "01",
+    title: "Biblioteca técnica",
+    copy: "Guías, Product Master, programas por cultivo, Casa & Jardín, criterios nutricionales y manuales para consultar o llevar al campo.",
+    href: "#biblioteca",
+    cta: "Explorar biblioteca",
+  },
+  {
+    number: "02",
+    title: "Proyectos / casos",
+    copy: "Experiencia documentada con contexto, periodo y alcance. Los casos muestran aprendizajes transferibles sin convertir evidencia histórica en resultados vigentes.",
+    href: "/proyectos",
+    cta: "Ver casos",
+  },
+  {
+    number: "03",
+    title: "Impacto",
+    copy: "Indicadores y resultados solo cuando cuentan con fuente, periodo, metodología y aprobación para publicación.",
+    href: "/impacto",
+    cta: "Ver impacto",
+  },
+] as const;
 
 const intentRoutes = [
   { number: "01", kicker: "Tengo un cultivo", title: "Quiero orientar el programa según la etapa.", copy: "Entra por café, cacao, aguacate, limón Tahití o pastos y revisa momentos, objetivos, cautelas, alertas y seguimiento.", href: "/wondergreen/cultivos", cta: "Elegir cultivo" },
@@ -18,7 +42,14 @@ const intentRoutes = [
   { number: "04", kicker: "Estoy revisando una recomendación", title: "Quiero comprobar si tengo suficiente contexto.", copy: "Revisa suelo, etapa, densidad, historial de fertilización y objetivo productivo antes de cerrar una decisión nutricional.", href: "/biblioteca/criterios-nutricionales", cta: "Comprobar criterios" },
   { number: "05", kicker: "Voy a aplicar Wondergreen", title: "Necesito preparar y registrar bien la aplicación.", copy: "Confirma referencia, condiciones, equipo, vía de aplicación, registro y seguimiento desde el manual de uso.", href: "/biblioteca/manual-uso-wondergreen", cta: "Abrir manual de uso" },
   { number: "06", kicker: "Quiero comparar referencias", title: "Necesito ver el Product Master público.", copy: "Consulta familias, fórmulas, formatos, estado público y relación con el sistema Wondergreen desde la fuente gobernada.", href: "/wondergreen/productos", cta: "Ver Product Master" },
-  { number: "07", kicker: "Quiero el material completo", title: "Necesito catálogo y guías descargables.", copy: "Descarga el catálogo Wondergreen y las guías completas por cultivo directamente desde esta biblioteca.", href: "#recursos", cta: "Ir a descargas" },
+  { number: "07", kicker: "Quiero el material completo", title: "Necesito catálogo y guías descargables.", copy: "Descarga el catálogo Wondergreen y las guías completas por cultivo directamente desde la biblioteca.", href: "#biblioteca", cta: "Ir a descargas" },
+] as const;
+
+const method = [
+  ["01", "Diagnosticar", "Revisa síntomas, lote, planta, suelo o sustrato y posibles confundidores."],
+  ["02", "Entender", "Ubica etapa, condición, contexto y objetivo antes de elegir una ruta."],
+  ["03", "Aplicar", "Usa la guía completa y la información vigente de la referencia para ejecutar."],
+  ["04", "Medir y ajustar", "Observa respuesta y usa evidencia para decidir el siguiente evento."],
 ] as const;
 
 function getDeliveryLabel(resource: PublicResource) {
@@ -37,70 +68,82 @@ function getMasterNotice(resource: PublicResource) {
 
 export default function LibraryPage() {
   return (
-    <div className={`${styles.page} ${refresh.page}`}>
+    <div className={styles.page}>
       <main>
-        <section className={styles.hero}>
+        <section className={styles.hero} aria-labelledby="resources-title">
+          <div className={styles.heroAccent} aria-hidden="true" />
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Greenatics · conocimiento aplicado</span>
-              <h1>Guías que puedes leer, usar y descargar.</h1>
-              <p className={styles.lead}>Catálogo Wondergreen, guías completas por cultivo, manuales y rutas técnicas navegables reunidas en un mismo lugar.</p>
+              <span className={styles.eyebrow}>Recursos Greenatics · conocimiento + evidencia</span>
+              <h1 id="resources-title">Conocimiento, casos y evidencia para decidir mejor.</h1>
+              <p className={styles.lead}>Recursos reúne la biblioteca técnica de Greenatics y Wondergreen con proyectos documentados e impacto gobernado. La idea no es acumular PDFs: es ayudarte a encontrar el contexto, la evidencia o la guía que necesitas para la siguiente decisión.</p>
+              <div className={styles.actions}>
+                <a className={`${styles.button} ${styles.primary}`} href="#biblioteca">Explorar biblioteca</a>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/proyectos">Ver proyectos</Link>
+              </div>
             </div>
-            <aside className={styles.warning}>
-              <strong>Del documento a la decisión.</strong>
-              <p>Consulta la versión web cuando quieras navegar por etapa y contexto; descarga el PDF cuando necesites conservar, compartir o trabajar el material completo.</p>
+            <aside className={styles.heroLedger}>
+              <span>Una sola entrada · tres capas</span>
+              <strong>Aprender, comprobar y transferir experiencia.</strong>
+              <p>La biblioteca explica. Los proyectos documentan experiencia. Impacto publica únicamente lo que puede sostenerse con una fuente y un periodo.</p>
+              <div className={styles.ledgerRows}>
+                <div className={styles.ledgerRow}><span>01</span><div><strong>Biblioteca</strong><small>guías · manuales · Product Master</small></div></div>
+                <div className={styles.ledgerRow}><span>02</span><div><strong>Casos</strong><small>contexto · evidencia · aprendizajes</small></div></div>
+                <div className={styles.ledgerRow}><span>03</span><div><strong>Impacto</strong><small>fuente · periodo · metodología</small></div></div>
+              </div>
             </aside>
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.soft}`} aria-labelledby="library-router-title">
+        <section className={styles.universes} aria-labelledby="resource-universes-title">
           <div className={styles.container}>
-            <div className={styles.sectionHeading}>
-              <span className={styles.eyebrow}>Empieza por tu decisión</span>
-              <h2 id="library-router-title">No necesitas conocer el nombre del recurso.</h2>
-              <p>Elige qué estás tratando de resolver y entra por cultivo, hogar, síntomas, producto o descarga.</p>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Tres capas de recursos</span><h2 id="resource-universes-title">No todo recurso cumple la misma función.</h2></div>
+              <p>Una guía orienta una decisión. Un caso prueba experiencia documentada. Un indicador resume un resultado bajo reglas de publicación. Separarlos hace que la evidencia sea más útil y menos ambigua.</p>
             </div>
-            <div className={styles.intentGrid}>
-              {intentRoutes.map((route) => (
-                route.href.startsWith("#") ? (
-                  <a className={styles.intentCard} href={route.href} key={route.number}>
-                    <span className={styles.intentNumber}>{route.number}</span><small className={styles.intentKicker}>{route.kicker}</small><h3>{route.title}</h3><p>{route.copy}</p><strong>{route.cta} →</strong>
-                  </a>
-                ) : (
-                  <Link className={styles.intentCard} href={route.href} key={route.number}>
-                    <span className={styles.intentNumber}>{route.number}</span><small className={styles.intentKicker}>{route.kicker}</small><h3>{route.title}</h3><p>{route.copy}</p><strong>{route.cta} →</strong>
-                  </Link>
-                )
+            <div className={styles.universeGrid}>
+              {resourceUniverses.map((item) => (
+                <article className={styles.universeCard} key={item.number}>
+                  <span>{item.number}</span><h3>{item.title}</h3><p>{item.copy}</p>
+                  {item.href.startsWith("#") ? <a href={item.href}>{item.cta} →</a> : <Link href={item.href}>{item.cta} →</Link>}
+                </article>
               ))}
             </div>
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.white}`} id="recursos">
+        <section className={styles.router} aria-labelledby="library-router-title">
           <div className={styles.container}>
-            <div className={styles.sectionHeading}>
-              <span className={styles.eyebrow}>Recursos disponibles</span>
-              <h2>Biblioteca Wondergreen.</h2>
-              <p>La lectura web y los PDFs se complementan. Las piezas que cuentan con material editorial publicado muestran su portada original y acceso directo al documento.</p>
+            <div className={styles.sectionHead}>
+              <div><span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Empieza por tu decisión</span><h2 id="library-router-title">No necesitas conocer el nombre del recurso.</h2></div>
+              <p>Elige qué estás tratando de resolver y entra por cultivo, hogar, síntomas, recomendación, producto o descarga.</p>
+            </div>
+            <div className={styles.intentList}>
+              {intentRoutes.map((route) => {
+                const content = <><span className={styles.intentNumber}>{route.number}</span><small className={styles.intentKicker}>{route.kicker}</small><div><h3>{route.title}</h3><p>{route.copy}</p></div><strong>{route.cta} →</strong></>;
+                return route.href.startsWith("#") ? <a className={styles.intentRow} href={route.href} key={route.number}>{content}</a> : <Link className={styles.intentRow} href={route.href} key={route.number}>{content}</Link>;
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.library} id="biblioteca" aria-labelledby="library-title">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Biblioteca técnica</span><h2 id="library-title">Guías que puedes leer, usar y descargar.</h2></div>
+              <p>La lectura web y los PDFs se complementan. Las piezas con material editorial publicado muestran su portada y acceso directo; los maestros aún pendientes se señalan sin fabricar descargas.</p>
             </div>
             <div className={styles.libraryGrid}>
               {publicResources.map((resource) => {
                 const masterNotice = getMasterNotice(resource);
                 return (
-                  <article className={`${styles.libraryCard} ${resource.coverImage ? styles.libraryCardVisual : ""}`} key={resource.id}>
-                    {resource.coverImage ? (
-                      <div className={styles.resourceVisual}>
-                        <Image src={resource.coverImage} alt={`Portada de ${resource.title}`} width={640} height={905} sizes="(max-width: 640px) 88vw, (max-width: 900px) 42vw, 28vw" unoptimized />
-                      </div>
-                    ) : null}
-                    <div className={styles.resourceMeta}>
-                      <span className={styles.status}>{resource.statusLabel}</span>
-                      <small className={styles.delivery}>{getDeliveryLabel(resource)}</small>
-                    </div>
+                  <article className={styles.resourceCard} key={resource.id}>
+                    {resource.coverImage ? <div className={styles.resourceVisual}><Image src={resource.coverImage} alt={`Portada de ${resource.title}`} width={640} height={905} sizes="(max-width: 640px) 88vw, (max-width: 900px) 42vw, 28vw" unoptimized /></div> : null}
+                    <div className={styles.resourceMeta}><span className={styles.status}>{resource.statusLabel}</span><small className={styles.delivery}>{getDeliveryLabel(resource)}</small></div>
                     <h3>{resource.title}</h3>
                     <p>{resource.copy}</p>
-                    {resource.masterLabel ? <small className={styles.delivery}>Maestro: {resource.masterLabel}</small> : null}
-                    {masterNotice ? <small className={styles.delivery}>{masterNotice}</small> : null}
+                    {resource.masterLabel ? <small className={styles.masterNotice}>Maestro: {resource.masterLabel}</small> : null}
+                    {masterNotice ? <small className={styles.masterNotice}>{masterNotice}</small> : null}
                     <div className={styles.resourceActions}>
                       <Link href={resource.href}>{resource.cta} →</Link>
                       {resource.downloadHref ? <a className={styles.downloadAction} href={resource.downloadHref} target="_blank" rel="noreferrer">{resource.downloadLabel ?? "Descargar PDF"} ↓</a> : null}
@@ -112,29 +155,20 @@ export default function LibraryPage() {
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.soft}`}>
+        <section className={styles.method} aria-labelledby="resource-method-title">
           <div className={styles.container}>
-            <div className={styles.sectionHeading}>
-              <span className={styles.eyebrow}>Cómo usar la biblioteca</span>
-              <h2>Diagnosticar → entender → elegir → aplicar → medir.</h2>
-              <p>La navegación acompaña la decisión y el PDF te permite llevar el material completo al campo, al equipo o al cliente.</p>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Cómo usar la biblioteca</span><h2 id="resource-method-title">Diagnosticar → entender → aplicar → medir.</h2></div>
+              <p>La navegación ayuda a encontrar la decisión correcta y el documento permite llevar el material completo al campo, al equipo o al cliente.</p>
             </div>
-            <div className={styles.ruleGrid}>
-              <article className={styles.ruleCard}><span>01</span><h3>Diagnosticar</h3><p>Revisa síntomas, lote, planta, suelo o sustrato y posibles confundidores.</p></article>
-              <article className={styles.ruleCard}><span>02</span><h3>Entender etapa</h3><p>Ubica el momento fisiológico, la condición y el objetivo antes de elegir una ruta.</p></article>
-              <article className={styles.ruleCard}><span>03</span><h3>Aplicar</h3><p>Usa la guía completa y la información de la referencia para ejecutar el programa.</p></article>
-              <article className={styles.ruleCard}><span>04</span><h3>Medir y ajustar</h3><p>Observa respuesta y usa evidencia para decidir el siguiente evento.</p></article>
-            </div>
+            <div className={styles.methodFlow}>{method.map(([number,title,copy]) => <article key={number}><span>{number}</span><h3>{title}</h3><p>{copy}</p></article>)}</div>
           </div>
         </section>
 
         <section className={styles.closing}>
-          <div className={`${styles.container} ${styles.closingInner}`}>
-            <div><span className={styles.eyebrow}>Biblioteca Greenatics</span><h2>¿Cultivo, producto o plantas en casa?</h2></div>
-            <div className={styles.closingActions}>
-              <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen/cultivos">Ver cultivos</Link>
-              <Link className={`${styles.button} ${styles.secondary}`} href="/casa-jardin">Casa & Jardín</Link>
-            </div>
+          <div className={`${styles.container} ${styles.closingGrid}`}>
+            <div><span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Recursos Greenatics</span><h2>¿Necesitas una guía, un caso o una conversación técnica?</h2></div>
+            <div><p>Puedes entrar por la biblioteca, revisar proyectos documentados o llevar un problema concreto al equipo Greenatics.</p><div className={styles.actions}><Link className={`${styles.button} ${styles.light}`} href="/contacto">Hablar con nosotros</Link><Link className={`${styles.button} ${styles.ghost}`} href="/proyectos">Ver casos</Link></div></div>
           </div>
         </section>
       </main>

--- a/src/app/biblioteca/resources-v2.module.css
+++ b/src/app/biblioteca/resources-v2.module.css
@@ -1,0 +1,133 @@
+.page {
+  --forest: #12372c;
+  --forest-deep: #0b241c;
+  --green: #0a7a4b;
+  --lime: #b8d65f;
+  --sun: #ddc952;
+  --ink: #18241f;
+  --muted: #69736d;
+  --paper: #fbfaf5;
+  --cream: #f0ede3;
+  --white: #ffffff;
+  --line: rgba(24, 36, 31, 0.16);
+  --line-dark: rgba(255, 255, 255, 0.18);
+  --display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Baskerville, Georgia, serif;
+  --sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: var(--ink);
+  background: var(--paper);
+  font-family: var(--sans);
+  line-height: 1.55;
+}
+.page *, .page *::before, .page *::after { box-sizing: border-box; }
+.page a { color: inherit; text-decoration: none; }
+.page a:focus-visible { outline: 3px solid var(--sun); outline-offset: 4px; }
+.container { width: min(1240px, calc(100% - 48px)); margin: 0 auto; }
+.page h1, .page h2, .page h3 { margin: 0; font-family: var(--display); font-weight: 600; letter-spacing: -0.035em; line-height: 1.02; }
+.page h1 { font-size: clamp(4rem, 7vw, 7rem); }
+.page h2 { font-size: clamp(2.7rem, 4.6vw, 4.9rem); }
+.page h3 { font-size: clamp(1.45rem, 2vw, 2.1rem); }
+.page p { margin: 0; }
+.eyebrow { display: inline-block; margin-bottom: 15px; color: var(--green); font-size: .72rem; font-weight: 800; letter-spacing: .15em; text-transform: uppercase; }
+.eyebrowLight { color: #d8ed9c; }
+.button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; padding: 0 20px; border: 1px solid transparent; border-radius: 4px; font-size: .8rem; font-weight: 800; letter-spacing: .04em; text-transform: uppercase; }
+.primary { background: var(--green); color: white !important; }
+.ghost { border-color: var(--line); }
+.light { background: var(--paper); color: var(--forest-deep) !important; }
+.actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 28px; }
+
+.hero { position: relative; background: var(--cream); border-bottom: 1px solid var(--line); overflow: hidden; }
+.heroAccent { height: 8px; background: var(--lime); }
+.heroGrid { min-height: 650px; display: grid; grid-template-columns: minmax(0, 1.08fr) minmax(360px, .92fr); gap: 72px; align-items: center; padding: 78px 0 88px; }
+.hero h1 { max-width: 880px; }
+.lead { max-width: 760px; margin-top: 26px; color: #4d5a53; font-size: clamp(1.06rem, 1.5vw, 1.25rem); line-height: 1.7; }
+.heroLedger { min-height: 470px; padding: 28px 30px; background: var(--forest); color: white; border-left: 8px solid var(--sun); display: flex; flex-direction: column; }
+.heroLedger > span { color: #d8ed9c; font-size: .7rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.heroLedger > strong { margin-top: 14px; font-family: var(--display); font-size: 2rem; line-height: 1.08; }
+.heroLedger > p { margin-top: 16px; color: #bdcac2; font-size: .9rem; line-height: 1.65; }
+.ledgerRows { margin-top: auto; border-top: 1px solid var(--line-dark); }
+.ledgerRow { min-height: 92px; display: grid; grid-template-columns: 44px 1fr; gap: 16px; align-items: center; border-bottom: 1px solid var(--line-dark); }
+.ledgerRow span { color: #d8ed9c; font-size: .68rem; font-weight: 800; }
+.ledgerRow strong { display: block; font-family: var(--display); font-size: 1.2rem; }
+.ledgerRow small { display: block; margin-top: 3px; color: #9fb0a6; }
+
+.universes { padding: 112px 0; }
+.sectionHead { display: grid; grid-template-columns: minmax(0,1.15fr) minmax(300px,.85fr); gap: 70px; align-items: end; margin-bottom: 46px; }
+.sectionHead p { color: var(--muted); font-size: 1.03rem; line-height: 1.72; }
+.universeGrid { display: grid; grid-template-columns: repeat(3,1fr); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.universeCard { min-height: 330px; padding: 28px 30px 28px 0; border-right: 1px solid var(--line); display: flex; flex-direction: column; }
+.universeCard:not(:first-child) { padding-left: 30px; }
+.universeCard:last-child { border-right: 0; }
+.universeCard > span { color: var(--green); font-size: .7rem; font-weight: 800; }
+.universeCard h3 { margin-top: 52px; }
+.universeCard p { margin-top: 16px; color: var(--muted); font-size: .93rem; line-height: 1.68; }
+.universeCard a { margin-top: auto; padding-top: 26px; color: var(--green); font-size: .82rem; font-weight: 800; }
+
+.router { padding: 118px 0; background: var(--forest-deep); color: white; }
+.router .sectionHead p { color: #b6c4bb; }
+.intentList { border-top: 1px solid var(--line-dark); }
+.intentRow { display: grid; grid-template-columns: 64px minmax(180px,.55fr) minmax(280px,1fr) auto; gap: 28px; align-items: center; min-height: 126px; border-bottom: 1px solid var(--line-dark); }
+.intentNumber { color: #d8ed9c; font-family: var(--display); font-size: 1.4rem; }
+.intentKicker { color: #d8ed9c; font-size: .67rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.intentRow h3 { font-size: clamp(1.45rem,2vw,2rem); }
+.intentRow p { color: #b9c7be; font-size: .85rem; line-height: 1.6; }
+.intentRow strong { color: #d8ed9c; font-size: .8rem; white-space: nowrap; }
+
+.library { padding: 120px 0; background: var(--cream); }
+.libraryGrid { display: grid; grid-template-columns: repeat(3,1fr); gap: 1px; background: var(--line); border: 1px solid var(--line); }
+.resourceCard { min-width: 0; background: var(--paper); padding: 26px; display: flex; flex-direction: column; }
+.resourceVisual { margin: -26px -26px 24px; aspect-ratio: 1.28; overflow: hidden; background: #e7e4db; }
+.resourceVisual img { width: 100%; height: 100%; display: block; object-fit: cover; object-position: top center; }
+.resourceMeta { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 8px 14px; margin-bottom: 18px; }
+.status { color: var(--green); font-size: .64rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; }
+.delivery { color: #7a847e; font-size: .68rem; }
+.resourceCard h3 { font-size: 1.75rem; }
+.resourceCard > p { margin-top: 15px; color: var(--muted); font-size: .88rem; line-height: 1.66; }
+.masterNotice { display: block; margin-top: 12px; color: #7a847e; font-size: .7rem; line-height: 1.5; }
+.resourceActions { margin-top: auto; padding-top: 22px; display: flex; flex-wrap: wrap; gap: 14px; }
+.resourceActions a { color: var(--green); font-size: .78rem; font-weight: 800; }
+.downloadAction { border-bottom: 1px solid currentColor; }
+
+.method { padding: 112px 0; }
+.methodFlow { display: grid; grid-template-columns: repeat(4,1fr); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.methodFlow article { min-height: 240px; padding: 26px 25px 25px 0; border-right: 1px solid var(--line); }
+.methodFlow article:not(:first-child) { padding-left: 25px; }
+.methodFlow article:last-child { border-right: 0; }
+.methodFlow span { color: var(--green); font-size: .7rem; font-weight: 800; }
+.methodFlow h3 { margin-top: 46px; }
+.methodFlow p { margin-top: 14px; color: var(--muted); font-size: .86rem; line-height: 1.65; }
+
+.closing { padding: 108px 0; background: var(--forest); color: white; }
+.closingGrid { display: grid; grid-template-columns: minmax(0,1.15fr) minmax(320px,.85fr); gap: 70px; align-items: center; }
+.closing p { color: #bdcac2; font-size: 1rem; line-height: 1.7; }
+
+@media (max-width: 1000px) {
+  .heroGrid { grid-template-columns: 1fr 360px; gap: 42px; }
+  .libraryGrid { grid-template-columns: repeat(2,1fr); }
+  .intentRow { grid-template-columns: 52px minmax(150px,.55fr) 1fr; }
+  .intentRow strong { grid-column: 2 / -1; padding-bottom: 18px; }
+}
+@media (max-width: 780px) {
+  .container { width: min(100% - 32px,1240px); }
+  .page h1 { font-size: clamp(3.2rem,15vw,5.2rem); }
+  .page h2 { font-size: clamp(2.45rem,11vw,3.8rem); }
+  .heroGrid, .sectionHead, .closingGrid { grid-template-columns: 1fr; gap: 38px; }
+  .heroGrid { min-height: 0; padding: 60px 0 68px; }
+  .heroLedger { min-height: 420px; }
+  .universes, .router, .library, .method, .closing { padding: 82px 0; }
+  .universeGrid { grid-template-columns: 1fr; }
+  .universeCard, .universeCard:not(:first-child) { min-height: 245px; padding: 26px 0; border-right: 0; border-bottom: 1px solid var(--line); }
+  .universeCard:last-child { border-bottom: 0; }
+  .universeCard h3 { margin-top: 28px; }
+  .intentRow { grid-template-columns: 42px 1fr; gap: 18px; padding: 22px 0; }
+  .intentKicker, .intentRow h3, .intentRow p, .intentRow strong { grid-column: 2; }
+  .intentRow h3 { margin-top: -10px; }
+  .intentRow strong { padding-bottom: 0; }
+  .libraryGrid { grid-template-columns: 1fr; }
+  .methodFlow { grid-template-columns: 1fr 1fr; }
+  .methodFlow article, .methodFlow article:not(:first-child) { padding: 24px; border-bottom: 1px solid var(--line); }
+}
+@media (max-width: 520px) {
+  .methodFlow { grid-template-columns: 1fr; }
+  .actions { flex-direction: column; align-items: stretch; }
+  .button { width: 100%; }
+}


### PR DESCRIPTION
## Objetivo
Convierte `/biblioteca` en el hub público de Recursos definido por la nueva arquitectura de Greenatics, sin perder la biblioteca técnica existente: Biblioteca → Proyectos / Casos → Impacto.

## Cambios principales
- Hero editorial de Recursos orientado a conocimiento, evidencia y decisiones.
- Tres capas explícitas: Biblioteca técnica, Proyectos / casos e Impacto.
- La biblioteca Wondergreen sigue siendo la capa de guías, Product Master, manuales y programas por cultivo.
- El router por intención se conserva antes de la selección de producto y ahora vive dentro del marco más amplio de Recursos.
- Las descargas siguen siendo same-origin y solo aparecen cuando existe binario público gobernado.
- Los recursos con maestro pendiente continúan señalándolo explícitamente.
- Nuevo sistema visual coherente con Home, Soluciones, Wondergreen y Casa & Jardín V2: papel/crema, verde profundo, acentos lima/amarillo, serif editorial, menos mosaicos y más recorridos.

## Guardrails
- Un caso no se convierte en indicador de impacto por existir una fotografía o antecedente histórico.
- Impacto sigue gobernado por fuente, periodo, metodología y aprobación.
- No se exponen enlaces privados de SharePoint/Graph.
- No se fabrican PDFs cuando el maestro sigue pendiente.
- Product Master, guías por cultivo y recursos técnicos conservan sus destinos y descargas gobernadas.

## Compatibilidad
- La ruta canónica sigue siendo `/biblioteca`, que ahora materializa el rótulo de navegación `Recursos`.
- Las rutas hijas `/biblioteca/guia-deficiencias`, `/biblioteca/criterios-nutricionales` y `/biblioteca/manual-uso-wondergreen` no cambian.
- `/proyectos` e `/impacto` siguen siendo páginas canónicas independientes y se presentan como capas del hub.

## Validación esperada
- typecheck / lint / unit / build
- database gates
- Playwright desktop y mobile
- descargas same-origin intactas
- navegación de Recursos y SEO sin regresiones