### PR TITLE
feat(public): alinea Wondergreen en Home y expone Finder

### DIFF
--- a/e2e/public-editorial-home.spec.ts
+++ b/e2e/public-editorial-home.spec.ts
@@ -36,9 +36,10 @@ test("public HOME explains Greenatics as an operating logic instead of stacked s
 test("public HOME elevates Wondergreen without publishing unsupported universal claims", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "Nutrición que vuelve a la tierra." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." })).toBeVisible();
   await expect(page.getByText(/matriz organomineral, la oclusión y la lenta liberación documentada para esa versión/i)).toBeVisible();
   await expect(page.getByText(/sin convertir una característica del producto en una promesa agronómica universal/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Encontrar mi programa →" })).toHaveAttribute("href", "/wondergreen/finder");
   await expect(page.getByRole("link", { name: "Productos →" })).toHaveAttribute("href", "/wondergreen/productos");
   await expect(page.getByRole("link", { name: "Cultivos →" })).toHaveAttribute("href", "/wondergreen/cultivos");
 });

--- a/e2e/public-web.spec.ts
+++ b/e2e/public-web.spec.ts
@@ -17,7 +17,7 @@ test("public home presents Greenatics and exposes the digital bridge", async ({ 
   await expect(page.getByRole("img", { name: "Greenatics" }).first()).toBeVisible();
   await expect(await digitalEntry(page)).toHaveAttribute("href", "/app");
   await expect(page.getByRole("heading", { name: "Una marca. Tres formas claras de entrar." })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Nutrición que vuelve a la tierra." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." })).toBeVisible();
   await expect(page.getByRole("heading", { name: "La operación también necesita una capa digital." })).toBeVisible();
 });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -178,7 +178,7 @@ export default function Home() {
                 height={221}
                 sizes="(max-width: 760px) 76vw, 420px"
               />
-              <h2 id="home-wondergreen-title">Nutrición que vuelve a la tierra.</h2>
+              <h2 id="home-wondergreen-title">Nutrición que trabaja con el suelo.</h2>
             </div>
 
             <div className={styles.wondergreenCopy}>
@@ -186,6 +186,7 @@ export default function Home() {
                 Wondergreen organiza el portafolio alrededor del suelo, la nutrición, la biología, el cultivo y el seguimiento. En las referencias sólidas que correspondan, la explicación técnica parte de la matriz organomineral, la oclusión y la lenta liberación documentada para esa versión, sin convertir una característica del producto en una promesa agronómica universal.
               </p>
               <div className={styles.wondergreenLinks}>
+                <Link href="/wondergreen/finder">Encontrar mi programa →</Link>
                 <Link href="/wondergreen/productos">Productos →</Link>
                 <Link href="/wondergreen/cultivos">Cultivos →</Link>
                 <Link href="/biblioteca">Guías →</Link>


### PR DESCRIPTION
## Objetivo
Alinear la banda Wondergreen de Home con el mensaje editorial ya certificado en `/wondergreen` y hacer visible el Finder como ruta directa desde la portada.

## Cambios
- H2 de la banda Wondergreen: `Nutrición que trabaja con el suelo.`
- Nueva entrada `Encontrar mi programa →` hacia `/wondergreen/finder`.
- Se conservan Productos, Cultivos y Guías como rutas separadas.
- Se preserva íntegramente el párrafo técnico existente y sus Truth Locks.

## Truth locks
- No se amplían claims de oclusión o lenta liberación.
- No se modifica Product Master.
- No se añade dosis, prescripción automática ni checkout.
- Finder sigue siendo una herramienta de orientación gobernada.

## E2E
- Certifica el nuevo mensaje Wondergreen en Home.
- Certifica la ruta directa al Finder.
- Conserva las verificaciones existentes de claims y rutas públicas.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile