### PR TITLE
feat(public): continuidad segura de Casa & Jardín hacia soporte técnico

### DIFF
--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -82,6 +82,7 @@ test("Casa diagnostic stops fertilizer-first response on safety conditions", asy
   await expect(page.getByText("Primero corrige la condición de la planta.", { exact: true })).toBeVisible();
   await expect(page.getByText(/NO EMPIECES FERTILIZANDO/i)).toBeVisible();
   await expect(page.getByText(/Calculadora de dosis: deshabilitada/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Llevar este contexto a soporte técnico →" })).toHaveAttribute("href", /need=nutricion/);
 });
 
 test("Casa diagnostic captures pot size but routes a healthy growing plant without calculating dose", async ({ page }) => {
@@ -98,6 +99,53 @@ test("Casa diagnostic captures pot size but routes a healthy growing plant witho
   await expect(page.getByRole("link", { name: "Abrir siguiente paso →" })).toHaveAttribute("href", "/casa-jardin/productos/crece");
   await expect(page.getByText(/Aún no tiene equivalencia pública a volumen ni gramos/i)).toBeVisible();
   await expect(page.getByText(/No calcula dosis ni cobertura todavía/i)).toBeVisible();
+
+  const params = await page.evaluate(() => Object.fromEntries(new URL(window.location.href).searchParams.entries()));
+  expect(params).toMatchObject({ plant: "green", stage: "growing", condition: "healthy", count: "6-10", pots: "M,L" });
+});
+
+test("Casa diagnostic restores structured state and Contact inherits it without turning it into a prescription", async ({ page }) => {
+  await page.goto("/casa-jardin/diagnostico?plant=green&stage=growing&condition=healthy&count=6-10&pots=M,L");
+
+  await expect(page.getByLabel("Tipo de planta")).toHaveValue("green");
+  await expect(page.getByLabel("Etapa de la planta")).toHaveValue("growing");
+  await expect(page.getByLabel("Condición de la planta")).toHaveValue("healthy");
+  await expect(page.getByLabel("Cantidad de plantas")).toHaveValue("6-10");
+  await expect(page.getByLabel("Matera M")).toBeChecked();
+  await expect(page.getByLabel("Matera L")).toBeChecked();
+  await expect(page.getByText("CRECE · 15-3-3", { exact: true })).toBeVisible();
+
+  const support = page.getByRole("link", { name: "Llevar este contexto a soporte técnico →" });
+  const href = await support.getAttribute("href");
+  expect(href).toBeTruthy();
+  const target = new URL(href!, "https://greenatics.com.co");
+  expect(target.searchParams.get("audience")).toBe("wondergreen");
+  expect(target.searchParams.get("need")).toBe("nutricion");
+  expect(target.searchParams.get("source")).toBe("casa-jardin-diagnostico");
+  expect(target.searchParams.get("contexto")).toContain("Materas: M, L");
+  expect(target.searchParams.get("contexto")).toContain("Punto").not;
+
+  await support.click();
+  await expect(page.getByRole("heading", { name: /Cuéntanos sobre tu cultivo o tu interés en Wondergreen/i })).toBeVisible();
+  await expect(page.getByLabel("¿Desde qué contexto nos escribes?")).toHaveValue("wondergreen");
+  await expect(page.getByLabel("¿Qué necesitas resolver primero?")).toHaveValue("nutricion");
+  await expect(page.getByText(/Contexto recibido de la navegación:/)).toContainText("Materas: M, L");
+
+  await page.getByRole("button", { name: "Preparar contexto" }).click();
+  await expect(page.getByLabel("Resumen preparado para la conversación")).toContainText("Contexto heredado: Casa & Jardín");
+  await expect(page.getByLabel("Resumen preparado para la conversación")).toContainText("Orientación del flujo: CRECE · 15-3-3");
+  await expect(page.getByText(/Nada se ha enviado todavía/i)).toBeVisible();
+});
+
+test("Casa diagnostic lets an unknown stage stay in review instead of fabricating a product", async ({ page }) => {
+  await page.goto("/casa-jardin/diagnostico");
+  await page.getByLabel("Tipo de planta").selectOption("green");
+  await page.getByLabel("Etapa de la planta").selectOption("unknown");
+  await page.getByLabel("Condición de la planta").selectOption("healthy");
+
+  await expect(page.getByText("Todavía falta contexto.", { exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Abrir siguiente paso →" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Llevar este contexto a soporte técnico →" })).toBeVisible();
 });
 
 test("extremely dry substrate stays in review instead of recommending fertilizer", async ({ page }) => {
@@ -107,6 +155,7 @@ test("extremely dry substrate stays in review instead of recommending fertilizer
   await page.getByLabel("Condición de la planta").selectOption("extremely-dry");
   await expect(page.getByText("Primero recupera una humedad adecuada.", { exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: "Abrir siguiente paso →" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Llevar este contexto a soporte técnico →" })).toBeVisible();
 });
 
 test("Casa guide library publishes four reconstructed same-origin PDFs", async ({ page }) => {

--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -129,7 +129,7 @@ test("Casa diagnostic restores structured state and Contact inherits it without 
   await expect(page.getByRole("heading", { name: /Cuéntanos sobre tu cultivo o tu interés en Wondergreen/i })).toBeVisible();
   await expect(page.getByLabel("¿Desde qué contexto nos escribes?")).toHaveValue("wondergreen");
   await expect(page.getByLabel("¿Qué necesitas resolver primero?")).toHaveValue("nutricion");
-  await expect(page.getByText(/Contexto recibido de la navegación:/)).toContainText("Materas: M, L");
+  await expect(page.getByLabel("Contexto recibido de la navegación")).toContainText("Materas: M, L");
 
   await page.getByRole("button", { name: "Preparar contexto" }).click();
   await expect(page.getByLabel("Resumen preparado para la conversación")).toContainText("Contexto heredado: Casa & Jardín");

--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -123,7 +123,7 @@ test("Casa diagnostic restores structured state and Contact inherits it without 
   expect(target.searchParams.get("need")).toBe("nutricion");
   expect(target.searchParams.get("source")).toBe("casa-jardin-diagnostico");
   expect(target.searchParams.get("contexto")).toContain("Materas: M, L");
-  expect(target.searchParams.get("contexto")).toContain("Punto").not;
+  expect(target.searchParams.get("contexto")).not.toContain("prescripción");
 
   await support.click();
   await expect(page.getByRole("heading", { name: /Cuéntanos sobre tu cultivo o tu interés en Wondergreen/i })).toBeVisible();

--- a/src/app/casa-jardin/diagnostico/home-garden-diagnostic.tsx
+++ b/src/app/casa-jardin/diagnostico/home-garden-diagnostic.tsx
@@ -1,16 +1,34 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { homeGardenDiagnostic, homeGardenProducts, visibleHomeGardenKits } from "@/data/home-garden";
 import styles from "../casa-jardin.module.css";
 
-type StageKey = keyof typeof homeGardenDiagnostic.stages | "";
+type StageKey = keyof typeof homeGardenDiagnostic.stages | "unknown" | "";
 type ConditionKey = "healthy" | "stressed" | "very-wilted" | "waterlogged" | "extremely-dry" | "pest-damage" | "root-problem" | "unknown" | "";
 type PlantType = "green" | "flower" | "garden" | "fruit" | "mixed" | "new-transplant" | "unsure" | "";
 type PotSize = (typeof homeGardenDiagnostic.potSizes)[number];
 
-const conditionOptions: readonly [ConditionKey, string][] = [
+type InitialDiagnosticContext = {
+  plantType?: string;
+  stage?: string;
+  condition?: string;
+  plantCount?: string;
+  potSizes?: string;
+};
+
+const plantTypeOptions: readonly [Exclude<PlantType, "">, string][] = [
+  ["green", "Planta verde / follaje"],
+  ["flower", "Planta con flor"],
+  ["garden", "Huerta / aromáticas"],
+  ["fruit", "Planta productiva / fruto"],
+  ["mixed", "Colección mixta"],
+  ["new-transplant", "Recién trasplantada"],
+  ["unsure", "No estoy seguro"],
+];
+
+const conditionOptions: readonly [Exclude<ConditionKey, "">, string][] = [
   ["healthy", "Activa / aparentemente sana"],
   ["stressed", "Estresada, pero sin daño severo evidente"],
   ["very-wilted", "Muy marchita"],
@@ -21,21 +39,42 @@ const conditionOptions: readonly [ConditionKey, string][] = [
   ["unknown", "No estoy seguro"],
 ];
 
-const stageOptions: readonly [StageKey, string][] = [
+const stageOptions: readonly [Exclude<StageKey, "">, string][] = [
   ["growing", "Sacando hojas o brotes nuevos"],
   ["stable", "Estable / mantenimiento"],
   ["flowering", "Formando botones o flores"],
   ["fruiting", "Con fruto o en etapa productiva"],
   ["mixed", "Tengo varias plantas en etapas distintas"],
-  ["", "No sé identificar la etapa"],
+  ["unknown", "No sé identificar la etapa"],
 ];
 
-export function HomeGardenDiagnostic() {
-  const [plantType, setPlantType] = useState<PlantType>("");
-  const [stage, setStage] = useState<StageKey>("");
-  const [condition, setCondition] = useState<ConditionKey>("");
-  const [plantCount, setPlantCount] = useState("");
-  const [potSizes, setPotSizes] = useState<PotSize[]>([]);
+const plantCounts = ["1-5", "6-10", "11-20", "21-40", "40+"] as const;
+
+function validOption<T extends string>(value: string | undefined, options: readonly (readonly [T, string])[]): T | "" {
+  if (!value) return "";
+  return options.some(([id]) => id === value) ? value as T : "";
+}
+
+function validPlantCount(value: string | undefined) {
+  return value && (plantCounts as readonly string[]).includes(value) ? value : "";
+}
+
+function validPotSizes(value: string | undefined): PotSize[] {
+  if (!value) return [];
+  const allowed = homeGardenDiagnostic.potSizes as readonly string[];
+  return value.split(",").filter((size): size is PotSize => allowed.includes(size));
+}
+
+function optionLabel<T extends string>(options: readonly (readonly [T, string])[], value: string) {
+  return options.find(([id]) => id === value)?.[1];
+}
+
+export function HomeGardenDiagnostic({ initial = {} }: { initial?: InitialDiagnosticContext }) {
+  const [plantType, setPlantType] = useState<PlantType>(() => validOption(initial.plantType, plantTypeOptions));
+  const [stage, setStage] = useState<StageKey>(() => validOption(initial.stage, stageOptions));
+  const [condition, setCondition] = useState<ConditionKey>(() => validOption(initial.condition, conditionOptions));
+  const [plantCount, setPlantCount] = useState(() => validPlantCount(initial.plantCount));
+  const [potSizes, setPotSizes] = useState<PotSize[]>(() => validPotSizes(initial.potSizes));
 
   const result = useMemo(() => {
     if (!condition || !stage) return null;
@@ -49,7 +88,7 @@ export function HomeGardenDiagnostic() {
       return { type: "review" as const, title: "Primero recupera una humedad adecuada.", copy: "El sustrato extremadamente seco queda en semáforo amarillo: corrige la condición y vuelve a observar antes de decidir una aplicación." };
     }
 
-    const destination = homeGardenDiagnostic.stages[stage as keyof typeof homeGardenDiagnostic.stages];
+    const destination = stage === "unknown" ? undefined : homeGardenDiagnostic.stages[stage as keyof typeof homeGardenDiagnostic.stages];
     if (!destination) return { type: "review" as const, title: "Todavía falta contexto.", copy: "No identificamos una etapa con suficiente claridad. Usa el semáforo, revisa agua, drenaje, raíces y sanidad, o solicita orientación antes de aplicar." };
 
     if (destination === "casa-completa") {
@@ -67,6 +106,37 @@ export function HomeGardenDiagnostic() {
     };
   }, [condition, plantType, stage]);
 
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (plantType) params.set("plant", plantType);
+    if (stage) params.set("stage", stage);
+    if (condition) params.set("condition", condition);
+    if (plantCount) params.set("count", plantCount);
+    if (potSizes.length) params.set("pots", potSizes.join(","));
+    const query = params.toString();
+    window.history.replaceState(null, "", query ? `${window.location.pathname}?${query}` : window.location.pathname);
+  }, [condition, plantCount, plantType, potSizes, stage]);
+
+  const contactHref = useMemo(() => {
+    if (!result) return null;
+    const context = [
+      "Casa & Jardín",
+      plantType ? `Tipo: ${optionLabel(plantTypeOptions, plantType)}` : "Tipo: por definir",
+      stage ? `Etapa: ${optionLabel(stageOptions, stage)}` : "Etapa: por definir",
+      condition ? `Condición: ${optionLabel(conditionOptions, condition)}` : "Condición: por definir",
+      plantCount ? `Escala: ${plantCount} plantas` : "",
+      potSizes.length ? `Materas: ${potSizes.join(", ")}` : "",
+      `Orientación del flujo: ${result.title}`,
+    ].filter(Boolean).join(" · ");
+    const params = new URLSearchParams({
+      audience: "wondergreen",
+      need: "nutricion",
+      source: "casa-jardin-diagnostico",
+      contexto: context,
+    });
+    return `/contacto?${params.toString()}#preparar`;
+  }, [condition, plantCount, plantType, potSizes, result, stage]);
+
   function togglePotSize(size: PotSize) {
     setPotSizes((current) => current.includes(size) ? current.filter((item) => item !== size) : [...current, size]);
   }
@@ -79,13 +149,7 @@ export function HomeGardenDiagnostic() {
           <h3>¿Qué estás cuidando?</h3>
           <select value={plantType} onChange={(event) => setPlantType(event.target.value as PlantType)} aria-label="Tipo de planta">
             <option value="">Selecciona una opción</option>
-            <option value="green">Planta verde / follaje</option>
-            <option value="flower">Planta con flor</option>
-            <option value="garden">Huerta / aromáticas</option>
-            <option value="fruit">Planta productiva / fruto</option>
-            <option value="mixed">Colección mixta</option>
-            <option value="new-transplant">Recién trasplantada</option>
-            <option value="unsure">No estoy seguro</option>
+            {plantTypeOptions.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
           </select>
         </label>
 
@@ -94,7 +158,7 @@ export function HomeGardenDiagnostic() {
           <h3>¿Qué está haciendo?</h3>
           <select value={stage} onChange={(event) => setStage(event.target.value as StageKey)} aria-label="Etapa de la planta">
             <option value="">Selecciona una opción</option>
-            {stageOptions.filter(([value]) => value).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+            {stageOptions.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
           </select>
         </label>
 
@@ -145,6 +209,7 @@ export function HomeGardenDiagnostic() {
             <strong>{result.title}</strong>
             <p>{result.copy}</p>
             {"href" in result && result.href ? <Link href={result.href}>Abrir siguiente paso →</Link> : null}
+            {contactHref ? <Link href={contactHref}>Llevar este contexto a soporte técnico →</Link> : null}
           </>
         )}
       </div>

--- a/src/app/casa-jardin/diagnostico/page.tsx
+++ b/src/app/casa-jardin/diagnostico/page.tsx
@@ -10,7 +10,28 @@ export const metadata: Metadata = {
   robots: { index: false, follow: true },
 };
 
-export default function CasaJardinDiagnosticoPage() {
+type DiagnosticSearchParams = {
+  plant?: string | string[];
+  stage?: string | string[];
+  condition?: string | string[];
+  count?: string | string[];
+  pots?: string | string[];
+};
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function CasaJardinDiagnosticoPage({ searchParams }: { searchParams: Promise<DiagnosticSearchParams> }) {
+  const query = await searchParams;
+  const initial = {
+    plantType: firstParam(query.plant),
+    stage: firstParam(query.stage),
+    condition: firstParam(query.condition),
+    plantCount: firstParam(query.count),
+    potSizes: firstParam(query.pots),
+  };
+
   return (
     <div className={styles.page}>
       <main>
@@ -35,7 +56,7 @@ export default function CasaJardinDiagnosticoPage() {
               <div><span className={styles.eyebrow}>Flujo orientativo</span><h2>Etapa + condición antes de producto.</h2></div>
               <p>La cantidad de plantas se captura únicamente para preparar una futura recomendación de formato. No se traduce todavía en gramos, cucharadas, cobertura ni frecuencia.</p>
             </div>
-            <HomeGardenDiagnostic />
+            <HomeGardenDiagnostic initial={initial} />
           </div>
         </section>
       </main>

--- a/src/app/contacto/contact-context-builder.tsx
+++ b/src/app/contacto/contact-context-builder.tsx
@@ -9,6 +9,7 @@ type ContactContextBuilderProps = {
   initialNeed?: string;
   initialProduct?: string;
   initialCrop?: string;
+  initialContext?: string;
 };
 
 const audiences = [
@@ -41,7 +42,7 @@ function optionLabel(options: readonly (readonly [string, string])[], value: str
   return options.find(([id]) => id === value)?.[1] ?? value;
 }
 
-export function ContactContextBuilder({ bookingUrl, initialAudience = "", initialNeed = "", initialProduct, initialCrop }: ContactContextBuilderProps) {
+export function ContactContextBuilder({ bookingUrl, initialAudience = "", initialNeed = "", initialProduct, initialCrop, initialContext }: ContactContextBuilderProps) {
   const [audience, setAudience] = useState(initialAudience);
   const [need, setNeed] = useState(initialNeed);
   const [location, setLocation] = useState("");
@@ -53,13 +54,14 @@ export function ContactContextBuilder({ bookingUrl, initialAudience = "", initia
     const lines = [
       `Contexto: ${optionLabel(audiences, audience) || "Por definir"}`,
       `Necesidad: ${optionLabel(needs, need) || "Por definir"}`,
+      initialContext ? `Contexto heredado: ${initialContext}` : "",
       location ? `Ubicación: ${location}` : "",
       initialProduct ? `Referencia Wondergreen: ${initialProduct}` : "",
       initialCrop ? `Cultivo: ${initialCrop}` : "",
       details ? `Situación: ${details}` : "",
     ].filter(Boolean);
     return lines.join("\n");
-  }, [audience, need, location, details, initialProduct, initialCrop]);
+  }, [audience, need, location, details, initialContext, initialProduct, initialCrop]);
 
   async function copySummary() {
     try {
@@ -95,6 +97,7 @@ export function ContactContextBuilder({ bookingUrl, initialAudience = "", initia
         </div>
       </div>
 
+      {initialContext ? <p className={styles.formHelp}><strong>Contexto recibido de la navegación:</strong> {initialContext}</p> : null}
       <p className={styles.formHelp}>Este paso no envía información a Greenatics ni la guarda en un servidor. Solo organiza el contexto en tu navegador para que llegues mejor preparado a la conversación.</p>
       <div className={styles.actions}><button className={`${styles.button} ${styles.primary}`} type="submit">Preparar contexto</button><a className={`${styles.button} ${styles.ghost}`} href={bookingUrl} target="_blank" rel="noreferrer">Agendar sin preparar</a></div>
 

--- a/src/app/contacto/contact-context-builder.tsx
+++ b/src/app/contacto/contact-context-builder.tsx
@@ -97,7 +97,7 @@ export function ContactContextBuilder({ bookingUrl, initialAudience = "", initia
         </div>
       </div>
 
-      {initialContext ? <p className={styles.formHelp}><strong>Contexto recibido de la navegación:</strong> {initialContext}</p> : null}
+      {initialContext ? <p className={styles.formHelp} aria-label="Contexto recibido de la navegación"><strong>Contexto recibido de la navegación:</strong> {initialContext}</p> : null}
       <p className={styles.formHelp}>Este paso no envía información a Greenatics ni la guarda en un servidor. Solo organiza el contexto en tu navegador para que llegues mejor preparado a la conversación.</p>
       <div className={styles.actions}><button className={`${styles.button} ${styles.primary}`} type="submit">Preparar contexto</button><a className={`${styles.button} ${styles.ghost}`} href={bookingUrl} target="_blank" rel="noreferrer">Agendar sin preparar</a></div>
 

--- a/src/app/contacto/page.tsx
+++ b/src/app/contacto/page.tsx
@@ -66,6 +66,7 @@ type ContactSearchParams = {
   source?: string | string[];
   producto?: string | string[];
   cultivo?: string | string[];
+  contexto?: string | string[];
 };
 
 function firstParam(value: string | string[] | undefined) {
@@ -84,6 +85,10 @@ function normalizeAudience(value: string | undefined) {
   return "";
 }
 
+function normalizeInheritedContext(value: string | undefined) {
+  return value?.trim().slice(0, 480) || undefined;
+}
+
 export default async function ContactPage({ searchParams }: { searchParams: Promise<ContactSearchParams> }) {
   const query = await searchParams;
   const audience = normalizeAudience(firstParam(query.audience));
@@ -91,6 +96,7 @@ export default async function ContactPage({ searchParams }: { searchParams: Prom
   const service = firstParam(query.service);
   const source = firstParam(query.source);
   const crop = firstParam(query.cultivo);
+  const inheritedContext = normalizeInheritedContext(firstParam(query.contexto));
   const productSlug = firstParam(query.producto);
   const product = productSlug ? getWondergreenReference(productSlug) : undefined;
   const contextual = audienceContent[audience];
@@ -107,12 +113,13 @@ export default async function ContactPage({ searchParams }: { searchParams: Prom
               <span className={styles.eyebrow}>Contacto Greenatics · conversación con contexto</span>
               <h1>{title}</h1>
               <p className={styles.lead}>{lead}</p>
-              {(source || service || product || crop) ? (
+              {(source || service || product || crop || inheritedContext) ? (
                 <div className={styles.contextLine} aria-label="Contexto heredado de navegación">
                   {source ? <span><strong>Origen:</strong> {source}</span> : null}
                   {service ? <span><strong>Servicio:</strong> {service}</span> : null}
                   {product ? <span><strong>Producto:</strong> {product.name}{product.formula ? ` ${product.formula}` : ""}</span> : null}
                   {crop ? <span><strong>Cultivo:</strong> {crop}</span> : null}
+                  {inheritedContext ? <span><strong>Contexto:</strong> {inheritedContext}</span> : null}
                 </div>
               ) : null}
             </div>
@@ -148,6 +155,7 @@ export default async function ContactPage({ searchParams }: { searchParams: Prom
               initialNeed={need}
               initialProduct={product ? `${product.name}${product.formula ? ` ${product.formula}` : ""}` : undefined}
               initialCrop={crop}
+              initialContext={inheritedContext}
             />
           </div>
         </section>


### PR DESCRIPTION
## Objetivo
Cierra la pérdida de contexto entre el diagnóstico orientativo de Casa & Jardín y Contacto, manteniendo los truth locks domésticos actuales: sin cálculo de dosis, sin checkout y sin convertir una orientación por etapa en una prescripción agronómica.

## Casa & Jardín · diagnóstico
- El estado válido del flujo se refleja en query params: `plant`, `stage`, `condition`, `count`, `pots`.
- Una URL válida restaura tipo de planta, etapa, condición, escala y tamaños de matera.
- Valores no reconocidos se descartan en el cliente en lugar de crear estados nuevos.
- Se habilita explícitamente `No sé identificar la etapa`; ese caso queda en revisión y no fabrica un producto.
- Las condiciones de seguridad siguen deteniendo la respuesta fertilizer-first.
- El resultado saludable conserva su siguiente paso doméstico existente y agrega una ruta separada para llevar el contexto a soporte técnico.
- Los estados safety/review pueden escalar a soporte sin abrir una recomendación de producto.

## Traspaso a Contacto V2
- Casa & Jardín envía únicamente valores estructurados derivados del propio flujo, nunca texto libre del usuario.
- Contacto acepta un parámetro `contexto`, limitado a 480 caracteres, y lo presenta como contexto heredado, no como diagnóstico.
- El builder de Contacto incorpora ese contexto al resumen local que el usuario puede preparar/copyar.
- Se preservan `audience=wondergreen`, `need=nutricion` y `source=casa-jardin-diagnostico`.
- Nada se envía ni persiste en servidor y el booking de Outlook sigue separado.

## Guardrails
- No se calculan gramos, cucharadas, frecuencia, cobertura ni equivalencias S/M/L/XL.
- No se publican precios ni se habilita ecommerce.
- No se recomienda fertilizante ante señales de seguridad o etapa desconocida.
- El texto heredado no se presenta como prescripción ni reemplaza diagnóstico técnico.

## Certificación añadida
- persistencia del estado válido en URL;
- restauración desde URL;
- etapa desconocida → revisión sin producto;
- safety → soporte técnico sin recomendación fertilizer-first;
- continuidad Casa & Jardín → Contacto → resumen preparado;
- conservación de los tests existentes de producto, kits, PDFs y no-checkout.

## Validación esperada
- quality
- database
- Playwright desktop
- Playwright mobile