### PR TITLE
feat(wondergreen): profundiza catálogo y fichas de producto V2.1

### DIFF
--- a/e2e/wondergreen-product-depth.spec.ts
+++ b/e2e/wondergreen-product-depth.spec.ts
@@ -17,7 +17,8 @@ test("Wondergreen product page exposes presentations and official PDF relationsh
 
   await expect(page.getByRole("heading", { name: /2Grow Sólido/ })).toBeVisible();
   await expect(page.getByRole("img", { name: "Identidad visual aprobada de la línea Wondergreen 2Grow" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Documentación oficial" })).toBeVisible();
+  await expect(page.getByText("Documentación oficial", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Abre los documentos aprobados, no una reconstrucción de ellos." })).toBeVisible();
   await expect(page.getByText("5 kg", { exact: true })).toBeVisible();
   await expect(page.getByText("40 kg", { exact: true })).toBeVisible();
 

--- a/e2e/wondergreen-product-depth.spec.ts
+++ b/e2e/wondergreen-product-depth.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+test("Wondergreen catalog starts with commercial products and keeps orientation secondary", async ({ page }) => {
+  await page.goto("/wondergreen/productos");
+
+  await expect(page.getByRole("heading", { name: "Productos concretos, formulación por formulación." })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Comerciales reconciliadas" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByRole("link", { name: /Encontrar mi programa/ })).toHaveAttribute("href", "/wondergreen/finder");
+
+  const growCard = page.getByRole("link", { name: /2Grow Sólido/ }).first();
+  await expect(growCard).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
+  await expect(growCard.getByRole("img", { name: "Identidad visual aprobada de la línea Wondergreen 2Grow" })).toBeVisible();
+});
+
+test("Wondergreen product page exposes presentations and official PDF relationships without inventing an individual technical sheet", async ({ page }) => {
+  await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
+
+  await expect(page.getByRole("heading", { name: /2Grow Sólido/ })).toBeVisible();
+  await expect(page.getByRole("img", { name: "Identidad visual aprobada de la línea Wondergreen 2Grow" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Documentación oficial" })).toBeVisible();
+  await expect(page.getByText("5 kg", { exact: true })).toBeVisible();
+  await expect(page.getByText("40 kg", { exact: true })).toBeVisible();
+
+  const hrefs = await page.locator("a").evaluateAll((links) => links.map((link) => link.getAttribute("href") ?? ""));
+  expect(hrefs).toContain("/api/public-resources/wondergreen-product-master");
+  expect(hrefs).toContain("/api/public-resources/wondergreen-guide-cafe");
+  expect(hrefs).toContain("/api/public-resources/wondergreen-guide-cacao");
+  expect(hrefs.join(" ")).not.toMatch(/sharepoint|graph\.microsoft/i);
+
+  await expect(page.getByRole("heading", { name: "Ficha técnica específica" })).toBeVisible();
+  await expect(page.getByText("Pendiente de vincular master público", { exact: true })).toBeVisible();
+});

--- a/e2e/wondergreen-products.spec.ts
+++ b/e2e/wondergreen-products.spec.ts
@@ -1,32 +1,37 @@
 import { test, expect } from "@playwright/test";
 
-test("Wondergreen product catalog exposes governed references", async ({ page }) => {
+test("Wondergreen product catalog exposes governed references with commercial products first", async ({ page }) => {
   await page.goto("/wondergreen/productos");
 
-  await expect(page.getByRole("heading", { name: /Un portafolio que muestra también/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Productos concretos, formulación por formulación." })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Comerciales reconciliadas" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByText("8 referencias", { exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: /2Grow Sólido/ }).first()).toBeVisible();
-  await expect(page.getByRole("link", { name: /Extracto de Neem/ }).first()).toBeVisible();
-  await expect(page.getByRole("link", { name: "Buscar por cultivo →" }).first()).toHaveAttribute("href", "/wondergreen/cultivos");
-  await expect(page.getByText("17 referencias", { exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Extracto de Neem/ })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: /Encontrar mi programa/ })).toHaveAttribute("href", "/wondergreen/finder");
 
   await expect(page.getByRole("link", { name: /2Grow Sólido/ }).first()).toHaveAttribute("data-tone", "grow");
   await expect(page.getByRole("link", { name: /2Balance Sólido/ }).first()).toHaveAttribute("data-tone", "balance");
   await expect(page.getByRole("link", { name: /2Bloom Sólido/ }).first()).toHaveAttribute("data-tone", "bloom");
   await expect(page.getByRole("link", { name: /2Fruit Sólido/ }).first()).toHaveAttribute("data-tone", "fruit");
+
+  await page.getByRole("button", { name: "Todo el portafolio" }).click();
+  await expect(page.getByText("17 referencias", { exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: /Extracto de Neem/ }).first()).toHaveAttribute("data-tone", "botanical");
 });
 
 test("catalog browser filters by search, commercial truth and format without changing Product Master", async ({ page }) => {
   await page.goto("/wondergreen/productos");
 
+  await page.getByRole("button", { name: "Todo el portafolio" }).click();
   const search = page.getByRole("searchbox", { name: "Buscar en el portafolio" });
   await search.fill("Neem");
   await expect(page.getByText("1 referencia", { exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: /Extracto de Neem/ }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: /2Grow Sólido/ })).toHaveCount(0);
 
-  await page.getByRole("button", { name: "Limpiar filtros" }).click();
-  await page.getByRole("button", { name: "Comerciales reconciliadas" }).click();
+  await page.getByRole("button", { name: "Volver a comerciales" }).click();
+  await expect(page.getByRole("button", { name: "Comerciales reconciliadas" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByRole("link", { name: /2Grow Sólido/ }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: /Extracto de Neem/ })).toHaveCount(0);
 
@@ -35,14 +40,15 @@ test("catalog browser filters by search, commercial truth and format without cha
   await expect(page.getByRole("link", { name: /2Grow Sólido/ })).toHaveCount(0);
 });
 
-test("commercial product page shows reconciled state without inventing a packshot", async ({ page }) => {
+test("commercial product page shows reconciled state and approved line artwork without inventing a packshot", async ({ page }) => {
   await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
 
   await expect(page.locator('div[data-tone="grow"]').first()).toBeVisible();
   await expect(page.getByRole("heading", { name: /2Grow Sólido/ })).toBeVisible();
   await expect(page.getByText("Referencia comercial reconciliada").first()).toBeVisible();
   await expect(page.getByText("Reconciliada", { exact: true })).toBeVisible();
-  await expect(page.getByText(/El packshot se publicará únicamente/)).toBeVisible();
+  await expect(page.getByRole("img", { name: "Identidad visual aprobada de la línea Wondergreen 2Grow" })).toBeVisible();
+  await expect(page.getByText(/No se presenta como packshot específico/)).toBeVisible();
   await expect(page.getByRole("link", { name: "Manual de uso Wondergreen" })).toHaveAttribute("href", "/biblioteca/manual-uso-wondergreen");
 });
 

--- a/src/app/wondergreen/productos/[slug]/page.tsx
+++ b/src/app/wondergreen/productos/[slug]/page.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import {
+  getWondergreenProductArtwork,
+  getWondergreenProductCrops,
+  getWondergreenProductDocuments,
+} from "@/data/wondergreen-product-assets";
 import { getWondergreenReference, wondergreenReferences } from "@/data/wondergreen-public";
-import { wondergreenCrops } from "@/data/wondergreen-crops";
 import { getWondergreenVisualTone } from "@/data/wondergreen-visual";
 import styles from "./product.module.css";
 
@@ -16,18 +21,13 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   if (!reference) return { title: "Producto | Wondergreen" };
   return {
     title: `${reference.name}${reference.formula ? ` ${reference.formula}` : ""} | Wondergreen`,
-    description: `${reference.role} Estado público: ${reference.publicStatus}.`,
+    description: `${reference.role} Consulta formulación, presentaciones, estado público y documentación Wondergreen vinculada.`,
     alternates: { canonical: `/wondergreen/productos/${reference.slug}` },
   };
 }
 
 function money(value: number) {
   return new Intl.NumberFormat("es-CO", { style: "currency", currency: "COP", maximumFractionDigits: 0 }).format(value);
-}
-
-function relatedCrops(family: string) {
-  const target = family.toLowerCase();
-  return wondergreenCrops.filter((crop) => crop.stages.some((stage) => stage.lines.some((line) => line.toLowerCase() === target)));
 }
 
 function formatLabel(format: string) {
@@ -46,7 +46,9 @@ export default async function WondergreenProductPage({ params }: { params: Promi
   const reference = getWondergreenReference(slug);
   if (!reference) notFound();
 
-  const crops = relatedCrops(reference.family);
+  const crops = getWondergreenProductCrops(reference);
+  const artwork = getWondergreenProductArtwork(reference);
+  const documents = getWondergreenProductDocuments(reference);
   const isCommercial = reference.truthStatus === "commercial-reconciled";
   const contactHref = `/contacto?producto=${encodeURIComponent(reference.slug)}#wondergreen`;
   const visualTone = getWondergreenVisualTone(reference);
@@ -57,40 +59,64 @@ export default async function WondergreenProductPage({ params }: { params: Promi
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div className={styles.heroCopy}>
-              <Link className={styles.back} href="/wondergreen#portafolio">← Volver al portafolio</Link>
+              <Link className={styles.back} href="/wondergreen/productos">← Volver a productos</Link>
               <span className={styles.eyebrow}>Wondergreen · {reference.family}</span>
               <h1>{reference.name}{reference.formula ? <em>{reference.formula}</em> : null}</h1>
               <p className={styles.lead}>{reference.role}</p>
               <div className={styles.heroMeta}>
                 <span>{formatLabel(reference.format)}</span>
                 <span>{reference.stage}</span>
+                <span>{reference.publicStatus}</span>
               </div>
               <div className={styles.actions}>
                 <Link className={`${styles.button} ${styles.primary}`} href={contactHref}>Consultar esta referencia</Link>
-                {crops.length > 0 ? <Link className={`${styles.button} ${styles.ghost}`} href={`/wondergreen/cultivos/${crops[0].slug}`}>Ver en cultivo</Link> : null}
+                {documents.catalog?.downloadHref ? (
+                  <a className={`${styles.button} ${styles.ghost}`} href={documents.catalog.downloadHref} target="_blank" rel="noreferrer">Ver catálogo PDF</a>
+                ) : null}
               </div>
             </div>
 
-            <aside className={styles.identityPlate} aria-label={`Identidad técnica de ${reference.name}`}>
-              <div className={styles.plateTop}>
-                <span>Product Master público</span>
-                <small>{reference.publicStatus}</small>
-              </div>
-              <div className={styles.familyMark}>{reference.family}</div>
-              {reference.formula ? <strong className={styles.formula}>{reference.formula}</strong> : <strong className={styles.formula}>{formatLabel(reference.format)}</strong>}
-              <p>Representación editorial. El packshot se publicará únicamente cuando exista maestro vigente vinculado a esta referencia.</p>
-            </aside>
+            {artwork ? (
+              <aside className={styles.visualPlate} aria-label={`Activo visual de ${reference.family}`}>
+                <Image
+                  className={styles.productArtwork}
+                  src={artwork.href}
+                  alt={artwork.alt}
+                  width={900}
+                  height={900}
+                  sizes="(max-width: 900px) 92vw, 520px"
+                  priority
+                  unoptimized
+                />
+                <div className={styles.visualCaption}>
+                  <strong>{artwork.label}</strong>
+                  <span>Activo aprobado de línea. No se presenta como packshot específico si ese master todavía no está vinculado.</span>
+                </div>
+              </aside>
+            ) : (
+              <aside className={styles.identityPlate} aria-label={`Identidad técnica de ${reference.name}`}>
+                <div className={styles.plateTop}>
+                  <span>Product Master público</span>
+                  <small>{reference.publicStatus}</small>
+                </div>
+                <div className={styles.familyMark}>{reference.family}</div>
+                {reference.formula ? <strong className={styles.formula}>{reference.formula}</strong> : <strong className={styles.formula}>{formatLabel(reference.format)}</strong>}
+                <p>La web mantiene una representación editorial hasta que exista un master visual específico aprobado para esta referencia.</p>
+              </aside>
+            )}
           </div>
         </section>
 
         <section className={`${styles.section} ${styles.white}`}>
           <div className={`${styles.container} ${styles.truthGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Estado de producto</span>
-              <h2>Qué sabemos hoy y qué todavía debe confirmarse.</h2>
+              <span className={styles.eyebrow}>Ficha de producto</span>
+              <h2>La referencia, su formulación y su condición comercial en un solo lugar.</h2>
             </div>
             <div className={styles.truthPanel}>
               <div className={styles.statusRow}><span>Estado público</span><strong>{reference.publicStatus}</strong></div>
+              <div className={styles.statusRow}><span>Familia</span><strong>{reference.family}</strong></div>
+              {reference.formula ? <div className={styles.statusRow}><span>Formulación declarada</span><strong>{reference.formula}</strong></div> : null}
               <div className={styles.statusRow}><span>Formato</span><strong>{formatLabel(reference.format)}</strong></div>
               <div className={styles.statusRow}><span>Momento / función</span><strong>{reference.stage}</strong></div>
               <div className={styles.statusRow}><span>Condición comercial</span><strong>{isCommercial ? "Reconciliada" : "Requiere confirmación"}</strong></div>
@@ -101,9 +127,9 @@ export default async function WondergreenProductPage({ params }: { params: Promi
         <section className={styles.section}>
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
-              <span className={styles.eyebrow}>Presentaciones y condición comercial</span>
-              <h2>Información visible sin fingir disponibilidad.</h2>
-              <p>Una presentación documentada no equivale automáticamente a inventario. El equipo confirma existencia, versión, despacho y recomendación antes de cerrar la venta.</p>
+              <span className={styles.eyebrow}>Presentaciones</span>
+              <h2>Tamaños documentados, separados de inventario y disponibilidad.</h2>
+              <p>La existencia de una presentación en Product Truth no equivale automáticamente a inventario disponible. La cotización confirma versión, despacho y condición comercial.</p>
             </div>
             <div className={styles.commercialGrid}>
               <article className={styles.infoCard}>
@@ -118,15 +144,45 @@ export default async function WondergreenProductPage({ params }: { params: Promi
           </div>
         </section>
 
+        <section className={`${styles.section} ${styles.white}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHeading}>
+              <span className={styles.eyebrow}>Documentación oficial</span>
+              <h2>Abre los documentos aprobados, no una reconstrucción de ellos.</h2>
+              <p>La página web organiza la referencia y sus relaciones. Los PDF publicados conservan el diseño y contenido del master editorial aprobado.</p>
+            </div>
+            <div className={styles.documentGrid}>
+              {documents.catalog?.downloadHref ? (
+                <article className={styles.documentCard}>
+                  {documents.catalog.coverImage ? <Image src={documents.catalog.coverImage} alt={`Portada de ${documents.catalog.title}`} width={520} height={735} unoptimized /> : null}
+                  <div><span>{documents.catalog.statusLabel}</span><h3>{documents.catalog.title}</h3><p>{documents.catalog.masterLabel}</p><a href={documents.catalog.downloadHref} target="_blank" rel="noreferrer">Abrir catálogo PDF →</a></div>
+                </article>
+              ) : null}
+
+              {documents.guides.map((guide) => (
+                <article className={styles.documentCard} key={guide.id}>
+                  {guide.coverImage ? <Image src={guide.coverImage} alt={`Portada de ${guide.title}`} width={520} height={735} unoptimized /> : null}
+                  <div><span>{guide.statusLabel}</span><h3>{guide.title}</h3><p>{guide.masterLabel}</p><div className={styles.documentActions}><Link href={guide.href}>Ver programa web</Link>{guide.downloadHref ? <a href={guide.downloadHref} target="_blank" rel="noreferrer">Abrir PDF →</a> : null}</div></div>
+                </article>
+              ))}
+
+              <article className={`${styles.documentCard} ${styles.pendingDocument}`}>
+                <div><span>Master individual</span><h3>{documents.technicalSheet.label}</h3><p>{documents.technicalSheet.note}</p><strong>Pendiente de vincular master público</strong></div>
+              </article>
+            </div>
+          </div>
+        </section>
+
         <section className={`${styles.section} ${styles.dark}`}>
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
-              <span className={styles.eyebrow}>Product Truth</span>
-              <h2>Lo que esta página deliberadamente no promete.</h2>
+              <span className={styles.eyebrow}>Condiciones y cautelas</span>
+              <h2>La ficha pública no convierte el producto en una receta universal.</h2>
+              <p>Dosis, frecuencia, compatibilidad, vía y eficacia solo se publican cuando la documentación vigente y el contexto agronómico las soportan.</p>
             </div>
             <div className={styles.notesGrid}>
               {reference.notes.map((note, index) => <article key={note}><span>{String(index + 1).padStart(2, "0")}</span><p>{note}</p></article>)}
-              <article><span>{String(reference.notes.length + 1).padStart(2, "0")}</span><p>Dosis, frecuencia, compatibilidad y eficacia se cierran únicamente con la versión técnica vigente y el contexto real del lote.</p></article>
+              <article><span>{String(reference.notes.length + 1).padStart(2, "0")}</span><p>La recomendación final debe cruzar cultivo, etapa, suelo, agua, manejo y documentación técnica vigente.</p></article>
             </div>
           </div>
         </section>
@@ -137,7 +193,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
               <div className={styles.sectionHeading}>
                 <span className={styles.eyebrow}>Cultivos relacionados</span>
                 <h2>Esta familia aparece dentro de programas por etapa.</h2>
-                <p>La relación indica pertinencia potencial dentro de una ruta agronómica; no una receta automática.</p>
+                <p>Cada programa abre también su guía PDF editorial cuando existe un master público aprobado.</p>
               </div>
               <div className={styles.cropGrid}>
                 {crops.map((crop) => <Link key={crop.slug} href={`/wondergreen/cultivos/${crop.slug}`}><span>Programa</span><h3>{crop.name}</h3><p>{crop.headline}</p><strong>Explorar cultivo →</strong></Link>)}
@@ -148,19 +204,19 @@ export default async function WondergreenProductPage({ params }: { params: Promi
 
         <section className={styles.resources}>
           <div className={`${styles.container} ${styles.resourceGrid}`}>
-            <div><span className={styles.eyebrow}>Usar mejor el producto</span><h2>Producto + contexto + aplicación + seguimiento.</h2></div>
+            <div><span className={styles.eyebrow}>Conocimiento relacionado</span><h2>Producto, criterio técnico y seguimiento.</h2></div>
             <div className={styles.resourceLinks}>
-              <Link href="/biblioteca/manual-uso-wondergreen"><strong>Manual de uso Wondergreen</strong><span>Preparar, aplicar, registrar y revisar →</span></Link>
-              <Link href="/biblioteca/criterios-nutricionales"><strong>Criterios de revisión nutricional</strong><span>Qué comprobar antes de recomendar →</span></Link>
-              <Link href="/biblioteca/guia-deficiencias"><strong>Guía de deficiencias</strong><span>Leer síntomas y confundidores →</span></Link>
+              {documents.webResources.map((resource) => (
+                <Link href={resource.href} key={resource.id}><strong>{resource.title}</strong><span>{resource.cta} →</span></Link>
+              ))}
             </div>
           </div>
         </section>
 
         <section className={styles.closing}>
           <div className={`${styles.container} ${styles.closingInner}`}>
-            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>¿Quieres validar esta referencia para tu cultivo o negocio?</h2></div>
-            <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href={contactHref}>Hablar con Greenatics</Link><Link className={`${styles.button} ${styles.ghost}`} href="/wondergreen">Ver Wondergreen</Link></div>
+            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>¿Quieres confirmar esta referencia para tu cultivo o negocio?</h2></div>
+            <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href={contactHref}>Hablar con Greenatics</Link><Link className={`${styles.button} ${styles.ghost}`} href="/wondergreen/productos">Ver todos los productos</Link></div>
           </div>
         </section>
       </main>

--- a/src/app/wondergreen/productos/[slug]/page.tsx
+++ b/src/app/wondergreen/productos/[slug]/page.tsx
@@ -10,6 +10,7 @@ import {
 import { getWondergreenReference, wondergreenReferences } from "@/data/wondergreen-public";
 import { getWondergreenVisualTone } from "@/data/wondergreen-visual";
 import styles from "./product.module.css";
+import depth from "./product-depth.module.css";
 
 export function generateStaticParams() {
   return wondergreenReferences.map((reference) => ({ slug: reference.slug }));
@@ -77,9 +78,9 @@ export default async function WondergreenProductPage({ params }: { params: Promi
             </div>
 
             {artwork ? (
-              <aside className={styles.visualPlate} aria-label={`Activo visual de ${reference.family}`}>
+              <aside className={depth.visualPlate} aria-label={`Activo visual de ${reference.family}`}>
                 <Image
-                  className={styles.productArtwork}
+                  className={depth.productArtwork}
                   src={artwork.href}
                   alt={artwork.alt}
                   width={900}
@@ -88,7 +89,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
                   priority
                   unoptimized
                 />
-                <div className={styles.visualCaption}>
+                <div className={depth.visualCaption}>
                   <strong>{artwork.label}</strong>
                   <span>Activo aprobado de línea. No se presenta como packshot específico si ese master todavía no está vinculado.</span>
                 </div>
@@ -151,22 +152,22 @@ export default async function WondergreenProductPage({ params }: { params: Promi
               <h2>Abre los documentos aprobados, no una reconstrucción de ellos.</h2>
               <p>La página web organiza la referencia y sus relaciones. Los PDF publicados conservan el diseño y contenido del master editorial aprobado.</p>
             </div>
-            <div className={styles.documentGrid}>
+            <div className={depth.documentGrid}>
               {documents.catalog?.downloadHref ? (
-                <article className={styles.documentCard}>
+                <article className={depth.documentCard}>
                   {documents.catalog.coverImage ? <Image src={documents.catalog.coverImage} alt={`Portada de ${documents.catalog.title}`} width={520} height={735} unoptimized /> : null}
                   <div><span>{documents.catalog.statusLabel}</span><h3>{documents.catalog.title}</h3><p>{documents.catalog.masterLabel}</p><a href={documents.catalog.downloadHref} target="_blank" rel="noreferrer">Abrir catálogo PDF →</a></div>
                 </article>
               ) : null}
 
               {documents.guides.map((guide) => (
-                <article className={styles.documentCard} key={guide.id}>
+                <article className={depth.documentCard} key={guide.id}>
                   {guide.coverImage ? <Image src={guide.coverImage} alt={`Portada de ${guide.title}`} width={520} height={735} unoptimized /> : null}
-                  <div><span>{guide.statusLabel}</span><h3>{guide.title}</h3><p>{guide.masterLabel}</p><div className={styles.documentActions}><Link href={guide.href}>Ver programa web</Link>{guide.downloadHref ? <a href={guide.downloadHref} target="_blank" rel="noreferrer">Abrir PDF →</a> : null}</div></div>
+                  <div><span>{guide.statusLabel}</span><h3>{guide.title}</h3><p>{guide.masterLabel}</p><div className={depth.documentActions}><Link href={guide.href}>Ver programa web</Link>{guide.downloadHref ? <a href={guide.downloadHref} target="_blank" rel="noreferrer">Abrir PDF →</a> : null}</div></div>
                 </article>
               ))}
 
-              <article className={`${styles.documentCard} ${styles.pendingDocument}`}>
+              <article className={`${depth.documentCard} ${depth.pendingDocument}`}>
                 <div><span>Master individual</span><h3>{documents.technicalSheet.label}</h3><p>{documents.technicalSheet.note}</p><strong>Pendiente de vincular master público</strong></div>
               </article>
             </div>

--- a/src/app/wondergreen/productos/[slug]/product-depth.module.css
+++ b/src/app/wondergreen/productos/[slug]/product-depth.module.css
@@ -1,0 +1,172 @@
+.visualPlate {
+  min-height: 470px;
+  background: #fff;
+  border-top: 6px solid var(--product-accent);
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  overflow: hidden;
+}
+
+.productArtwork {
+  width: 100%;
+  height: 100%;
+  min-height: 350px;
+  object-fit: cover;
+  object-position: center;
+  background: var(--product-wash);
+}
+
+.visualCaption {
+  padding: 18px 20px 20px;
+  display: grid;
+  gap: 6px;
+  border-top: 1px solid var(--line);
+}
+
+.visualCaption strong {
+  color: var(--product-accent);
+  font-size: .75rem;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+}
+
+.visualCaption span {
+  color: var(--muted);
+  font-size: .8rem;
+  line-height: 1.5;
+}
+
+.documentGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.documentCard {
+  min-height: 420px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  display: grid;
+  grid-template-columns: minmax(116px, .62fr) 1fr;
+  align-items: stretch;
+  overflow: hidden;
+}
+
+.documentCard > img {
+  width: 100%;
+  height: 100%;
+  min-height: 420px;
+  object-fit: cover;
+  object-position: top center;
+  border-right: 1px solid var(--line);
+}
+
+.documentCard > div {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.documentCard > div > span {
+  color: var(--product-accent);
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  font-size: .66rem;
+  font-weight: 850;
+  margin-bottom: 24px;
+}
+
+.documentCard h3 {
+  font-size: clamp(1.55rem, 2.2vw, 2.15rem);
+  line-height: 1.03;
+}
+
+.documentCard p {
+  color: var(--muted);
+  line-height: 1.55;
+  font-size: .86rem;
+}
+
+.documentCard a,
+.documentCard strong {
+  margin-top: auto;
+  color: var(--product-accent);
+  font-size: .82rem;
+  font-weight: 850;
+}
+
+.documentActions {
+  margin-top: auto;
+  padding: 0 !important;
+  display: grid !important;
+  gap: 9px;
+}
+
+.documentActions a {
+  margin-top: 0;
+}
+
+.pendingDocument {
+  grid-template-columns: 1fr;
+  background: linear-gradient(145deg, var(--product-wash), #fff);
+  border-style: dashed;
+}
+
+.pendingDocument > div {
+  min-height: 100%;
+}
+
+@media (max-width: 1120px) {
+  .documentGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .visualPlate {
+    min-height: 390px;
+  }
+}
+
+@media (max-width: 720px) {
+  .documentGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .documentCard {
+    min-height: 0;
+    grid-template-columns: 118px 1fr;
+  }
+
+  .documentCard > img {
+    min-height: 340px;
+  }
+}
+
+@media (max-width: 520px) {
+  .visualPlate {
+    min-height: 340px;
+  }
+
+  .productArtwork {
+    min-height: 280px;
+  }
+
+  .documentCard {
+    grid-template-columns: 1fr;
+  }
+
+  .documentCard > img {
+    height: auto;
+    min-height: 0;
+    max-height: 420px;
+    object-fit: contain;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+    background: #fff;
+  }
+}

--- a/src/app/wondergreen/productos/catalog-depth.module.css
+++ b/src/app/wondergreen/productos/catalog-depth.module.css
@@ -1,0 +1,42 @@
+.commercialNote {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 20px;
+  padding: 8px 10px;
+  border: 1px solid rgba(6, 61, 44, .15);
+  background: rgba(255,255,255,.58);
+  color: #52675c;
+  font-size: .76rem;
+  font-weight: 750;
+}
+
+.cardArtwork {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  object-position: center;
+  margin: 18px 0 4px;
+  border: 1px solid rgba(6, 61, 44, .12);
+  background: rgba(255,255,255,.72);
+}
+
+.cardIdentityWithArtwork {
+  margin-top: 18px !important;
+}
+
+.cardAssetLabel {
+  display: inline-block;
+  margin-top: 6px;
+  color: var(--product-accent);
+  font-size: .63rem;
+  font-weight: 850;
+  text-transform: uppercase;
+  letter-spacing: .07em;
+}
+
+@media (max-width: 640px) {
+  .cardArtwork {
+    max-height: 260px;
+  }
+}

--- a/src/app/wondergreen/productos/page.tsx
+++ b/src/app/wondergreen/productos/page.tsx
@@ -4,8 +4,8 @@ import { ProductCatalogBrowser } from "./product-catalog-browser";
 import styles from "./catalog.module.css";
 
 export const metadata: Metadata = {
-  title: "Productos Wondergreen | Portafolio técnico",
-  description: "Explora fertilizantes sólidos y líquidos, compost y bioinsumos Wondergreen con estado técnico y comercial visible.",
+  title: "Productos Wondergreen | Portafolio técnico y comercial",
+  description: "Explora fertilizantes sólidos y líquidos Wondergreen por línea, formulación, presentación, estado comercial y documentación pública vinculada.",
   alternates: { canonical: "/wondergreen/productos" },
 };
 
@@ -16,14 +16,14 @@ export default function WondergreenProductsPage() {
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Wondergreen · Product Master público</span>
-              <h1>Un portafolio que muestra también lo que todavía debe confirmarse.</h1>
-              <p className={styles.lead}>Cada referencia tiene una ficha propia con función, formato, etapa, presentaciones, condición comercial y cautelas. El catálogo separa producto documentado de disponibilidad real.</p>
+              <span className={styles.eyebrow}>Wondergreen · Productos</span>
+              <h1>Productos concretos, formulación por formulación.</h1>
+              <p className={styles.lead}>Empieza por las referencias comercialmente reconciliadas y abre cada producto para revisar formulación, presentaciones, condición comercial, cultivos relacionados y documentos oficiales. Las referencias técnicas o en desarrollo permanecen separadas y explícitamente identificadas.</p>
             </div>
             <aside className={styles.router}>
-              <strong>¿No sabes por cuál empezar?</strong>
-              <p>Entra por cultivo y etapa. La selección final se ajusta al lote, análisis, agua, manejo y documentación vigente.</p>
-              <Link href="/wondergreen/cultivos">Buscar por cultivo →</Link>
+              <strong>¿No sabes qué producto revisar?</strong>
+              <p>Los productos son la oferta. El Finder y los programas por cultivo sirven para orientarte cuando todavía no sabes cuál corresponde a tu contexto.</p>
+              <Link href="/wondergreen/finder">Encontrar mi programa →</Link>
             </aside>
           </div>
         </section>
@@ -32,18 +32,18 @@ export default function WondergreenProductsPage() {
 
         <section className={styles.knowledge}>
           <div className={`${styles.container} ${styles.knowledgeGrid}`}>
-            <div><span className={styles.eyebrow}>Producto + conocimiento</span><h2>La ficha no termina en la fórmula.</h2><p>Wondergreen conecta producto con diagnóstico, cultivo, aplicación y seguimiento.</p></div>
+            <div><span className={styles.eyebrow}>Producto + documentación</span><h2>Profundiza hasta el documento oficial.</h2><p>La web explica y conecta. Los PDF aprobados conservan su diseño, contenido y condición de master público.</p></div>
             <div className={styles.knowledgeLinks}>
-              <Link href="/biblioteca/manual-uso-wondergreen">Manual de uso <span>→</span></Link>
-              <Link href="/biblioteca/criterios-nutricionales">Criterios nutricionales <span>→</span></Link>
-              <Link href="/biblioteca/guia-deficiencias">Deficiencias nutricionales <span>→</span></Link>
-              <Link href="/wondergreen/cultivos">Programas por cultivo <span>→</span></Link>
+              <Link href="/biblioteca"><strong>Biblioteca técnica</strong><span>→</span></Link>
+              <Link href="/biblioteca/manual-uso-wondergreen"><strong>Manual de uso Wondergreen</strong><span>→</span></Link>
+              <Link href="/biblioteca/criterios-nutricionales"><strong>Criterios nutricionales</strong><span>→</span></Link>
+              <Link href="/wondergreen/cultivos"><strong>Programas y guías por cultivo</strong><span>→</span></Link>
             </div>
           </div>
         </section>
 
         <section className={styles.closing}>
-          <div className={`${styles.container} ${styles.closingInner}`}><div><span className={styles.eyebrow}>Wondergreen</span><h2>¿Necesitas confirmar una referencia, presentación o disponibilidad?</h2></div><Link className={styles.button} href="/contacto">Consultar con Greenatics</Link></div>
+          <div className={`${styles.container} ${styles.closingInner}`}><div><span className={styles.eyebrow}>Wondergreen</span><h2>¿Quieres confirmar una referencia, presentación o condición comercial?</h2></div><Link className={styles.button} href="/contacto?necesidad=producto-wondergreen#wondergreen">Hablar con Greenatics</Link></div>
         </section>
       </main>
     </div>

--- a/src/app/wondergreen/productos/product-catalog-browser.tsx
+++ b/src/app/wondergreen/productos/product-catalog-browser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import {
   bioinputReferences,
@@ -11,8 +12,10 @@ import {
   type WondergreenReference,
   type WondergreenTruthStatus,
 } from "@/data/wondergreen-public";
+import { getWondergreenProductArtwork } from "@/data/wondergreen-product-assets";
 import { getWondergreenVisualTone } from "@/data/wondergreen-visual";
 import styles from "./catalog.module.css";
+import depth from "./catalog-depth.module.css";
 
 type StatusFilter = "all" | WondergreenTruthStatus;
 type FormatFilter = "all" | "solid" | "liquid" | "compost" | "bioinput";
@@ -25,8 +28,8 @@ const groups = [
 ] as const;
 
 const statusOptions: { value: StatusFilter; label: string }[] = [
-  { value: "all", label: "Todos los estados" },
   { value: "commercial-reconciled", label: "Comerciales reconciliadas" },
+  { value: "all", label: "Todo el portafolio" },
   { value: "technical-portfolio", label: "Portafolio técnico" },
   { value: "development", label: "Desarrollo" },
 ];
@@ -62,7 +65,7 @@ function searchableText(reference: WondergreenReference) {
 
 export function ProductCatalogBrowser() {
   const [query, setQuery] = useState("");
-  const [status, setStatus] = useState<StatusFilter>("all");
+  const [status, setStatus] = useState<StatusFilter>("commercial-reconciled");
   const [format, setFormat] = useState<FormatFilter>("all");
 
   const filtered = useMemo(() => {
@@ -81,7 +84,7 @@ export function ProductCatalogBrowser() {
 
   const clearFilters = () => {
     setQuery("");
-    setStatus("all");
+    setStatus("commercial-reconciled");
     setFormat("all");
   };
 
@@ -91,10 +94,11 @@ export function ProductCatalogBrowser() {
         <div className={styles.container}>
           <div className={styles.browserHeading}>
             <div>
-              <span className={styles.eyebrow}>Explorar el Product Master</span>
-              <h2>Encuentra una referencia sin perder su estado técnico.</h2>
+              <span className={styles.eyebrow}>Portafolio Wondergreen</span>
+              <h2>Empieza por los productos comercialmente reconciliados.</h2>
+              <span className={depth.commercialNote}>Después puedes abrir el portafolio técnico y las referencias en desarrollo sin mezclarlas con disponibilidad comercial.</span>
             </div>
-            <p>Busca por nombre, familia, fórmula, etapa o función y filtra únicamente con atributos ya gobernados en Product Truth.</p>
+            <p>Busca por nombre, familia, formulación, etapa o función. Cada referencia abre una página propia con presentaciones, documentación pública vinculada y condición comercial.</p>
           </div>
 
           <div className={styles.browserControls}>
@@ -144,7 +148,7 @@ export function ProductCatalogBrowser() {
           <div className={styles.resultBar} aria-live="polite">
             <strong>{filtered.length} {filtered.length === 1 ? "referencia" : "referencias"}</strong>
             <span>de {wondergreenReferences.length} en el Product Master público</span>
-            {(query || status !== "all" || format !== "all") ? <button type="button" onClick={clearFilters}>Limpiar filtros</button> : null}
+            {(query || status !== "commercial-reconciled" || format !== "all") ? <button type="button" onClick={clearFilters}>Volver a comerciales</button> : null}
           </div>
         </div>
       </section>
@@ -159,13 +163,20 @@ export function ProductCatalogBrowser() {
             <div className={styles.productGrid}>
               {group.items.map((item) => {
                 const tone = getWondergreenVisualTone(item);
+                const artwork = getWondergreenProductArtwork(item);
                 return (
                   <Link className={styles.productCard} data-tone={tone} href={`/wondergreen/productos/${item.slug}`} key={item.slug}>
                     <div className={styles.cardTop}><span>{item.publicStatus}</span><small>{item.format}</small></div>
-                    <div className={styles.identity}><strong>{item.family}</strong>{item.formula ? <em>{item.formula}</em> : null}</div>
+                    {artwork ? (
+                      <>
+                        <Image className={depth.cardArtwork} src={artwork.href} alt={artwork.alt} width={720} height={450} sizes="(max-width: 640px) 92vw, (max-width: 900px) 45vw, 30vw" unoptimized />
+                        <span className={depth.cardAssetLabel}>{artwork.label}</span>
+                      </>
+                    ) : null}
+                    <div className={`${styles.identity} ${artwork ? depth.cardIdentityWithArtwork : ""}`}><strong>{item.family}</strong>{item.formula ? <em>{item.formula}</em> : null}</div>
                     <h3>{item.name}</h3>
                     <p>{item.role}</p>
-                    <div className={styles.cardBottom}><span>{item.stage}</span><strong>Ver ficha →</strong></div>
+                    <div className={styles.cardBottom}><span>{item.stage}</span><strong>Ver producto →</strong></div>
                   </Link>
                 );
               })}
@@ -179,9 +190,9 @@ export function ProductCatalogBrowser() {
           <div className={styles.container}>
             <span className={styles.eyebrow}>Sin coincidencias</span>
             <h2>No encontramos una referencia con esos filtros.</h2>
-            <p>Esto no significa que debas escoger otro producto automáticamente. Limpia los filtros o entra por cultivo para revisar el contexto agronómico.</p>
+            <p>Esto no significa que debas escoger otro producto automáticamente. Vuelve al portafolio comercial o entra por cultivo para revisar el contexto agronómico.</p>
             <div className={styles.emptyActions}>
-              <button type="button" onClick={clearFilters}>Ver todo el portafolio</button>
+              <button type="button" onClick={clearFilters}>Ver referencias comerciales</button>
               <Link href="/wondergreen/cultivos">Buscar por cultivo →</Link>
             </div>
           </div>

--- a/src/data/wondergreen-product-assets.test.ts
+++ b/src/data/wondergreen-product-assets.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { publicResources } from "./public-resources";
+import {
+  getWondergreenProductArtwork,
+  getWondergreenProductDocuments,
+  wondergreenProductAssetRegistry,
+} from "./wondergreen-product-assets";
+import { wondergreenReferences } from "./wondergreen-public";
+
+const governedFamilies = ["2Grow", "2Balance", "2Bloom", "2Fruit"] as const;
+
+describe("Wondergreen product asset registry", () => {
+  it("binds approved line artwork only to governed product families", () => {
+    for (const family of governedFamilies) {
+      const reference = wondergreenReferences.find((item) => item.family === family);
+      expect(reference, `missing reference for ${family}`).toBeTruthy();
+      const artwork = getWondergreenProductArtwork(reference!);
+      expect(artwork?.href).toMatch(/^\/api\/public-media\/wondergreen-/);
+      expect(artwork?.scope).toBe("approved-line-artwork");
+    }
+
+    const compost = wondergreenReferences.find((item) => item.family === "Compost");
+    expect(compost).toBeTruthy();
+    expect(getWondergreenProductArtwork(compost!)).toBeNull();
+  });
+
+  it("links only existing public resources into product documentation", () => {
+    const ids = new Set(publicResources.map((resource) => resource.id));
+    expect(ids.has("wondergreen-product-master")).toBe(true);
+
+    for (const reference of wondergreenReferences) {
+      const docs = getWondergreenProductDocuments(reference);
+      expect(docs.catalog?.id).toBe("wondergreen-product-master");
+      expect(docs.technicalSheet.status).toBe("public-master-pending");
+      for (const resource of [...docs.guides, ...docs.webResources]) {
+        expect(ids.has(resource.id), `${reference.slug} points to unknown ${resource.id}`).toBe(true);
+      }
+    }
+  });
+
+  it("keeps crop guides tied to same-origin public downloads", () => {
+    for (const resourceId of Object.values(wondergreenProductAssetRegistry.guideResourceByCropSlug)) {
+      const resource = publicResources.find((item) => item.id === resourceId);
+      expect(resource?.delivery).toBe("public-download");
+      expect(resource?.downloadHref).toMatch(/^\/api\/public-resources\//);
+    }
+  });
+});

--- a/src/data/wondergreen-product-assets.ts
+++ b/src/data/wondergreen-product-assets.ts
@@ -1,0 +1,111 @@
+import { publicResources, type PublicResource } from "./public-resources";
+import { wondergreenCrops, type WondergreenCrop } from "./wondergreen-crops";
+import type { WondergreenReference } from "./wondergreen-public";
+
+export type WondergreenArtwork = Readonly<{
+  mediaId: string;
+  href: string;
+  alt: string;
+  label: string;
+  scope: "approved-line-artwork";
+}>;
+
+export type WondergreenProductDocumentSet = Readonly<{
+  catalog: PublicResource | null;
+  guides: PublicResource[];
+  webResources: PublicResource[];
+  technicalSheet: Readonly<{
+    status: "public-master-pending";
+    label: string;
+    note: string;
+  }>;
+}>;
+
+const publicMedia = (assetId: string) => `/api/public-media/${assetId}`;
+
+const artworkByFamily = {
+  "2Grow": {
+    mediaId: "wondergreen-2grow",
+    href: publicMedia("wondergreen-2grow"),
+    alt: "Identidad visual aprobada de la línea Wondergreen 2Grow",
+    label: "Arte aprobado de línea 2Grow",
+    scope: "approved-line-artwork",
+  },
+  "2Balance": {
+    mediaId: "wondergreen-2balance",
+    href: publicMedia("wondergreen-2balance"),
+    alt: "Identidad visual aprobada de la línea Wondergreen 2Balance",
+    label: "Arte aprobado de línea 2Balance",
+    scope: "approved-line-artwork",
+  },
+  "2Bloom": {
+    mediaId: "wondergreen-2bloom",
+    href: publicMedia("wondergreen-2bloom"),
+    alt: "Identidad visual aprobada de la línea Wondergreen 2Bloom",
+    label: "Arte aprobado de línea 2Bloom",
+    scope: "approved-line-artwork",
+  },
+  "2Fruit": {
+    mediaId: "wondergreen-2fruit",
+    href: publicMedia("wondergreen-2fruit"),
+    alt: "Identidad visual aprobada de la línea Wondergreen 2Fruit",
+    label: "Arte aprobado de línea 2Fruit",
+    scope: "approved-line-artwork",
+  },
+} as const satisfies Record<string, WondergreenArtwork>;
+
+const guideResourceByCropSlug: Record<string, string> = {
+  cafe: "wondergreen-guide-cafe",
+  cacao: "wondergreen-guide-cacao",
+  aguacate: "wondergreen-guide-aguacate",
+  "limon-tahiti": "wondergreen-guide-limon-tahiti",
+  "pastos-gramineas": "wondergreen-guide-pastos",
+};
+
+const webResourceIds = [
+  "wondergreen-use-manual",
+  "nutritional-review-criteria",
+  "nutritional-deficiencies",
+] as const;
+
+function resourceById(resourceId: string) {
+  return publicResources.find((resource) => resource.id === resourceId) ?? null;
+}
+
+export function getWondergreenProductArtwork(reference: Pick<WondergreenReference, "family">): WondergreenArtwork | null {
+  return artworkByFamily[reference.family as keyof typeof artworkByFamily] ?? null;
+}
+
+export function getWondergreenProductCrops(reference: Pick<WondergreenReference, "family">): WondergreenCrop[] {
+  const family = reference.family.toLowerCase();
+  return wondergreenCrops.filter((crop) => crop.stages.some((stage) => stage.lines.some((line) => line.toLowerCase() === family)));
+}
+
+export function getWondergreenProductDocuments(reference: Pick<WondergreenReference, "family">): WondergreenProductDocumentSet {
+  const cropGuides = getWondergreenProductCrops(reference)
+    .map((crop) => guideResourceByCropSlug[crop.slug])
+    .filter((resourceId): resourceId is string => Boolean(resourceId))
+    .map(resourceById)
+    .filter((resource): resource is PublicResource => Boolean(resource && resource.delivery === "public-download"));
+
+  const webResources = webResourceIds
+    .map(resourceById)
+    .filter((resource): resource is PublicResource => Boolean(resource));
+
+  return {
+    catalog: resourceById("wondergreen-product-master"),
+    guides: cropGuides,
+    webResources,
+    technicalSheet: {
+      status: "public-master-pending",
+      label: "Ficha técnica específica",
+      note: "No existe todavía un master público individual vinculado a esta referencia. La web no inventa ni reconstruye una ficha técnica a partir de extractos.",
+    },
+  };
+}
+
+export const wondergreenProductAssetRegistry = Object.freeze({
+  artworkByFamily,
+  guideResourceByCropSlug,
+  webResourceIds,
+});


### PR DESCRIPTION
## Objetivo
Aplicar la nueva jerarquía comercial acordada: producto primero, orientación después. Wondergreen deja de quedarse en narrativa general y baja hasta referencia, formulación, presentaciones, activos aprobados y documentación oficial.

## Cambios
- Catálogo `/wondergreen/productos` inicia por referencias comercialmente reconciliadas.
- Finder/programas quedan como ruta auxiliar para quien no sabe qué producto revisar.
- Nuevo registro gobernado de activos Wondergreen por familia.
- Las líneas 2Grow, 2Balance, 2Bloom y 2Fruit consumen activos visuales públicos aprobados sin sintetizar packshots inexistentes.
- La ficha individual conecta formulación, formato, etapa, presentaciones y condición comercial.
- Nueva sección de documentación oficial: catálogo PDF y guías PDF por cultivo relacionadas, servidas same-origin.
- La ficha técnica individual se marca explícitamente como master público pendiente cuando no existe un archivo gobernado; no se reconstruye desde extractos.
- Relaciones producto ↔ cultivo ↔ documento derivadas desde Product Truth existente.

## Truth / Brand locks
- No se inventan SKUs, dosis, frecuencias, compatibilidades ni eficacia.
- No se afirma que un arte de línea sea packshot específico.
- No se exponen URLs privadas de SharePoint/Graph.
- PDF aprobado = documento oficial; la web contextualiza y relaciona.

## Tests
- Unit contract del registro de activos/documentos.
- Playwright para catálogo commercial-first y profundidad de 2Grow sólido.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile