### PR TITLE
feat(public): integra Finder Wondergreen en el hub editorial

### DIFF
--- a/e2e/wondergreen-editorial.spec.ts
+++ b/e2e/wondergreen-editorial.spec.ts
@@ -23,6 +23,7 @@ test("Wondergreen subnavigation follows the approved editorial hierarchy", async
   await expect(nav.getByRole("link", { name: "Tecnología" })).toHaveAttribute("href", "#tecnologia");
   await expect(nav.getByRole("link", { name: "Productos" })).toHaveAttribute("href", "/wondergreen/productos");
   await expect(nav.getByRole("link", { name: "Cultivos" })).toHaveAttribute("href", "/wondergreen/cultivos");
+  await expect(nav.getByRole("link", { name: "Finder" })).toHaveAttribute("href", "/wondergreen/finder");
   await expect(nav.getByRole("link", { name: "Bioinsumos" })).toHaveAttribute("href", "#bioinsumos");
   await expect(nav.getByRole("link", { name: "Guías" })).toHaveAttribute("href", "/biblioteca");
   await expect(nav.getByRole("link", { name: "Casa & Jardín" })).toHaveAttribute("href", "/casa-jardin");
@@ -40,6 +41,29 @@ test("Wondergreen exposes a household entry without turning Casa Jardin into eco
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
   await expect(page.getByRole("button", { name: /comprar/i })).toHaveCount(0);
   await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
+});
+
+test("Wondergreen hub surfaces the governed Finder without turning it into a product shortcut", async ({ page }) => {
+  await page.goto("/wondergreen");
+
+  await expect(page.getByRole("link", { name: "Encontrar mi programa" })).toHaveAttribute("href", "/wondergreen/finder");
+
+  const needEntry = page.getByRole("article").filter({
+    has: page.getByRole("heading", { name: "Tengo una necesidad", exact: true }),
+  });
+  await expect(needEntry.getByRole("link", { name: "Continuar →" })).toHaveAttribute("href", "/wondergreen/finder");
+
+  const finder = page.locator("#finder");
+  await expect(finder.getByRole("link", { name: "Abrir Finder Wondergreen" })).toHaveAttribute("href", "/wondergreen/finder");
+  await expect(finder.getByText(/cinco programas publicados/i)).toBeVisible();
+  await expect(finder.getByText(/no una prescripción automática/i)).toBeVisible();
+
+  await page.getByRole("link", { name: "Encontrar mi programa" }).click();
+  await expect(page).toHaveURL(/\/wondergreen\/finder$/);
+  await expect(page.getByRole("heading", { name: "Empieza por el cultivo y la etapa." })).toBeVisible();
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
+  await expect(page.getByRole("button", { name: /comprar/i })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: /comprar/i })).toHaveCount(0);
 });
 
 test("Wondergreen V2 explains what the system is before technology and product selection", async ({ page }) => {
@@ -115,7 +139,7 @@ test("Wondergreen finder follows diagnosis to follow-up without automatic prescr
   await expect(finder.getByText("Diagnóstico y análisis", { exact: true })).toBeVisible();
   await expect(finder.getByText("Seguimiento y ajuste", { exact: true })).toBeVisible();
   await expect(finder.getByText(/no una prescripción automática/i)).toBeVisible();
-  await expect(finder.getByRole("link", { name: "Empezar por cultivo" })).toHaveAttribute("href", "/wondergreen/cultivos");
+  await expect(finder.getByRole("link", { name: "Abrir Finder Wondergreen" })).toHaveAttribute("href", "/wondergreen/finder");
   await expect(finder.getByRole("link", { name: "Consultar guías" })).toHaveAttribute("href", "/biblioteca");
 });
 

--- a/src/app/wondergreen/page.tsx
+++ b/src/app/wondergreen/page.tsx
@@ -22,8 +22,8 @@ const entryPaths = [
   {
     number: "02",
     title: "Tengo una necesidad",
-    copy: "Cruza contexto, síntomas, análisis y objetivo antes de cerrar una ruta técnica.",
-    href: "#finder",
+    copy: "Organiza cultivo, etapa y evidencia disponible antes de revisar una ruta técnica.",
+    href: "/wondergreen/finder",
   },
   {
     number: "03",
@@ -85,6 +85,7 @@ export default function WondergreenPage() {
             <a href="#tecnologia">Tecnología</a>
             <Link href="/wondergreen/productos">Productos</Link>
             <Link href="/wondergreen/cultivos">Cultivos</Link>
+            <Link href="/wondergreen/finder">Finder</Link>
             <a href="#bioinsumos">Bioinsumos</a>
             <Link href="/biblioteca">Guías</Link>
             <Link href="/casa-jardin">Casa & Jardín</Link>
@@ -113,7 +114,7 @@ export default function WondergreenPage() {
               </p>
               <div className={styles.actions}>
                 <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/wondergreen/productos">Ver productos</Link>
-                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/wondergreen/cultivos">Empezar por cultivo</Link>
+                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/wondergreen/finder">Encontrar mi programa</Link>
                 <Link className={styles.textLink} href="/contacto">Hablar con equipo técnico →</Link>
               </div>
               <div className={styles.heroTruth}>
@@ -174,7 +175,7 @@ export default function WondergreenPage() {
                   <span className={styles.index}>{item.number}</span>
                   <h3>{item.title}</h3>
                   <p>{item.copy}</p>
-                  {item.href.startsWith("/") ? <Link href={item.href}>Continuar →</Link> : <a href={item.href}>Continuar →</a>}
+                  <Link href={item.href}>Continuar →</Link>
                 </article>
               ))}
             </div>
@@ -283,9 +284,9 @@ export default function WondergreenPage() {
             <div className={styles.finderIntro}>
               <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Objetivo + etapa</span>
               <h2 id="finder-title">Del contexto al seguimiento.</h2>
-              <p>La ruta es una orientación técnica, no una prescripción automática. Cuando falte información, el sistema debe pedir análisis o derivar a un asesor antes de cerrar una recomendación.</p>
+              <p>El Finder V1 organiza cultivo, etapa y evidencia disponible dentro de los cinco programas publicados. Es una orientación técnica, no una prescripción automática, y se detiene cuando la etapa no está clara.</p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.buttonLight}`} href="/wondergreen/cultivos">Empezar por cultivo</Link>
+                <Link className={`${styles.button} ${styles.buttonLight}`} href="/wondergreen/finder">Abrir Finder Wondergreen</Link>
                 <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/biblioteca">Consultar guías</Link>
               </div>
             </div>


### PR DESCRIPTION
## Objetivo
Hacer que el Finder Wondergreen V1 sea una entrada visible y coherente desde `/wondergreen` sin convertirlo en prescriptor ni ampliar el alcance agronómico gobernado.

## Cambios
- La subnavegación Wondergreen incorpora `Finder` → `/wondergreen/finder`.
- El hero cambia la entrada secundaria a `Encontrar mi programa` → Finder.
- La tarjeta `Tengo una necesidad` del router deja de hacer scroll conceptual y abre el Finder funcional.
- El bloque `Del contexto al seguimiento` explica explícitamente el alcance V1 y añade `Abrir Finder Wondergreen`.
- Se mantiene Product Master como fuente separada para composición, condición comercial, dosis y uso.

## Truth locks preservados
- Solo cinco programas gobernados: Café, Cacao, Aguacate, Limón Tahití y Pastos/Gramíneas.
- No hay dosis, frecuencia, mezcla, compatibilidad, eficacia, cobertura ni disponibilidad comercial calculadas por el Finder.
- No hay diagnóstico automático por síntomas.
- El Finder continúa `noindex` en V1.
- No se añade checkout ni CTA de compra.

## E2E
- Finder visible en subnavegación.
- Finder visible en hero.
- Router `Tengo una necesidad` conduce al Finder.
- Bloque conceptual conduce al Finder.
- Navegación real al Finder conserva `noindex` y ausencia de compra.
- Se actualiza el contrato existente del bloque Finder.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile