### PR TITLE
feat(public): crea hub Recursos Greenatics

### DIFF
--- a/e2e/pilot-day-cycle.spec.ts
+++ b/e2e/pilot-day-cycle.spec.ts
@@ -1,5 +1,28 @@
 import { expect, test } from "@playwright/test";
 
+function operationalDateFromLotCode(lotCode: string) {
+  const match = lotCode.match(/TAM-FORSU-(\d{2})(\d{2})(\d{2})-\d{3}/);
+  if (!match) throw new Error(`No se pudo derivar la fecha operativa de ${lotCode}.`);
+  return `20${match[1]}-${match[2]}-${match[3]}`;
+}
+
+function bogotaLocalMinuteForDate(operationalDate: string) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    hourCycle: "h23",
+    timeZone: "America/Bogota",
+  }).formatToParts(new Date());
+  const read = (type: Intl.DateTimeFormatPartTypes) => parts.find((part) => part.type === type)?.value;
+  const currentDate = `${read("year")}-${read("month")}-${read("day")}`;
+  const currentTime = `${read("hour")}:${read("minute")}`;
+  return `${operationalDate}T${currentDate === operationalDate ? currentTime : "23:59"}`;
+}
+
 /**
  * Pilot-readiness integration gate for the deterministic local adapter.
  *
@@ -32,6 +55,7 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   const receptionText = await reception.textContent();
   const lotCode = receptionText?.match(/TAM-FORSU-\d{6}-\d{3}/)?.[0];
   expect(lotCode).toBeTruthy();
+  const operationalDate = operationalDateFromLotCode(lotCode!);
 
   await page.goto("/app");
   await expect(page.getByLabel("Indicadores de hoy").locator(".metric-block").filter({ hasText: "Recibido" })).toContainText("1.50 t");
@@ -67,6 +91,9 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   await sourceRow.getByRole("checkbox").check();
   await sourceRow.getByLabel("Asignar (kg)").fill("1500");
   await page.getByLabel("Volumen conformado (m³)").fill("8");
+  const formationMoment = bogotaLocalMinuteForDate(operationalDate);
+  await page.getByLabel("Inicio de conformación · hora Colombia").fill(formationMoment);
+  await page.getByLabel("Fin de conformación · hora Colombia").fill(formationMoment);
   await page.getByRole("group", { name: "Trabajadores de conformación" }).getByRole("checkbox").first().check();
   await page.getByRole("button", { name: "Conformar pila" }).click();
   await page.waitForURL((url) => url.pathname.startsWith("/compost/") && url.pathname !== "/compost/new");
@@ -105,8 +132,9 @@ test("pilot day preserves cross-module traceability from intake to dashboard", a
   const stock = page.locator("article").filter({ hasText: "Wondergreen sólido" }).first();
   await expect(stock).toContainText("300 kg");
 
-  // 8) Direction can reconstruct the day from canonical facts in one dashboard.
+  // 8) Direction can reconstruct the same operational day from canonical facts in one dashboard.
   await page.goto("/dashboard");
+  await page.getByLabel("Fecha").fill(operationalDate);
   const indicators = page.getByLabel("Indicadores operativos");
   await expect(indicators.locator("article").filter({ hasText: "Recibido" })).toContainText("1.50 t");
   await expect(indicators.locator("article").filter({ hasText: "Procesado" })).toContainText("1.50 t");

--- a/e2e/public-company-contact.spec.ts
+++ b/e2e/public-company-contact.spec.ts
@@ -8,7 +8,7 @@ test("company page explains Greenatics through capability, method and evidence",
   await expect(page.getByRole("heading", { name: /Diagnóstico primero\. Después una ruta que pueda ejecutarse/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: /Un caso sirve cuando deja aprendizaje transferible/i })).toBeVisible();
   await expect(page.getByRole("link", { name: /Wondergreen/i }).last()).toHaveAttribute("href", "/wondergreen");
-  await expect(page.getByRole("link", { name: /Recursos/i }).last()).toHaveAttribute("href", "/biblioteca");
+  await expect(page.getByRole("link", { name: /Recursos/i }).last()).toHaveAttribute("href", "/recursos");
 });
 
 test("contact page starts with context instead of forcing a service name", async ({ page }) => {

--- a/e2e/public-foundation.spec.ts
+++ b/e2e/public-foundation.spec.ts
@@ -12,6 +12,7 @@ const publicRoutes = [
   "/wondergreen",
   "/wondergreen/cultivos",
   "/wondergreen/cultivos/cafe",
+  "/recursos",
   "/proyectos",
   "/proyectos/yarumal",
   "/impacto",

--- a/e2e/public-seo-contract.spec.ts
+++ b/e2e/public-seo-contract.spec.ts
@@ -14,6 +14,7 @@ const publicRoutes = [
   "/wondergreen",
   "/wondergreen/cultivos",
   "/wondergreen/cultivos/cafe",
+  "/recursos",
   "/proyectos",
   "/proyectos/yarumal",
   "/impacto",

--- a/e2e/public-shell-seo.spec.ts
+++ b/e2e/public-shell-seo.spec.ts
@@ -6,7 +6,7 @@ const shellRoutes = [
   "/soluciones", "/soluciones/esp", "/soluciones/municipios", "/soluciones/empresas",
   "/soluciones/propiedad-horizontal", "/soluciones/plantas",
   "/soluciones/residuos-organicos", "/soluciones/infraestructura-plantas", "/soluciones/propiedad-horizontal-redes",
-  "/soluciones/diagnostico-caracterizacion", "/proyectos", "/proyectos/yarumal", "/impacto",
+  "/soluciones/diagnostico-caracterizacion", "/recursos", "/proyectos", "/proyectos/yarumal", "/impacto",
   "/biblioteca", "/biblioteca/guia-deficiencias", "/nosotros", "/contacto",
 ];
 
@@ -43,12 +43,13 @@ test("public home uses the canonical shell V2 and real routes", async ({ page },
     await expect(nav.getByRole("link", { name: "Soluciones", exact: true })).toHaveAttribute("href", "/soluciones");
     await expect(nav.getByRole("link", { name: "Wondergreen", exact: true })).toHaveAttribute("href", "/wondergreen");
     await expect(nav.getByRole("link", { name: "Casa & Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
-    await expect(nav.getByRole("link", { name: "Recursos", exact: true })).toHaveAttribute("href", "/biblioteca");
+    await expect(nav.getByRole("link", { name: "Recursos", exact: true })).toHaveAttribute("href", "/recursos");
     await expect(nav.getByRole("link", { name: "Nosotros", exact: true })).toHaveAttribute("href", "/nosotros");
     await expect(header.getByRole("link", { name: "Hablar con nosotros", exact: true })).toHaveAttribute("href", "/contacto");
     await expect(header.getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
   }
 
+  await expect(footer.getByRole("link", { name: "Recursos", exact: true })).toHaveAttribute("href", "/recursos");
   await expect(footer.getByRole("link", { name: "Casa & Jardín", exact: true })).toHaveAttribute("href", "/casa-jardin");
   await expect(footer.getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
 });
@@ -131,6 +132,8 @@ test("sitemap exposes canonical audience routes while legacy combined routes sta
     "/soluciones/infraestructura-plantas",
     "/soluciones/propiedad-horizontal-redes",
     "/soluciones/diagnostico-caracterizacion",
+    "/recursos",
+    "/biblioteca",
   ]) expect(sitemapText).toContain(`https://greenatics.com.co${path}`);
   expect(sitemapText).not.toContain("https://greenatics.com.co/soluciones/esp-municipios");
   expect(sitemapText).not.toContain("https://greenatics.com.co/soluciones/empresas-grandes-generadores");

--- a/e2e/public-social.spec.ts
+++ b/e2e/public-social.spec.ts
@@ -4,6 +4,7 @@ const routes = [
   "/wondergreen",
   "/wondergreen/cultivos",
   "/wondergreen/cultivos/cafe",
+  "/recursos",
   "/impacto",
   "/biblioteca",
   "/biblioteca/guia-deficiencias",

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -19,7 +19,7 @@ test("public resources hub exposes library, projects and impact as distinct laye
   await expect(page.getByRole("link", { name: "Abrir biblioteca →", exact: true })).toHaveAttribute("href", "/biblioteca");
   await expect(page.getByRole("link", { name: "Ver proyectos →", exact: true })).toHaveAttribute("href", "/proyectos");
   await expect(page.getByRole("link", { name: "Ver impacto →", exact: true })).toHaveAttribute("href", "/impacto");
-  await expect(page.getByRole("link", { name: "Explorar soluciones →", exact: true })).toHaveAttribute("href", "/soluciones");
+  await expect(page.getByRole("link", { name: /Explorar soluciones/ })).toHaveAttribute("href", "/soluciones");
 });
 
 test("public library exposes Wondergreen guides with same-origin PDF downloads", async ({ page }) => {

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -10,14 +10,16 @@ const approvedDownloadIds = [
 ];
 
 test("public resources hub exposes library, projects and impact as distinct layers", async ({ page }) => {
-  await page.goto("/biblioteca");
+  await page.goto("/recursos");
 
-  await expect(page.getByRole("heading", { name: "Conocimiento, casos y evidencia para decidir mejor." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Conocimiento, experiencia e impacto para decidir mejor." })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Biblioteca técnica", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Proyectos / casos", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Impacto", exact: true })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Ver casos →", exact: true })).toHaveAttribute("href", "/proyectos");
+  await expect(page.getByRole("link", { name: "Abrir biblioteca →", exact: true })).toHaveAttribute("href", "/biblioteca");
+  await expect(page.getByRole("link", { name: "Ver proyectos →", exact: true })).toHaveAttribute("href", "/proyectos");
   await expect(page.getByRole("link", { name: "Ver impacto →", exact: true })).toHaveAttribute("href", "/impacto");
+  await expect(page.getByRole("link", { name: "Explorar soluciones →", exact: true })).toHaveAttribute("href", "/soluciones");
 });
 
 test("public library exposes Wondergreen guides with same-origin PDF downloads", async ({ page }) => {

--- a/e2e/wondergreen-knowledge.spec.ts
+++ b/e2e/wondergreen-knowledge.spec.ts
@@ -19,7 +19,7 @@ test("public resources hub exposes library, projects and impact as distinct laye
   await expect(page.getByRole("link", { name: "Abrir biblioteca →", exact: true })).toHaveAttribute("href", "/biblioteca");
   await expect(page.getByRole("link", { name: "Ver proyectos →", exact: true })).toHaveAttribute("href", "/proyectos");
   await expect(page.getByRole("link", { name: "Ver impacto →", exact: true })).toHaveAttribute("href", "/impacto");
-  await expect(page.getByRole("link", { name: /Explorar soluciones/ })).toHaveAttribute("href", "/soluciones");
+  await expect(page.getByRole("link", { name: "Explorar soluciones", exact: true })).toHaveAttribute("href", "/soluciones");
 });
 
 test("public library exposes Wondergreen guides with same-origin PDF downloads", async ({ page }) => {

--- a/src/app/nosotros/page.tsx
+++ b/src/app/nosotros/page.tsx
@@ -37,7 +37,7 @@ const ecosystem = [
   ["Soluciones", "/soluciones", "Diagnóstico, planeación, regulación, rutas, plantas, operación, datos y valorización."],
   ["Wondergreen", "/wondergreen", "Suelo, nutrición, biología, productos, cultivos y acompañamiento técnico."],
   ["Casa & Jardín", "/casa-jardin", "Una entrada doméstica por observación, seguridad y etapa, todavía sin ecommerce activo."],
-  ["Recursos", "/biblioteca", "Biblioteca técnica, proyectos documentados e impacto publicado con gobierno."],
+  ["Recursos", "/recursos", "Biblioteca técnica, proyectos documentados e impacto publicado con gobierno."],
   ["GREENATICS OPS", "/app", "La capa digital donde una operación activa puede registrar y convertir actividad en evidencia."],
 ] as const;
 
@@ -56,7 +56,7 @@ export default function AboutPage() {
               <p className={styles.lead}>Greenatics conecta gestión de residuos, ingeniería, procesos biológicos, operación, productos agrícolas y datos para desarrollar soluciones que puedan implementarse, medirse y mejorar.</p>
               <div className={styles.actions}>
                 <Link className={`${styles.button} ${styles.primary}`} href="/soluciones">Ver soluciones</Link>
-                <Link className={`${styles.button} ${styles.ghost}`} href="/biblioteca">Ver recursos y experiencia</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/recursos">Ver recursos y experiencia</Link>
               </div>
             </div>
             {yarumal ? (

--- a/src/app/recursos/layout.tsx
+++ b/src/app/recursos/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { PublicShell } from "@/components/public-shell";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const social = publicSocialMetadata({
+  title: "Recursos | Greenatics",
+  description:
+    "Biblioteca técnica, proyectos documentados e impacto gobernado de Greenatics reunidos para aprender, comprobar experiencia y revisar resultados con contexto.",
+  path: "/recursos",
+});
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/recursos" },
+  ...social,
+};
+
+export default function ResourcesLayout({ children }: { children: React.ReactNode }) {
+  return <PublicShell ownsMain={false}>{children}</PublicShell>;
+}

--- a/src/app/recursos/page.tsx
+++ b/src/app/recursos/page.tsx
@@ -1,0 +1,170 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import styles from "../biblioteca/resources-v2.module.css";
+
+export const metadata: Metadata = {
+  title: "Recursos | Greenatics",
+  description:
+    "Biblioteca técnica, proyectos documentados e impacto gobernado de Greenatics reunidos en una entrada común para aprender, comprobar experiencia y revisar resultados con contexto.",
+  alternates: { canonical: "/recursos" },
+};
+
+const layers = [
+  {
+    number: "01",
+    kicker: "Aprender",
+    title: "Biblioteca técnica",
+    copy: "Guías, manuales, criterios, programas por cultivo y recursos que ayudan a entender una decisión antes de ejecutarla.",
+    href: "/biblioteca",
+    cta: "Abrir biblioteca",
+  },
+  {
+    number: "02",
+    kicker: "Ver experiencia",
+    title: "Proyectos / casos",
+    copy: "Trabajo documentado con periodo, alcance, evidencia y aprendizajes, sin presentar una fotografía histórica como prueba automática del estado actual.",
+    href: "/proyectos",
+    cta: "Ver proyectos",
+  },
+  {
+    number: "03",
+    kicker: "Ver resultados",
+    title: "Impacto",
+    copy: "Indicadores públicos únicamente cuando existe fuente, periodo, metodología y gobierno suficiente para sostener lo publicado.",
+    href: "/impacto",
+    cta: "Ver impacto",
+  },
+] as const;
+
+const decisionRoutes = [
+  {
+    number: "01",
+    kicker: "Necesito conocimiento técnico",
+    title: "Quiero una guía, un manual o un criterio para tomar una decisión.",
+    copy: "Empieza por la biblioteca y busca el recurso según cultivo, síntoma, producto, aplicación o tema técnico disponible.",
+    href: "/biblioteca",
+    cta: "Explorar biblioteca",
+  },
+  {
+    number: "02",
+    kicker: "Quiero comprobar experiencia",
+    title: "Necesito ver proyectos reales y entender qué se hizo.",
+    copy: "Los casos publicados separan contexto, evidencia, aprendizaje y estado para que la experiencia sea verificable y transferible.",
+    href: "/proyectos",
+    cta: "Revisar casos",
+  },
+  {
+    number: "03",
+    kicker: "Busco resultados",
+    title: "Quiero revisar indicadores sin perder la fuente ni el periodo.",
+    copy: "Impacto reúne únicamente cifras publicables bajo reglas explícitas de trazabilidad, contexto y aprobación.",
+    href: "/impacto",
+    cta: "Revisar impacto",
+  },
+  {
+    number: "04",
+    kicker: "Tengo un problema concreto",
+    title: "Necesito pasar del conocimiento a una ruta de intervención.",
+    copy: "Si ya existe una necesidad operativa, técnica o territorial, entra a Soluciones o lleva el contexto directamente al equipo Greenatics.",
+    href: "/soluciones",
+    cta: "Explorar soluciones",
+  },
+] as const;
+
+export default function ResourcesHubPage() {
+  return (
+    <div className={styles.page}>
+      <main>
+        <section className={styles.hero} aria-labelledby="resources-hub-title">
+          <div className={styles.heroAccent} aria-hidden="true" />
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <span className={styles.eyebrow}>Recursos Greenatics · conocimiento + evidencia</span>
+              <h1 id="resources-hub-title">Conocimiento, experiencia e impacto para decidir mejor.</h1>
+              <p className={styles.lead}>
+                Recursos organiza tres rutas distintas: aprender con la biblioteca, comprobar experiencia mediante proyectos documentados y revisar resultados únicamente cuando pueden sostenerse con fuente, periodo y metodología.
+              </p>
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.primary}`} href="/biblioteca">Abrir biblioteca</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/proyectos">Ver proyectos</Link>
+              </div>
+            </div>
+
+            <aside className={styles.heroLedger}>
+              <span>Una entrada · tres funciones</span>
+              <strong>Aprender, comprobar y revisar resultados.</strong>
+              <p>Cada capa responde una pregunta diferente y conserva su propio estándar de evidencia.</p>
+              <div className={styles.ledgerRows}>
+                <div className={styles.ledgerRow}><span>01</span><div><strong>Biblioteca</strong><small>guías · manuales · criterios</small></div></div>
+                <div className={styles.ledgerRow}><span>02</span><div><strong>Proyectos</strong><small>contexto · evidencia · aprendizajes</small></div></div>
+                <div className={styles.ledgerRow}><span>03</span><div><strong>Impacto</strong><small>fuente · periodo · metodología</small></div></div>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section className={styles.universes} aria-labelledby="resources-layers-title">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div>
+                <span className={styles.eyebrow}>Tres rutas</span>
+                <h2 id="resources-layers-title">No todo recurso cumple la misma función.</h2>
+              </div>
+              <p>Una guía orienta. Un caso documenta experiencia. Un indicador resume un resultado bajo reglas de publicación. Separarlos evita convertir información útil en una promesa ambigua.</p>
+            </div>
+
+            <div className={styles.universeGrid}>
+              {layers.map((item) => (
+                <article className={styles.universeCard} key={item.number}>
+                  <span>{item.number} · {item.kicker}</span>
+                  <h3>{item.title}</h3>
+                  <p>{item.copy}</p>
+                  <Link href={item.href}>{item.cta} →</Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.router} aria-labelledby="resources-router-title">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div>
+                <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Empieza por lo que necesitas encontrar</span>
+                <h2 id="resources-router-title">No necesitas conocer el nombre del documento.</h2>
+              </div>
+              <p>Elige si estás buscando conocimiento, experiencia, resultados o una ruta de intervención.</p>
+            </div>
+
+            <div className={styles.intentList}>
+              {decisionRoutes.map((route) => (
+                <Link className={styles.intentRow} href={route.href} key={route.number}>
+                  <span className={styles.intentNumber}>{route.number}</span>
+                  <small className={styles.intentKicker}>{route.kicker}</small>
+                  <div><h3>{route.title}</h3><p>{route.copy}</p></div>
+                  <strong>{route.cta} →</strong>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.closing}>
+          <div className={`${styles.container} ${styles.closingGrid}`}>
+            <div>
+              <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Recursos Greenatics</span>
+              <h2>El conocimiento sirve cuando ayuda a tomar la siguiente decisión.</h2>
+            </div>
+            <div>
+              <p>Consulta una guía, revisa un caso, valida un indicador o lleva un problema concreto al equipo si ya necesitas convertir información en una intervención.</p>
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.light}`} href="/contacto?source=recursos">Hablar con nosotros</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/soluciones">Explorar soluciones</Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/data/public-navigation.ts
+++ b/src/data/public-navigation.ts
@@ -15,7 +15,7 @@ export const publicPrimaryNav: readonly PublicPrimaryNavItem[] = [
   { href: "/soluciones", label: "Soluciones", menu: "solutions" },
   { href: "/wondergreen", label: "Wondergreen" },
   { href: "/casa-jardin", label: "Casa & Jardín" },
-  { href: "/biblioteca", label: "Recursos", menu: "resources" },
+  { href: "/recursos", label: "Recursos", menu: "resources" },
   { href: "/nosotros", label: "Nosotros" },
 ] as const;
 

--- a/src/data/public-site.ts
+++ b/src/data/public-site.ts
@@ -22,7 +22,7 @@ export const publicFooterNav = [
     title: "Explorar",
     links: [
       { href: "/soluciones", label: "Soluciones" },
-      { href: "/biblioteca", label: "Recursos" },
+      { href: "/recursos", label: "Recursos" },
       { href: "/proyectos", label: "Proyectos / casos" },
       { href: "/impacto", label: "Impacto" },
     ],
@@ -54,6 +54,7 @@ export const publicStaticRoutes = [
   "/wondergreen",
   "/wondergreen/productos",
   "/wondergreen/cultivos",
+  "/recursos",
   "/proyectos",
   "/impacto",
   "/biblioteca",


### PR DESCRIPTION
## Objetivo
Crear `/recursos` como entrada Greenatics de nivel superior para conocimiento y evidencia, separando claramente Biblioteca, Proyectos/Casos e Impacto sin retirar ni redirigir `/biblioteca`.

## Cambios
- Nueva ruta canónica `/recursos`.
- Hub con tres funciones: aprender, comprobar experiencia y revisar resultados.
- Navegación primaria y footer: la etiqueta `Recursos` ahora apunta a `/recursos`.
- El menú hijo conserva Biblioteca `/biblioteca`, Proyectos `/proyectos` e Impacto `/impacto`.
- `Nosotros` lleva sus enlaces generales de recursos al nuevo hub.
- `/recursos` entra a rutas públicas, sitemap y contratos SEO/social/accesibilidad.

## Compatibilidad
- `/biblioteca` permanece pública, indexable y con su canonical propio.
- No se crean redirects ni se retiran URLs existentes.
- Los enlaces específicos a guías/biblioteca siguen apuntando a `/biblioteca`.

## Truth locks
- No se añaden cifras ni claims nuevos.
- Proyectos siguen separando evidencia histórica de estado actual.
- Impacto sigue limitado a indicadores con fuente, periodo, metodología y gobierno.
- El hub no convierte documentos o casos en promesas universales.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile