### PR TITLE
feat(wondergreen): rebalancea hub con productos primero V2.2

### DIFF
--- a/e2e/public-web.spec.ts
+++ b/e2e/public-web.spec.ts
@@ -21,11 +21,12 @@ test("public home presents Greenatics and exposes the digital bridge", async ({ 
   await expect(page.getByRole("heading", { name: "La operación también necesita una capa digital." })).toBeVisible();
 });
 
-test("Wondergreen exposes fertilizers, bioinputs and governed technology narrative", async ({ page }) => {
+test("Wondergreen exposes commercial products, full portfolio and governed technology narrative", async ({ page }) => {
   await page.goto("/wondergreen");
 
   await expect(page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Dos grandes líneas dentro de una misma marca." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Empieza por los productos que ya puedes revisar." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Fertilizantes y bioinsumos, con su estado visible." })).toBeVisible();
 
   const portfolio = page.locator("#portafolio");
   await expect(portfolio.getByText("2Grow Sólido · 15-3-3", { exact: true })).toBeVisible();

--- a/e2e/wondergreen-editorial.spec.ts
+++ b/e2e/wondergreen-editorial.spec.ts
@@ -15,18 +15,20 @@ test("Wondergreen uses the canonical public shell without duplicate chrome", asy
   await expect(page.getByRole("contentinfo").getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
 });
 
-test("Wondergreen subnavigation follows the approved editorial hierarchy", async ({ page }) => {
+test("Wondergreen subnavigation exposes products before orientation while preserving governed destinations", async ({ page }) => {
   await page.goto("/wondergreen");
 
   const nav = page.getByRole("navigation", { name: "Navegación Wondergreen" });
-  await expect(nav.getByRole("link", { name: "Qué es" })).toHaveAttribute("href", "#que-es");
-  await expect(nav.getByRole("link", { name: "Tecnología" })).toHaveAttribute("href", "#tecnologia");
+  const labels = await nav.locator("a").allTextContents();
+  expect(labels.indexOf("Productos")).toBeLessThan(labels.indexOf("Finder"));
   await expect(nav.getByRole("link", { name: "Productos" })).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(nav.getByRole("link", { name: "Tecnología" })).toHaveAttribute("href", "#tecnologia");
   await expect(nav.getByRole("link", { name: "Cultivos" })).toHaveAttribute("href", "/wondergreen/cultivos");
+  await expect(nav.getByRole("link", { name: "Guías" })).toHaveAttribute("href", "/biblioteca");
   await expect(nav.getByRole("link", { name: "Finder" })).toHaveAttribute("href", "/wondergreen/finder");
   await expect(nav.getByRole("link", { name: "Bioinsumos" })).toHaveAttribute("href", "#bioinsumos");
-  await expect(nav.getByRole("link", { name: "Guías" })).toHaveAttribute("href", "/biblioteca");
   await expect(nav.getByRole("link", { name: "Casa & Jardín" })).toHaveAttribute("href", "/casa-jardin");
+  await expect(nav.getByRole("link", { name: "Qué es" })).toHaveAttribute("href", "#que-es");
 });
 
 test("Wondergreen exposes a household entry without turning Casa Jardin into ecommerce", async ({ page }) => {
@@ -43,13 +45,15 @@ test("Wondergreen exposes a household entry without turning Casa Jardin into eco
   await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
 });
 
-test("Wondergreen hub surfaces the governed Finder without turning it into a product shortcut", async ({ page }) => {
+test("Wondergreen keeps Finder available as secondary orientation rather than the primary product shortcut", async ({ page }) => {
   await page.goto("/wondergreen");
 
-  await expect(page.getByRole("link", { name: "Encontrar mi programa" })).toHaveAttribute("href", "/wondergreen/finder");
+  const hero = page.locator("section").filter({ has: page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." }) }).first();
+  await expect(hero.getByRole("link", { name: "Ver productos" })).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(hero.getByRole("link", { name: /No sé qué producto revisar/ })).toHaveAttribute("href", "/wondergreen/finder");
 
   const needEntry = page.getByRole("article").filter({
-    has: page.getByRole("heading", { name: "Tengo una necesidad", exact: true }),
+    has: page.getByRole("heading", { name: "No sé qué producto revisar", exact: true }),
   });
   await expect(needEntry.getByRole("link", { name: "Continuar →" })).toHaveAttribute("href", "/wondergreen/finder");
 
@@ -58,7 +62,7 @@ test("Wondergreen hub surfaces the governed Finder without turning it into a pro
   await expect(finder.getByText(/cinco programas publicados/i)).toBeVisible();
   await expect(finder.getByText(/no una prescripción automática/i)).toBeVisible();
 
-  await page.getByRole("link", { name: "Encontrar mi programa" }).click();
+  await hero.getByRole("link", { name: /No sé qué producto revisar/ }).click();
   await expect(page).toHaveURL(/\/wondergreen\/finder$/);
   await expect(page.getByRole("heading", { name: "Empieza por el cultivo y la etapa." })).toBeVisible();
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
@@ -66,28 +70,48 @@ test("Wondergreen hub surfaces the governed Finder without turning it into a pro
   await expect(page.getByRole("link", { name: /comprar/i })).toHaveCount(0);
 });
 
-test("Wondergreen hero uses the approved soil message with governed technical qualification", async ({ page }) => {
+test("Wondergreen hero uses the approved soil message and makes product discovery primary", async ({ page }) => {
   await page.goto("/wondergreen");
 
   const hero = page.locator("section").filter({ has: page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." }) }).first();
   await expect(page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." })).toBeVisible();
-  await expect(hero.getByText(/nutrición organomineral, soluciones líquidas, biología y conocimiento/i)).toBeVisible();
-  await expect(hero.getByText(/En las referencias sólidas donde está documentado/i)).toBeVisible();
-  await expect(hero.getByText(/matriz, la oclusión y la lenta liberación/i)).toBeVisible();
-  await expect(hero.getByText(/la selección siempre vuelve al cultivo, la etapa y la evidencia disponible/i)).toBeVisible();
-  await expect(hero.getByRole("link", { name: "Encontrar mi programa" })).toHaveAttribute("href", "/wondergreen/finder");
+  await expect(hero.getByText(/referencias organominerales sólidas, soluciones líquidas, compost y bioinsumos/i)).toBeVisible();
+  await expect(hero.getByText(/empezar por el producto y profundizar hasta formulación, presentación, tecnología y documentación/i)).toBeVisible();
   await expect(hero.getByRole("link", { name: "Ver productos" })).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(hero.getByRole("link", { name: "Explorar cultivos y guías" })).toHaveAttribute("href", "/wondergreen/cultivos");
+  await expect(hero.getByRole("link", { name: /No sé qué producto revisar/ })).toHaveAttribute("href", "/wondergreen/finder");
   await expect(hero.getByText("Product Master público", { exact: true })).toBeVisible();
 });
 
-test("Wondergreen V2 explains what the system is before technology and product selection", async ({ page }) => {
+test("Wondergreen places real commercial products before explanatory and orientative layers", async ({ page }) => {
   await page.goto("/wondergreen");
 
-  await expect(page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." })).toBeVisible();
+  const showcase = page.locator("#productos-destacados");
+  await expect(showcase.getByRole("heading", { name: "Empieza por los productos que ya puedes revisar." })).toBeVisible();
+  for (const product of ["2Grow Sólido", "2Balance Sólido", "2Bloom Sólido", "2Fruit Sólido"]) {
+    await expect(showcase.getByRole("link", { name: new RegExp(product) })).toBeVisible();
+  }
+  await expect(showcase.getByRole("img", { name: /Identidad visual aprobada de la línea Wondergreen 2Grow/ })).toBeVisible();
+  await expect(showcase.getByText(/Producto primero, sin confundir producto con recomendación/i)).toBeVisible();
+
+  const productComesFirst = await page.evaluate(() => {
+    const products = document.querySelector("#productos-destacados");
+    const definition = document.querySelector("#que-es");
+    const finder = document.querySelector("#finder");
+    if (!products || !definition || !finder) return false;
+    return Boolean(products.compareDocumentPosition(definition) & Node.DOCUMENT_POSITION_FOLLOWING)
+      && Boolean(products.compareDocumentPosition(finder) & Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+  expect(productComesFirst).toBe(true);
+});
+
+test("Wondergreen explains the system after exposing the commercial offer", async ({ page }) => {
+  await page.goto("/wondergreen");
+
   await expect(page.getByRole("heading", { name: "Un sistema de nutrición y manejo alrededor del suelo y del cultivo." })).toBeVisible();
   await expect(page.getByText(/fertilizantes organominerales sólidos, referencias líquidas, compost, bioinsumos, conocimiento y acompañamiento técnico/i)).toBeVisible();
-  await expect(page.getByText(/Primero se lee el contexto; después se seleccionan las herramientas/i)).toBeVisible();
-  await expect(page.getByText("Product Master público", { exact: true })).toBeVisible();
+  await expect(page.getByText(/El portafolio es una entrada comercial real/i)).toBeVisible();
+  await expect(page.getByText(/El contexto agronómico determina después cómo y cuándo una referencia puede convertirse en una recomendación específica/i)).toBeVisible();
 });
 
 test("Wondergreen V2 separates organomineral, occlusion and slow release without universal claims", async ({ page }) => {
@@ -117,7 +141,7 @@ test("Wondergreen V2 separates organomineral, occlusion and slow release without
 test("Wondergreen keeps agronomic implications separate from product characteristics", async ({ page }) => {
   await page.goto("/wondergreen");
 
-  await expect(page.getByRole("heading", { name: "La tecnología sirve para formular mejores preguntas, no para saltarse el diagnóstico." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "La tecnología ayuda a entender el producto; el contexto define la recomendación." })).toBeVisible();
   for (const heading of [
     "El suelo es parte del sistema",
     "La etapa cambia la decisión",
@@ -132,7 +156,7 @@ test("Wondergreen keeps agronomic implications separate from product characteris
 test("Wondergreen editorial hub preserves governed product truth and opens exact references", async ({ page }) => {
   await page.goto("/wondergreen");
 
-  await expect(page.getByRole("heading", { name: "Dos grandes líneas dentro de una misma marca." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Fertilizantes y bioinsumos, con su estado visible." })).toBeVisible();
 
   const portfolio = page.locator("#portafolio");
   await expect(portfolio.getByText("2Grow Sólido · 15-3-3", { exact: true })).toBeVisible();
@@ -145,7 +169,7 @@ test("Wondergreen editorial hub preserves governed product truth and opens exact
   await expect(page.getByText(/únicamente desde la versión técnica vigente/i)).toBeVisible();
 });
 
-test("Wondergreen finder follows diagnosis to follow-up without automatic prescription", async ({ page }) => {
+test("Wondergreen finder follows context to follow-up without automatic prescription", async ({ page }) => {
   await page.goto("/wondergreen");
 
   const finder = page.locator("#finder");
@@ -157,24 +181,24 @@ test("Wondergreen finder follows diagnosis to follow-up without automatic prescr
   await expect(finder.getByRole("link", { name: "Consultar guías" })).toHaveAttribute("href", "/biblioteca");
 });
 
-test("Wondergreen knowledge layer keeps guidance, product truth and case recommendation distinct", async ({ page }) => {
+test("Wondergreen knowledge layer connects web context with official documents", async ({ page }) => {
   await page.goto("/wondergreen");
 
-  await expect(page.getByRole("heading", { name: "La recomendación debe poder explicar de dónde sale." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Profundiza desde el producto hasta el documento oficial." })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Programas por cultivo", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Deficiencias nutricionales", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Criterios nutricionales", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Manual de uso", exact: true })).toBeVisible();
-  await expect(page.getByText(/mantienen separadas la orientación general, la ficha del producto y la recomendación específica para un caso/i)).toBeVisible();
+  await expect(page.getByText(/Las guías y PDF aprobados conservan su diseño y contenido como piezas documentales/i)).toBeVisible();
 });
 
 test("Wondergreen audience routes end in real governed destinations", async ({ page }) => {
   await page.goto("/wondergreen");
 
   const routes = page.locator("#acompanamiento");
-  await expect(routes.getByRole("link", { name: "Empezar por cultivo →" })).toHaveAttribute("href", "/wondergreen/cultivos");
+  await expect(routes.getByRole("link", { name: "Ver productos →" })).toHaveAttribute("href", "/wondergreen/productos");
   await expect(routes.getByRole("link", { name: "Explorar Casa & Jardín →" })).toHaveAttribute("href", "/casa-jardin");
   await expect(routes.getByRole("link", { name: "Quiero vender Wondergreen →" })).toHaveAttribute("href", "/contacto");
   await expect(routes.getByRole("link", { name: "Abrir biblioteca técnica →" })).toHaveAttribute("href", "/biblioteca");
-  await expect(page.getByRole("link", { name: "Hablar con equipo técnico" }).first()).toHaveAttribute("href", "/contacto");
+  await expect(page.getByRole("link", { name: "Hablar con equipo técnico" }).last()).toHaveAttribute("href", "/contacto");
 });

--- a/src/app/wondergreen/page.tsx
+++ b/src/app/wondergreen/page.tsx
@@ -3,39 +3,40 @@ import Image from "next/image";
 import Link from "next/link";
 import { bioinputReferences, compostReferences, liquidFertilizers, solidFertilizers } from "@/data/wondergreen-public";
 import { wondergreenCrops } from "@/data/wondergreen-crops";
+import { WondergreenCommercialShowcase } from "./wondergreen-commercial-showcase";
 import styles from "./wondergreen-v2.module.css";
 
 export const metadata: Metadata = {
   title: "Wondergreen | Suelo, nutrición y biología",
   description:
-    "Wondergreen integra nutrición organomineral, fertilizantes líquidos, compost, bioinsumos, guías por cultivo y acompañamiento técnico dentro de una misma lógica de suelo y seguimiento.",
+    "Wondergreen integra productos organominerales, fertilizantes líquidos, compost, bioinsumos, tecnología, guías por cultivo y acompañamiento técnico dentro de una misma lógica de suelo y seguimiento.",
   alternates: { canonical: "/wondergreen" },
 };
 
 const entryPaths = [
   {
     number: "01",
-    title: "Tengo un cultivo",
-    copy: "Empieza por especie, etapa y objetivo antes de elegir una referencia.",
-    href: "/wondergreen/cultivos",
-  },
-  {
-    number: "02",
-    title: "Tengo una necesidad",
-    copy: "Organiza cultivo, etapa y evidencia disponible antes de revisar una ruta técnica.",
-    href: "/wondergreen/finder",
-  },
-  {
-    number: "03",
-    title: "Sé qué producto busco",
-    copy: "Entra al Product Master público y revisa familia, formato y condición vigente.",
+    title: "Quiero ver productos",
+    copy: "Entra al catálogo y abre cada referencia para revisar formulación, presentaciones, condición comercial y documentación vinculada.",
     href: "/wondergreen/productos",
   },
   {
-    number: "04",
+    number: "02",
+    title: "Tengo un cultivo",
+    copy: "Explora los programas publicados y sus guías PDF antes de convertir una referencia en recomendación.",
+    href: "/wondergreen/cultivos",
+  },
+  {
+    number: "03",
     title: "Tengo plantas en casa",
-    copy: "Entra a Casa & Jardín para observar etapa, diagnóstico orientativo, productos y guías.",
+    copy: "Entra a Casa & Jardín para conocer productos, kits, etapas, guías y orientación segura.",
     href: "/casa-jardin",
+  },
+  {
+    number: "04",
+    title: "No sé qué producto revisar",
+    copy: "Usa el Finder como orientación cuando todavía necesitas ordenar cultivo, etapa y contexto antes de escoger una referencia.",
+    href: "/wondergreen/finder",
   },
 ] as const;
 
@@ -68,9 +69,9 @@ const knowledgeRoutes = [
 ] as const;
 
 const audiences = [
-  ["01", "Productor", "Encuentra una ruta técnica para tu cultivo.", "Empezar por cultivo", "/wondergreen/cultivos"],
-  ["02", "Hogar / jardín", "Observa la etapa de tus plantas y entra al sistema doméstico sin dosificar a ciegas.", "Explorar Casa & Jardín", "/casa-jardin"],
-  ["03", "Agrotienda / distribuidor", "Conoce familias, formatos y oportunidad comercial.", "Quiero vender Wondergreen", "/contacto"],
+  ["01", "Productor", "Conoce primero el portafolio y luego cruza la referencia con la etapa de tu cultivo.", "Ver productos", "/wondergreen/productos"],
+  ["02", "Hogar / jardín", "Explora productos, kits y guías domésticas sin convertir la navegación en dosificación automática.", "Explorar Casa & Jardín", "/casa-jardin"],
+  ["03", "Agrotienda / distribuidor", "Conoce familias, formatos y condición comercial antes de conversar sobre distribución.", "Quiero vender Wondergreen", "/contacto"],
   ["04", "Agrónomo / técnico", "Accede a portafolio, guías y criterios técnicos navegables.", "Abrir biblioteca técnica", "/biblioteca"],
 ] as const;
 
@@ -81,14 +82,14 @@ export default function WondergreenPage() {
         <div className={styles.container}>
           <span>Wondergreen</span>
           <div>
-            <a href="#que-es">Qué es</a>
-            <a href="#tecnologia">Tecnología</a>
             <Link href="/wondergreen/productos">Productos</Link>
+            <a href="#tecnologia">Tecnología</a>
             <Link href="/wondergreen/cultivos">Cultivos</Link>
+            <Link href="/biblioteca">Guías</Link>
             <Link href="/wondergreen/finder">Finder</Link>
             <a href="#bioinsumos">Bioinsumos</a>
-            <Link href="/biblioteca">Guías</Link>
             <Link href="/casa-jardin">Casa & Jardín</Link>
+            <a href="#que-es">Qué es</a>
           </div>
         </div>
       </nav>
@@ -110,12 +111,12 @@ export default function WondergreenPage() {
               />
               <h1 id="wondergreen-title">Nutrición que trabaja con el suelo.</h1>
               <p className={styles.lead}>
-                En Wondergreen desarrollamos soluciones para acompañar el cultivo desde el suelo: nutrición organomineral, soluciones líquidas, biología y conocimiento. En las referencias sólidas donde está documentado, explicamos además la matriz, la oclusión y la lenta liberación; la selección siempre vuelve al cultivo, la etapa y la evidencia disponible.
+                Wondergreen reúne productos para nutrición y manejo del cultivo: referencias organominerales sólidas, soluciones líquidas, compost y bioinsumos. Puedes empezar por el producto y profundizar hasta formulación, presentación, tecnología y documentación; cuando la elección todavía no está clara, las guías y el Finder ayudan a ordenar el contexto.
               </p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/wondergreen/finder">Encontrar mi programa</Link>
-                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/wondergreen/productos">Ver productos</Link>
-                <Link className={styles.textLink} href="/contacto">Hablar con equipo técnico →</Link>
+                <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/wondergreen/productos">Ver productos</Link>
+                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/wondergreen/cultivos">Explorar cultivos y guías</Link>
+                <Link className={styles.textLink} href="/wondergreen/finder">No sé qué producto revisar →</Link>
               </div>
               <div className={styles.heroTruth}>
                 <span>Product Master público</span>
@@ -160,14 +161,16 @@ export default function WondergreenPage() {
           </div>
         </section>
 
+        <WondergreenCommercialShowcase />
+
         <section className={styles.router} aria-labelledby="router-title">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div>
-                <span className={styles.eyebrow}>Empieza por tu contexto</span>
-                <h2 id="router-title">No empieces por el producto. Empieza por la decisión.</h2>
+                <span className={styles.eyebrow}>Elige tu nivel de profundidad</span>
+                <h2 id="router-title">Si ya sabes qué buscas, entra directo. Si no, te orientamos.</h2>
               </div>
-              <p>La selección cambia con cultivo, etapa, suelo o sustrato, problema, análisis disponibles y objetivo. Wondergreen organiza distintas puertas para llegar a la misma base técnica.</p>
+              <p>La web separa dos recorridos: quien conoce el producto puede abrirlo y llegar hasta su documentación; quien todavía tiene dudas puede entrar por cultivo, Casa & Jardín o Finder sin convertir la orientación en prescripción automática.</p>
             </div>
             <div className={styles.routerGrid}>
               {entryPaths.map((item) => (
@@ -190,8 +193,8 @@ export default function WondergreenPage() {
               <h2 id="definition-title">Un sistema de nutrición y manejo alrededor del suelo y del cultivo.</h2>
             </div>
             <div className={styles.editorialCopy}>
-              <p>Wondergreen reúne fertilizantes organominerales sólidos, referencias líquidas, compost, bioinsumos, conocimiento y acompañamiento técnico bajo una misma arquitectura de decisión.</p>
-              <p>La marca no presupone que una necesidad se resuelva con un solo producto. Primero se lee el contexto; después se seleccionan las herramientas que correspondan.</p>
+              <p>Wondergreen reúne fertilizantes organominerales sólidos, referencias líquidas, compost, bioinsumos, conocimiento y acompañamiento técnico bajo una misma arquitectura de producto y decisión.</p>
+              <p>El portafolio es una entrada comercial real. El contexto agronómico determina después cómo y cuándo una referencia puede convertirse en una recomendación específica.</p>
             </div>
           </div>
         </section>
@@ -267,9 +270,9 @@ export default function WondergreenPage() {
             <div className={styles.sectionHead}>
               <div>
                 <span className={styles.eyebrow}>Qué cambia en la lectura agronómica</span>
-                <h2 id="implications-title">La tecnología sirve para formular mejores preguntas, no para saltarse el diagnóstico.</h2>
+                <h2 id="implications-title">La tecnología ayuda a entender el producto; el contexto define la recomendación.</h2>
               </div>
-              <p>La matriz, la forma física y la característica de liberación se interpretan dentro de un sistema vivo. La recomendación final sigue dependiendo del cultivo y de la información disponible.</p>
+              <p>La matriz, la forma física y la característica de liberación se interpretan dentro de un sistema vivo. Conocer el producto es el primer nivel; decidir dosis, momento o combinación exige la información aplicable al cultivo.</p>
             </div>
             <div className={styles.implicationGrid}>
               {scienceImplications.map(([number, title, copy]) => (
@@ -282,9 +285,9 @@ export default function WondergreenPage() {
         <section className={styles.finder} id="finder" aria-labelledby="finder-title">
           <div className={`${styles.container} ${styles.finderGrid}`}>
             <div className={styles.finderIntro}>
-              <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Objetivo + etapa</span>
+              <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Orientación cuando hace falta</span>
               <h2 id="finder-title">Del contexto al seguimiento.</h2>
-              <p>El Finder V1 organiza cultivo, etapa y evidencia disponible dentro de los cinco programas publicados. Es una orientación técnica, no una prescripción automática, y se detiene cuando la etapa no está clara.</p>
+              <p>El Finder V1 organiza cultivo, etapa y evidencia disponible dentro de los cinco programas publicados. Es una orientación técnica para quien todavía no sabe qué referencia revisar, no una prescripción automática, y se detiene cuando la etapa no está clara.</p>
               <div className={styles.actions}>
                 <Link className={`${styles.button} ${styles.buttonLight}`} href="/wondergreen/finder">Abrir Finder Wondergreen</Link>
                 <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/biblioteca">Consultar guías</Link>
@@ -302,10 +305,10 @@ export default function WondergreenPage() {
           <div className={styles.container}>
             <div className={styles.portfolioHead}>
               <div>
-                <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Portafolio · Product Master público</span>
-                <h2 id="portfolio-title">Dos grandes líneas dentro de una misma marca.</h2>
+                <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Portafolio completo · Product Master público</span>
+                <h2 id="portfolio-title">Fertilizantes y bioinsumos, con su estado visible.</h2>
               </div>
-              <p>Fertilizantes y bioinsumos pueden integrarse en programas de manejo, pero no cumplen la misma función ni siguen necesariamente la misma secuencia fenológica.</p>
+              <p>Después de las referencias comerciales destacadas, el Product Master permite revisar también referencias técnicas o en desarrollo sin confundirlas con disponibilidad comercial.</p>
             </div>
 
             <div className={styles.portfolioColumns}>
@@ -352,14 +355,14 @@ export default function WondergreenPage() {
         <section className={styles.crops} id="cultivos" aria-labelledby="crops-title">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Programas por cultivo</span><h2 id="crops-title">La decisión técnica cambia con la etapa.</h2></div>
-              <p>Las guías conectan momento fisiológico, objetivo, cautelas, alertas y referencias gobernadas sin convertir todos los cultivos en una misma receta.</p>
+              <div><span className={styles.eyebrow}>Programas y guías por cultivo</span><h2 id="crops-title">La decisión técnica cambia con la etapa.</h2></div>
+              <p>Las rutas de cultivo conectan momento fisiológico, objetivo, cautelas y productos relacionados; cuando existe una guía PDF aprobada, la página la mantiene disponible como documento editorial completo.</p>
             </div>
             <div className={styles.cropGrid}>
               {wondergreenCrops.map((crop, index) => (
                 <Link href={`/wondergreen/cultivos/${crop.slug}`} key={crop.slug}>
                   <span>{String(index + 1).padStart(2, "0")}</span>
-                  <small>Programa técnico</small>
+                  <small>Programa + guía</small>
                   <h3>{crop.name}</h3>
                   <p>{crop.headline}</p>
                   <strong>Abrir programa →</strong>
@@ -372,8 +375,8 @@ export default function WondergreenPage() {
         <section className={styles.knowledge} aria-labelledby="knowledge-title">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Evidencia y conocimiento</span><h2 id="knowledge-title">La recomendación debe poder explicar de dónde sale.</h2></div>
-              <p>Guías, criterios y Product Master mantienen separadas la orientación general, la ficha del producto y la recomendación específica para un caso.</p>
+              <div><span className={styles.eyebrow}>Documentación y conocimiento</span><h2 id="knowledge-title">Profundiza desde el producto hasta el documento oficial.</h2></div>
+              <p>La web contextualiza y conecta. Las guías y PDF aprobados conservan su diseño y contenido como piezas documentales, mientras Product Truth gobierna la referencia exacta.</p>
             </div>
             <div className={styles.knowledgeGrid}>
               {knowledgeRoutes.map(([number, title, copy, href, cta]) => (
@@ -386,8 +389,8 @@ export default function WondergreenPage() {
         <section className={styles.commercial} id="acompanamiento" aria-labelledby="commercial-title">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Distribución y asesoría</span><h2 id="commercial-title">El mismo sistema, distintas preguntas.</h2></div>
-              <p>La entrada puede ser un cultivo, una planta en casa, una oportunidad de distribución o una necesidad técnica. Cada ruta termina en un destino público gobernado.</p>
+              <div><span className={styles.eyebrow}>Compra informada, distribución y asesoría</span><h2 id="commercial-title">El mismo portafolio, distintas necesidades.</h2></div>
+              <p>El productor puede revisar productos, el hogar entra por Casa & Jardín, un distribuidor conversa sobre líneas y formatos y el técnico profundiza en documentación. La orientación aparece cuando agrega valor, no como sustituto de la oferta.</p>
             </div>
             <div className={styles.commercialList}>
               {audiences.map(([number, title, copy, cta, href]) => (
@@ -401,13 +404,13 @@ export default function WondergreenPage() {
           <div className={`${styles.container} ${styles.closingGrid}`}>
             <div>
               <span className={styles.eyebrow}>Wondergreen</span>
-              <h2 id="closing-title">¿Tienes un cultivo, una necesidad o un problema por resolver?</h2>
+              <h2 id="closing-title">¿Quieres revisar un producto, una presentación o una ruta para tu cultivo?</h2>
             </div>
             <div>
-              <p>Empieza por el contexto. El siguiente paso puede ser una guía, un producto, un análisis, Casa & Jardín o acompañamiento técnico.</p>
+              <p>Puedes entrar directamente al producto, consultar las guías o hablar con Greenatics cuando necesites confirmar disponibilidad, contexto técnico o distribución.</p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.buttonDark}`} href="/contacto">Hablar con equipo técnico</Link>
-                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/">Volver a Greenatics</Link>
+                <Link className={`${styles.button} ${styles.buttonDark}`} href="/wondergreen/productos">Ver productos</Link>
+                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/contacto">Hablar con equipo técnico</Link>
               </div>
             </div>
           </div>

--- a/src/app/wondergreen/wondergreen-commercial-showcase.tsx
+++ b/src/app/wondergreen/wondergreen-commercial-showcase.tsx
@@ -1,0 +1,65 @@
+import Image from "next/image";
+import Link from "next/link";
+import { getWondergreenProductArtwork } from "@/data/wondergreen-product-assets";
+import { solidFertilizers } from "@/data/wondergreen-public";
+import styles from "./wondergreen-commercial.module.css";
+
+const featuredProducts = solidFertilizers.filter((reference) => reference.truthStatus === "commercial-reconciled");
+
+export function WondergreenCommercialShowcase() {
+  return (
+    <section className={styles.showcase} id="productos-destacados" aria-labelledby="wondergreen-commercial-title">
+      <div className={styles.container}>
+        <div className={styles.heading}>
+          <div>
+            <span className={styles.eyebrow}>Productos Wondergreen</span>
+            <h2 id="wondergreen-commercial-title">Empieza por los productos que ya puedes revisar.</h2>
+          </div>
+          <div className={styles.headingCopy}>
+            <p>Estas referencias sólidas tienen condición comercial reconciliada en Product Truth. Cada una abre su ficha con formulación, presentaciones, cultivos relacionados y documentación pública vinculada.</p>
+            <Link href="/wondergreen/productos">Ver todos los productos →</Link>
+          </div>
+        </div>
+
+        <div className={styles.grid}>
+          {featuredProducts.map((product) => {
+            const artwork = getWondergreenProductArtwork(product);
+            return (
+              <Link className={styles.card} href={`/wondergreen/productos/${product.slug}`} key={product.slug}>
+                {artwork ? (
+                  <Image
+                    className={styles.artwork}
+                    src={artwork.href}
+                    alt={artwork.alt}
+                    width={760}
+                    height={520}
+                    sizes="(max-width: 700px) 92vw, (max-width: 1100px) 46vw, 24vw"
+                    unoptimized
+                  />
+                ) : null}
+                <div className={styles.cardBody}>
+                  <span>{product.publicStatus}</span>
+                  <div className={styles.identity}>
+                    <strong>{product.family}</strong>
+                    {product.formula ? <em>{product.formula}</em> : null}
+                  </div>
+                  <h3>{product.name}</h3>
+                  <p>{product.role}</p>
+                  <div className={styles.meta}>
+                    <small>{product.presentations?.join(" · ") ?? "Presentación por confirmar"}</small>
+                    <b>Ver ficha completa →</b>
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+
+        <div className={styles.truthLock}>
+          <strong>Producto primero, sin confundir producto con recomendación.</strong>
+          <span>La página permite conocer la referencia y sus documentos; dosis, frecuencia, compatibilidad y uso específico siguen dependiendo de la versión técnica vigente y del contexto real.</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/wondergreen/wondergreen-commercial.module.css
+++ b/src/app/wondergreen/wondergreen-commercial.module.css
@@ -1,0 +1,60 @@
+.showcase {
+  --forest: #063d2c;
+  --green: #2f7d32;
+  --lime: #7db43c;
+  --ink: #263b32;
+  --muted: #65776e;
+  --paper: #f7faf8;
+  --line: rgba(6, 61, 44, .15);
+  --display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, Georgia, serif;
+  padding: 88px 0 96px;
+  background: #fff;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink);
+}
+
+.container { width: min(1240px, calc(100% - 48px)); margin: 0 auto; }
+.heading { display: grid; grid-template-columns: 1fr .72fr; gap: 64px; align-items: end; margin-bottom: 38px; }
+.eyebrow { display: inline-block; margin-bottom: 14px; color: var(--green); font-size: .69rem; font-weight: 850; text-transform: uppercase; letter-spacing: .13em; }
+.heading h2 { margin: 0; max-width: 12ch; font-family: var(--display); font-size: clamp(2.7rem, 5vw, 5rem); font-weight: 600; line-height: .98; letter-spacing: -.04em; }
+.headingCopy p { margin: 0 0 16px; color: var(--muted); line-height: 1.65; }
+.headingCopy a { color: var(--green); font-weight: 850; text-decoration: none; }
+
+.grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.card { min-width: 0; display: flex; flex-direction: column; color: inherit; text-decoration: none; background: var(--paper); border-right: 1px solid var(--line); transition: transform .18s ease, background-color .18s ease; }
+.card:last-child { border-right: 0; }
+.card:hover { transform: translateY(-3px); background: #fff; }
+.card:focus-visible { outline: 3px solid #f4d944; outline-offset: 4px; }
+.artwork { width: 100%; aspect-ratio: 4 / 3; object-fit: cover; object-position: center; border-bottom: 1px solid var(--line); background: #fff; }
+.cardBody { min-height: 330px; padding: 22px; display: flex; flex-direction: column; }
+.cardBody > span { color: var(--green); font-size: .64rem; font-weight: 850; text-transform: uppercase; letter-spacing: .07em; }
+.identity { display: flex; align-items: baseline; gap: 10px; margin: 26px 0 12px; }
+.identity strong { font-family: var(--display); font-size: 2rem; color: var(--forest); letter-spacing: -.04em; }
+.identity em { font-style: normal; font-size: .78rem; font-weight: 850; color: var(--green); }
+.cardBody h3 { margin: 0; font-family: var(--display); font-size: 1.5rem; line-height: 1.05; font-weight: 600; letter-spacing: -.03em; }
+.cardBody p { color: var(--muted); line-height: 1.55; font-size: .86rem; }
+.meta { margin-top: auto; padding-top: 20px; border-top: 1px solid var(--line); display: grid; gap: 10px; }
+.meta small { color: var(--muted); line-height: 1.4; }
+.meta b { color: var(--green); font-size: .82rem; }
+.truthLock { margin-top: 26px; padding: 18px 20px; display: grid; grid-template-columns: .55fr 1.45fr; gap: 28px; background: #eaf4e4; border-left: 4px solid var(--lime); }
+.truthLock strong { color: var(--forest); }
+.truthLock span { color: var(--muted); line-height: 1.55; }
+
+@media (max-width: 1050px) {
+  .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .card:nth-child(2) { border-right: 0; }
+  .card:nth-child(-n+2) { border-bottom: 1px solid var(--line); }
+}
+
+@media (max-width: 760px) {
+  .container { width: min(100% - 28px, 1240px); }
+  .showcase { padding: 68px 0 74px; }
+  .heading { grid-template-columns: 1fr; gap: 20px; }
+  .grid { grid-template-columns: 1fr; }
+  .card,
+  .card:nth-child(2) { border-right: 0; border-bottom: 1px solid var(--line); }
+  .card:last-child { border-bottom: 0; }
+  .cardBody { min-height: 0; }
+  .artwork { max-height: 360px; object-fit: cover; }
+  .truthLock { grid-template-columns: 1fr; gap: 8px; }
+}


### PR DESCRIPTION
## Objetivo
Aplicar en `/wondergreen` la jerarquía comercial acordada: productos y profundidad de oferta primero; tecnología, cultivos, documentación y orientación después.

## Cambios
- Hero conserva `Nutrición que trabaja con el suelo.` pero cambia el CTA principal a `Ver productos`.
- Subnavegación coloca Productos antes de Finder.
- Nueva banda comercial inmediata con 2Grow, 2Balance, 2Bloom y 2Fruit sólidos comercialmente reconciliados.
- Cada tarjeta usa el activo visual aprobado de línea y abre la ficha profunda V2.1.
- La entrada secundaria separa cuatro recorridos: productos, cultivos, Casa & Jardín y Finder.
- Se elimina el mensaje `No empieces por el producto`; ahora la web permite entrar directo al producto y usa orientación cuando hace falta.
- Product Master completo sigue visible más adelante, incluyendo referencias técnicas/en desarrollo con estado explícito.
- Cultivos y conocimiento se presentan como programa + guía/documentación, no como sustituto de los PDFs aprobados.
- Finder permanece gobernado y no prescriptivo, pero deja de ser el CTA principal del universo Wondergreen.

## Truth / Brand locks
- Solo se destacan referencias `commercial-reconciled`.
- No se inventan packshots, SKUs, dosis, frecuencias, eficacia ni disponibilidad.
- Los activos de línea se identifican como identidad visual aprobada, no como packshot específico.
- `lenta liberación` permanece limitada a referencias/versiones documentadas.

## Tests
- Jerarquía de subnav Producto > Finder.
- Hero product-first.
- Banda de productos comerciales antes de definición/Finder.
- Destinos gobernados, tecnología, Product Truth, Casa & Jardín y Finder preservados.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile