### PR TITLE
feat(public): alinea el hero Wondergreen con el mensaje de suelo

### DIFF
--- a/e2e/legacy-public-cutover.spec.ts
+++ b/e2e/legacy-public-cutover.spec.ts
@@ -25,7 +25,7 @@ test("legacy product discovery lands on Wondergreen without preserving old claim
   ]) {
     await page.goto(path);
     await expect(page).toHaveURL(/\/wondergreen$/);
-    await expect(page.getByRole("heading", { name: /Nutrición que vuelve a la tierra/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Nutrición que trabaja con el suelo/i })).toBeVisible();
   }
 });
 

--- a/e2e/public-web.spec.ts
+++ b/e2e/public-web.spec.ts
@@ -24,7 +24,7 @@ test("public home presents Greenatics and exposes the digital bridge", async ({ 
 test("Wondergreen exposes fertilizers, bioinputs and governed technology narrative", async ({ page }) => {
   await page.goto("/wondergreen");
 
-  await expect(page.getByRole("heading", { name: "Nutrición que vuelve a la tierra." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Dos grandes líneas dentro de una misma marca." })).toBeVisible();
 
   const portfolio = page.locator("#portafolio");

--- a/e2e/wondergreen-editorial.spec.ts
+++ b/e2e/wondergreen-editorial.spec.ts
@@ -66,10 +66,24 @@ test("Wondergreen hub surfaces the governed Finder without turning it into a pro
   await expect(page.getByRole("link", { name: /comprar/i })).toHaveCount(0);
 });
 
+test("Wondergreen hero uses the approved soil message with governed technical qualification", async ({ page }) => {
+  await page.goto("/wondergreen");
+
+  const hero = page.locator("section").filter({ has: page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." }) }).first();
+  await expect(page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." })).toBeVisible();
+  await expect(hero.getByText(/nutrición organomineral, soluciones líquidas, biología y conocimiento/i)).toBeVisible();
+  await expect(hero.getByText(/En las referencias sólidas donde está documentado/i)).toBeVisible();
+  await expect(hero.getByText(/matriz, la oclusión y la lenta liberación/i)).toBeVisible();
+  await expect(hero.getByText(/la selección siempre vuelve al cultivo, la etapa y la evidencia disponible/i)).toBeVisible();
+  await expect(hero.getByRole("link", { name: "Encontrar mi programa" })).toHaveAttribute("href", "/wondergreen/finder");
+  await expect(hero.getByRole("link", { name: "Ver productos" })).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(hero.getByText("Product Master público", { exact: true })).toBeVisible();
+});
+
 test("Wondergreen V2 explains what the system is before technology and product selection", async ({ page }) => {
   await page.goto("/wondergreen");
 
-  await expect(page.getByRole("heading", { name: "Nutrición que vuelve a la tierra." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Un sistema de nutrición y manejo alrededor del suelo y del cultivo." })).toBeVisible();
   await expect(page.getByText(/fertilizantes organominerales sólidos, referencias líquidas, compost, bioinsumos, conocimiento y acompañamiento técnico/i)).toBeVisible();
   await expect(page.getByText(/Primero se lee el contexto; después se seleccionan las herramientas/i)).toBeVisible();

--- a/src/app/wondergreen/page.tsx
+++ b/src/app/wondergreen/page.tsx
@@ -108,13 +108,13 @@ export default function WondergreenPage() {
                 sizes="(max-width: 720px) 78vw, 420px"
                 priority
               />
-              <h1 id="wondergreen-title">Nutrición que vuelve a la tierra.</h1>
+              <h1 id="wondergreen-title">Nutrición que trabaja con el suelo.</h1>
               <p className={styles.lead}>
-                Wondergreen integra suelo, nutrición, biología y conocimiento. En sus sólidos aplicables, la historia técnica parte de una matriz organomineral y de procesos como la oclusión; la lectura agronómica siempre vuelve al cultivo, al suelo y a la evidencia disponible.
+                En Wondergreen desarrollamos soluciones para acompañar el cultivo desde el suelo: nutrición organomineral, soluciones líquidas, biología y conocimiento. En las referencias sólidas donde está documentado, explicamos además la matriz, la oclusión y la lenta liberación; la selección siempre vuelve al cultivo, la etapa y la evidencia disponible.
               </p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/wondergreen/productos">Ver productos</Link>
-                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/wondergreen/finder">Encontrar mi programa</Link>
+                <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/wondergreen/finder">Encontrar mi programa</Link>
+                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/wondergreen/productos">Ver productos</Link>
                 <Link className={styles.textLink} href="/contacto">Hablar con equipo técnico →</Link>
               </div>
               <div className={styles.heroTruth}>


### PR DESCRIPTION
## Objetivo
Alinear el hero público de Wondergreen con el mensaje editorial aprobado sin convertir oclusión o lenta liberación en atributos universales del portafolio.

## Cambios
- H1: `Nutrición que trabaja con el suelo.`
- Lead reorganizado alrededor de suelo, nutrición organomineral, soluciones líquidas, biología y conocimiento.
- La matriz, la oclusión y la lenta liberación quedan expresamente limitadas a las referencias sólidas donde estén documentadas.
- `Encontrar mi programa` pasa a ser CTA primaria y conserva destino `/wondergreen/finder`.
- `Ver productos` queda como CTA secundaria y conserva Product Master separado.

## Truth locks
- No se afirma que todo el portafolio sea ocluido o de lenta liberación.
- No se añaden beneficios agronómicos cuantificados ni resultados universales.
- El Product Master sigue gobernando composición, condición comercial, dosis y uso.
- Finder sigue separado de prescripción, dosis y checkout.

## E2E
- Certifica el H1 aprobado.
- Certifica la calificación `En las referencias sólidas donde está documentado`.
- Certifica que matriz, oclusión y lenta liberación no se presentan sin esa calificación.
- Certifica destinos Finder y Product Master.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile