### PR TITLE
feat(wondergreen): profundiza guías oficiales por cultivo V2.1

### DIFF
--- a/e2e/wondergreen-crop-documents.spec.ts
+++ b/e2e/wondergreen-crop-documents.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+
+const publishedGuides = [
+  ["cafe", "Guía Wondergreen para café", "wondergreen-guide-cafe"],
+  ["cacao", "Guía Wondergreen para cacao", "wondergreen-guide-cacao"],
+  ["aguacate", "Guía Wondergreen para aguacate", "wondergreen-guide-aguacate"],
+  ["limon-tahiti", "Guía Wondergreen para limón Tahití", "wondergreen-guide-limon-tahiti"],
+  ["pastos-gramineas", "Guía Wondergreen para pastos y gramíneas", "wondergreen-guide-pastos"],
+] as const;
+
+for (const [slug, title, resourceId] of publishedGuides) {
+  test(`${slug} keeps the published PDF master visually primary and separately downloadable`, async ({ page }) => {
+    await page.goto(`/wondergreen/cultivos/${slug}`);
+
+    const document = page.getByRole("complementary", { name: new RegExp(`Documento oficial para`, "i") });
+    await expect(document.getByRole("heading", { name: title, exact: true })).toBeVisible();
+    await expect(document.getByRole("img", { name: `Portada de ${title}` })).toBeVisible();
+    await expect(document.getByText(/Documento completo publicado/i)).toBeVisible();
+    await expect(document.getByText(/20 páginas/i)).toBeVisible();
+    await expect(document.getByText(/PDF público same-origin/i)).toBeVisible();
+
+    await expect(document.getByRole("link", { name: "Abrir PDF original ↗" })).toHaveAttribute(
+      "href",
+      `/api/public-resources/${resourceId}`,
+    );
+    await expect(document.getByRole("link", { name: "Descargar PDF ↓" })).toHaveAttribute(
+      "href",
+      `/api/public-resources/${resourceId}?download=1`,
+    );
+
+    const nav = page.getByRole("navigation", { name: new RegExp(`Contenido del programa`, "i") });
+    await expect(nav.getByRole("link", { name: "Etapas" })).toHaveAttribute("href", "#etapas");
+    await expect(nav.getByRole("link", { name: "Comprobaciones" })).toHaveAttribute("href", "#comprobaciones");
+    await expect(nav.getByRole("link", { name: "Seguimiento" })).toHaveAttribute("href", "#seguimiento");
+    await expect(nav.getByRole("link", { name: "Productos relacionados" })).toHaveAttribute("href", "#referencias");
+  });
+}
+
+test("crop guide web context explicitly preserves PDF and Product Master as different authorities", async ({ page }) => {
+  await page.goto("/wondergreen/cultivos/cafe");
+
+  await expect(page.getByRole("heading", { name: /La web no reemplaza la guía/i })).toBeVisible();
+  await expect(page.getByText(/la fuente publicada es la guía PDF asociada a este cultivo/i)).toBeVisible();
+  await expect(page.getByText(/El PDF y el Product Master siguen siendo fuentes distintas/i)).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Referencias que aparecen en este programa." })).toBeVisible();
+});

--- a/e2e/wondergreen-crop-documents.spec.ts
+++ b/e2e/wondergreen-crop-documents.spec.ts
@@ -12,11 +12,11 @@ for (const [slug, title, resourceId] of publishedGuides) {
   test(`${slug} keeps the published PDF master visually primary and separately downloadable`, async ({ page }) => {
     await page.goto(`/wondergreen/cultivos/${slug}`);
 
-    const document = page.getByRole("complementary", { name: new RegExp(`Documento oficial para`, "i") });
+    const document = page.getByRole("complementary", { name: /Documento oficial para/i });
     await expect(document.getByRole("heading", { name: title, exact: true })).toBeVisible();
     await expect(document.getByRole("img", { name: `Portada de ${title}` })).toBeVisible();
     await expect(document.getByText(/Documento completo publicado/i)).toBeVisible();
-    await expect(document.getByText(/20 páginas/i)).toBeVisible();
+    await expect(document.locator("strong").filter({ hasText: /20 páginas/i })).toHaveCount(1);
     await expect(document.getByText(/PDF público same-origin/i)).toBeVisible();
 
     await expect(document.getByRole("link", { name: "Abrir PDF original ↗" })).toHaveAttribute(
@@ -28,7 +28,7 @@ for (const [slug, title, resourceId] of publishedGuides) {
       `/api/public-resources/${resourceId}?download=1`,
     );
 
-    const nav = page.getByRole("navigation", { name: new RegExp(`Contenido del programa`, "i") });
+    const nav = page.getByRole("navigation", { name: /Contenido del programa/i });
     await expect(nav.getByRole("link", { name: "Etapas" })).toHaveAttribute("href", "#etapas");
     await expect(nav.getByRole("link", { name: "Comprobaciones" })).toHaveAttribute("href", "#comprobaciones");
     await expect(nav.getByRole("link", { name: "Seguimiento" })).toHaveAttribute("href", "#seguimiento");

--- a/e2e/wondergreen-crops.spec.ts
+++ b/e2e/wondergreen-crops.spec.ts
@@ -25,14 +25,16 @@ test("crop library exposes the five initial programs", async ({ page }) => {
   }
 });
 
-test("cacao program connects stage guidance, its PDF and exact Product Master references", async ({ page }) => {
+test("cacao program connects its official PDF, stage guidance and exact Product Master references", async ({ page }) => {
   await page.goto("/wondergreen/cultivos/cacao");
 
   await expect(page.getByText(/01 · Establecimiento/)).toBeVisible();
   await expect(page.getByText("Compost", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("2Grow", { exact: true }).first()).toBeVisible();
   await expect(page.getByRole("img", { name: /Portada de Guía Wondergreen para cacao/i })).toBeVisible();
-  await expect(page.getByRole("link", { name: /Descargar guía PDF/i }).first()).toHaveAttribute("href", "/api/public-resources/wondergreen-guide-cacao");
+  await expect(page.getByRole("link", { name: "Abrir PDF original ↗" })).toHaveAttribute("href", "/api/public-resources/wondergreen-guide-cacao");
+  await expect(page.getByRole("link", { name: "Descargar PDF ↓" })).toHaveAttribute("href", "/api/public-resources/wondergreen-guide-cacao?download=1");
+  await expect(page.getByText(/El PDF conserva el desarrollo editorial completo publicado/i)).toBeVisible();
   await expect(page.getByRole("heading", { name: /Referencias que aparecen en este programa/i })).toBeVisible();
 
   const grow = page.getByRole("link", { name: /2Grow Sólido · 15-3-3/i }).first();

--- a/src/app/api/public-resources/[resourceId]/route.ts
+++ b/src/app/api/public-resources/[resourceId]/route.ts
@@ -4,7 +4,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(
-  _request: Request,
+  request: Request,
   context: { params: Promise<{ resourceId: string }> },
 ) {
   const { resourceId } = await context.params;
@@ -15,9 +15,11 @@ export async function GET(
     const download = await downloadPublicWondergreenPdf(resourceId);
     if (!download) return new Response("Recurso no encontrado.", { status: 404 });
 
+    const attachmentRequested = new URL(request.url).searchParams.get("download") === "1";
+    const disposition = attachmentRequested ? "attachment" : "inline";
     const headers = new Headers({
       "content-type": "application/pdf",
-      "content-disposition": `inline; filename="${download.asset.filename}"`,
+      "content-disposition": `${disposition}; filename="${download.asset.filename}"`,
       "cache-control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
       "x-content-type-options": "nosniff",
     });

--- a/src/app/wondergreen/cultivos/[slug]/crop-document.module.css
+++ b/src/app/wondergreen/cultivos/[slug]/crop-document.module.css
@@ -1,0 +1,108 @@
+.documentPanel {
+  display: grid;
+  grid-template-columns: minmax(180px, 250px) 1fr;
+  gap: 28px;
+  align-items: center;
+  padding: 24px;
+  border: 1px solid rgba(6, 61, 44, .14);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, .94);
+  box-shadow: 0 28px 72px rgba(6, 61, 44, .1);
+}
+
+.coverWrap { position: relative; }
+.coverWrap::after {
+  content: "PDF";
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  padding: 6px 9px;
+  border-radius: 999px;
+  background: #063d2c;
+  color: white;
+  font-size: .64rem;
+  font-weight: 900;
+  letter-spacing: .12em;
+}
+
+.cover {
+  display: block;
+  width: 100%;
+  height: auto;
+  border: 1px solid rgba(6, 61, 44, .16);
+  border-radius: 16px;
+  box-shadow: 0 20px 48px rgba(6, 61, 44, .14);
+}
+
+.documentCopy { min-width: 0; }
+.documentStatus {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: #e5f0df;
+  color: #2f7d32;
+  font-size: .67rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+}
+.documentCopy h2 { margin-top: 12px !important; font-size: clamp(1.75rem, 3.2vw, 2.7rem) !important; }
+.documentCopy p { color: #65776e; line-height: 1.6; }
+.documentMeta { display: grid; gap: 9px; margin: 20px 0; padding: 16px 0; border-top: 1px solid rgba(6,61,44,.12); border-bottom: 1px solid rgba(6,61,44,.12); }
+.documentMeta div { display: grid; grid-template-columns: 92px 1fr; gap: 12px; }
+.documentMeta span { color: #65776e; font-size: .72rem; font-weight: 900; text-transform: uppercase; letter-spacing: .07em; }
+.documentMeta strong { color: #263b32; font-size: .88rem; line-height: 1.35; }
+.documentActions { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+.openButton, .downloadButton, .libraryButton {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0 17px;
+  font-size: .82rem;
+  font-weight: 900;
+}
+.openButton { background: #2f7d32; color: white !important; }
+.downloadButton { border: 1px solid #2f7d32; color: #2f7d32 !important; background: white; }
+.libraryButton { color: #2f7d32 !important; padding-inline: 4px; }
+
+.authorityNote {
+  margin: 0;
+  padding-top: 14px;
+  color: #53675d !important;
+  font-size: .82rem;
+}
+.authorityNote strong { color: #263b32; }
+
+.documentNav { background: #fff; border-top: 1px solid rgba(6,61,44,.1); border-bottom: 1px solid rgba(6,61,44,.1); }
+.documentNavInner { display: flex; flex-wrap: wrap; align-items: center; gap: 10px 24px; min-height: 68px; }
+.documentNavInner > strong { margin-right: auto; font-size: .78rem; text-transform: uppercase; letter-spacing: .1em; color: #263b32; }
+.documentNavInner a { color: #2f7d32 !important; font-size: .8rem; font-weight: 900; }
+
+.documentAuthority { padding: 74px 0; background: #063d2c; color: white; }
+.authorityGrid { display: grid; grid-template-columns: .8fr 1.2fr; gap: 56px; align-items: start; }
+.authorityGrid h2 { max-width: 580px; }
+.authorityGrid p { margin: 0; color: #c2d2c9; line-height: 1.7; }
+.authorityFacts { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 24px; }
+.authorityFacts article { padding: 18px; border: 1px solid rgba(255,255,255,.14); border-radius: 18px; background: rgba(255,255,255,.06); }
+.authorityFacts span { display: block; margin-bottom: 8px; color: #9bcf72; font-size: .67rem; font-weight: 900; text-transform: uppercase; letter-spacing: .08em; }
+.authorityFacts strong { font-size: .9rem; line-height: 1.4; }
+
+@media (max-width: 900px) {
+  .documentPanel { grid-template-columns: 180px 1fr; }
+  .authorityGrid { grid-template-columns: 1fr; gap: 28px; }
+}
+
+@media (max-width: 640px) {
+  .documentPanel { grid-template-columns: 1fr; }
+  .coverWrap { width: min(72%, 260px); }
+  .documentMeta div { grid-template-columns: 1fr; gap: 4px; }
+  .documentActions { align-items: stretch; }
+  .openButton, .downloadButton { width: 100%; }
+  .documentNavInner { padding: 14px 0; align-items: flex-start; }
+  .documentNavInner > strong { width: 100%; margin-right: 0; }
+  .authorityFacts { grid-template-columns: 1fr; }
+}

--- a/src/app/wondergreen/cultivos/[slug]/crop-document.module.css
+++ b/src/app/wondergreen/cultivos/[slug]/crop-document.module.css
@@ -83,6 +83,7 @@
 .documentNavInner a { color: #2f7d32 !important; font-size: .8rem; font-weight: 900; }
 
 .documentAuthority { padding: 74px 0; background: #063d2c; color: white; }
+.authorityEyebrow { color: #9bcf72 !important; }
 .authorityGrid { display: grid; grid-template-columns: .8fr 1.2fr; gap: 56px; align-items: start; }
 .authorityGrid h2 { max-width: 580px; }
 .authorityGrid p { margin: 0; color: #c2d2c9; line-height: 1.7; }

--- a/src/app/wondergreen/cultivos/[slug]/page.tsx
+++ b/src/app/wondergreen/cultivos/[slug]/page.tsx
@@ -2,20 +2,13 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { publicResources } from "@/data/public-resources";
 import { fieldApplicationRules, fieldChecklist, getWondergreenCrop, wondergreenCrops } from "@/data/wondergreen-crops";
+import { getWondergreenCropDocument } from "@/data/wondergreen-crop-documents";
 import { wondergreenReferences } from "@/data/wondergreen-public";
 import { getWondergreenVisualTone } from "@/data/wondergreen-visual";
 import styles from "../crops.module.css";
 import refresh from "../crops-refresh.module.css";
-
-const cropGuideResourceIds: Record<string, string> = {
-  cafe: "wondergreen-guide-cafe",
-  cacao: "wondergreen-guide-cacao",
-  aguacate: "wondergreen-guide-aguacate",
-  "limon-tahiti": "wondergreen-guide-limon-tahiti",
-  "pastos-gramineas": "wondergreen-guide-pastos",
-};
+import docStyles from "./crop-document.module.css";
 
 export function generateStaticParams() {
   return wondergreenCrops.map((crop) => ({ slug: crop.slug }));
@@ -25,9 +18,12 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params;
   const crop = getWondergreenCrop(slug);
   if (!crop) return { title: "Cultivo | Wondergreen" };
+  const guide = getWondergreenCropDocument(slug);
   return {
     title: `${crop.name} | Programa Wondergreen`,
-    description: `${crop.headline} Programa por etapa, contexto del lote, seguimiento y guía Wondergreen descargable.`,
+    description: guide
+      ? `${crop.headline} Consulta el programa navegable y abre la guía Wondergreen completa en PDF.`
+      : `${crop.headline} Programa por etapa, contexto del lote y seguimiento.`,
   };
 }
 
@@ -43,38 +39,93 @@ export default async function WondergreenCropPage({ params }: { params: Promise<
 
   const programFamilies = [...new Set(crop.stages.flatMap((stage) => stage.lines))];
   const references = relatedReferences(programFamilies);
-  const guideResourceId = cropGuideResourceIds[slug];
-  const guide = guideResourceId ? publicResources.find((resource) => resource.id === guideResourceId) : undefined;
+  const guide = getWondergreenCropDocument(slug);
 
   return (
     <div className={`${styles.page} ${refresh.page}`}>
       <main>
-        <section className={styles.hero}>
+        <section className={styles.hero} aria-labelledby="crop-title">
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Programa Wondergreen · {crop.name}</span>
-              <h1>{crop.headline}</h1>
+              <span className={styles.eyebrow}>{guide ? "Guía oficial Wondergreen" : "Programa Wondergreen"} · {crop.name}</span>
+              <h1 id="crop-title">{crop.headline}</h1>
               <p className={styles.lead}>{crop.intro}</p>
+              <p className={styles.lead}>{crop.context}</p>
             </div>
-            <aside className={`${styles.heroAside} ${guide?.coverImage ? styles.guideAside : ""}`}>
-              {guide?.coverImage ? (
-                <Image className={styles.guideCover} src={guide.coverImage} alt={`Portada de ${guide.title}`} width={640} height={905} sizes="(max-width: 900px) 50vw, 320px" priority unoptimized />
-              ) : null}
-              <div>
-                <strong>{guide ? "Guía completa disponible." : "Contexto antes de producto."}</strong>
-                <p>{guide ? `Consulta este programa en la web o abre la guía editorial completa para ${crop.name}.` : crop.context}</p>
-                {guide?.downloadHref ? (
-                  <div className={styles.guideActions}>
-                    <a className={`${styles.button} ${styles.primary}`} href={guide.downloadHref} target="_blank" rel="noreferrer">Descargar guía PDF ↓</a>
-                    <Link className={styles.guideLibraryLink} href="/biblioteca#recursos">Ver en Biblioteca →</Link>
+
+            {guide ? (
+              <aside className={docStyles.documentPanel} aria-label={`Documento oficial para ${crop.name}`}>
+                <div className={docStyles.coverWrap}>
+                  <Image
+                    className={docStyles.cover}
+                    src={guide.coverImage}
+                    alt={`Portada de ${guide.title}`}
+                    width={640}
+                    height={905}
+                    sizes="(max-width: 640px) 72vw, (max-width: 900px) 180px, 250px"
+                    priority
+                    unoptimized
+                  />
+                </div>
+                <div className={docStyles.documentCopy}>
+                  <span className={docStyles.documentStatus}>Documento completo publicado</span>
+                  <h2>{guide.title}</h2>
+                  <p>{guide.copy}</p>
+                  <div className={docStyles.documentMeta}>
+                    <div><span>Master</span><strong>{guide.masterLabel}</strong></div>
+                    <div><span>Autoridad</span><strong>{guide.sourceAuthority}</strong></div>
+                    <div><span>Entrega</span><strong>PDF público same-origin + contexto web navegable</strong></div>
                   </div>
-                ) : null}
-              </div>
-            </aside>
+                  <div className={docStyles.documentActions}>
+                    <a className={docStyles.openButton} href={guide.openHref} target="_blank" rel="noreferrer">Abrir PDF original ↗</a>
+                    <a className={docStyles.downloadButton} href={guide.attachmentHref}>Descargar PDF ↓</a>
+                    <Link className={docStyles.libraryButton} href="/biblioteca#recursos">Ver en Biblioteca →</Link>
+                  </div>
+                  <p className={docStyles.authorityNote}><strong>Autoridad documental:</strong> esta página organiza la navegación y el contexto. El PDF conserva el desarrollo editorial completo publicado.</p>
+                </div>
+              </aside>
+            ) : (
+              <aside className={styles.heroAside}>
+                <strong>Contexto antes de producto.</strong>
+                <p>{crop.context}</p>
+              </aside>
+            )}
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.sectionWhite}`}>
+        {guide ? (
+          <nav className={docStyles.documentNav} aria-label={`Contenido del programa ${crop.name}`}>
+            <div className={`${styles.container} ${docStyles.documentNavInner}`}>
+              <strong>En esta ruta</strong>
+              <a href="#etapas">Etapas</a>
+              <a href="#comprobaciones">Comprobaciones</a>
+              <a href="#seguimiento">Seguimiento</a>
+              <a href="#referencias">Productos relacionados</a>
+              <a href={guide.openHref} target="_blank" rel="noreferrer">PDF completo ↗</a>
+            </div>
+          </nav>
+        ) : null}
+
+        {guide ? (
+          <section className={docStyles.documentAuthority} aria-labelledby="document-authority-title">
+            <div className={`${styles.container} ${docStyles.authorityGrid}`}>
+              <div>
+                <span className={`${styles.eyebrow} ${refresh.eyebrowLight}`}>Documento + navegación</span>
+                <h2 id="document-authority-title">La web no reemplaza la guía. La hace más fácil de encontrar y recorrer.</h2>
+              </div>
+              <div>
+                <p>El programa web conecta etapas, comprobaciones de campo, alertas, seguimiento y referencias exactas del Product Master. Cuando necesitas el desarrollo editorial completo, la fuente publicada es la guía PDF asociada a este cultivo.</p>
+                <div className={docStyles.authorityFacts}>
+                  <article><span>01 · Documento</span><strong>{guide.masterLabel}</strong></article>
+                  <article><span>02 · Web</span><strong>Contexto navegable y enlaces a referencias gobernadas.</strong></article>
+                  <article><span>03 · Uso</span><strong>Orientación técnica; no sustituye una recomendación específica para el lote.</strong></article>
+                </div>
+              </div>
+            </div>
+          </section>
+        ) : null}
+
+        <section className={`${styles.section} ${styles.sectionWhite}`} id="etapas">
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Ruta por etapa</span>
@@ -93,7 +144,7 @@ export default async function WondergreenCropPage({ params }: { params: Promise<
           </div>
         </section>
 
-        <section className={styles.section}>
+        <section className={styles.section} id="comprobaciones">
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Antes de recomendar</span>
@@ -103,11 +154,11 @@ export default async function WondergreenCropPage({ params }: { params: Promise<
               <article className={styles.guidanceCard}><h3>Leer el lote</h3><ul>{fieldChecklist.map((item) => <li key={item}>{item}</li>)}</ul></article>
               <article className={styles.guidanceCard}><h3>Aplicar con contexto</h3><ul>{fieldApplicationRules.map((item) => <li key={item}>{item}</li>)}</ul></article>
             </div>
-            <div className={styles.truth}><strong>Programa Wondergreen:</strong> usa la ruta web para navegar por etapa y la guía descargable para consultar el desarrollo técnico completo del cultivo.</div>
+            <div className={styles.truth}><strong>Programa Wondergreen:</strong> la ruta web permite navegar por etapa y conectar referencias; {guide ? "la guía PDF conserva el desarrollo técnico editorial completo del cultivo." : "la recomendación final exige contexto de lote."}</div>
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.sectionDark}`}>
+        <section className={`${styles.section} ${styles.sectionDark}`} id="seguimiento">
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Alertas y seguimiento</span>
@@ -122,12 +173,12 @@ export default async function WondergreenCropPage({ params }: { params: Promise<
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.sectionWhite}`}>
+        <section className={`${styles.section} ${styles.sectionWhite}`} id="referencias">
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Product Master relacionado</span>
               <h2>Referencias que aparecen en este programa.</h2>
-              <p>Cada tarjeta abre la ficha pública de la referencia exacta y complementa la guía descargable.</p>
+              <p>Cada tarjeta abre la ficha pública de la referencia exacta. El PDF y el Product Master siguen siendo fuentes distintas: uno desarrolla el programa por cultivo y el otro gobierna la referencia de producto.</p>
             </div>
             <div className={styles.referenceGrid}>
               {references.map((reference) => {
@@ -148,9 +199,10 @@ export default async function WondergreenCropPage({ params }: { params: Promise<
 
         <section className={styles.closing}>
           <div className={`${styles.container} ${styles.closingInner}`}>
-            <div><span className={styles.eyebrow}>Siguiente decisión</span><h2>¿Quieres convertir esta ruta en un programa para tu lote?</h2></div>
+            <div><span className={styles.eyebrow}>Siguiente decisión</span><h2>¿Quieres llevar esta guía al contexto real de tu lote?</h2></div>
             <div className={styles.guideActions}>
-              {guide?.downloadHref ? <a className={`${styles.button} ${styles.primary}`} href={guide.downloadHref} target="_blank" rel="noreferrer">Descargar PDF</a> : null}
+              {guide ? <a className={`${styles.button} ${styles.primary}`} href={guide.openHref} target="_blank" rel="noreferrer">Abrir guía PDF</a> : null}
+              {guide ? <a className={styles.button} href={guide.attachmentHref}>Descargar PDF</a> : null}
               <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen#contacto">Hablar con equipo técnico</Link>
             </div>
           </div>

--- a/src/data/wondergreen-crop-documents.test.ts
+++ b/src/data/wondergreen-crop-documents.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getWondergreenCropDocument, wondergreenDocumentedCropSlugs } from "./wondergreen-crop-documents";
+
+describe("Wondergreen crop documents", () => {
+  it("keeps the five published crop programs attached to governed public PDF masters", () => {
+    expect(wondergreenDocumentedCropSlugs).toEqual([
+      "cafe",
+      "cacao",
+      "aguacate",
+      "limon-tahiti",
+      "pastos-gramineas",
+    ]);
+
+    for (const slug of wondergreenDocumentedCropSlugs) {
+      const document = getWondergreenCropDocument(slug);
+      expect(document).toBeDefined();
+      expect(document?.delivery).toBe("public-download");
+      expect(document?.openHref).toMatch(/^\/api\/public-resources\/wondergreen-guide-/);
+      expect(document?.attachmentHref).toBe(`${document?.openHref}?download=1`);
+      expect(document?.coverImage).toMatch(/^\/api\/public-media\//);
+      expect(document?.masterLabel).toMatch(/20 páginas/);
+      expect(document?.sourceAuthority).toContain("guía editorial publicada");
+      expect(JSON.stringify(document)).not.toMatch(/sharepoint|graph\.microsoft|https?:\/\//i);
+    }
+  });
+
+  it("fails closed when a crop has no published guide relationship", () => {
+    expect(getWondergreenCropDocument("banano")).toBeUndefined();
+  });
+});

--- a/src/data/wondergreen-crop-documents.ts
+++ b/src/data/wondergreen-crop-documents.ts
@@ -1,0 +1,47 @@
+import { publicResources, type PublicResource } from "./public-resources";
+
+const cropGuideResourceIds = {
+  cafe: "wondergreen-guide-cafe",
+  cacao: "wondergreen-guide-cacao",
+  aguacate: "wondergreen-guide-aguacate",
+  "limon-tahiti": "wondergreen-guide-limon-tahiti",
+  "pastos-gramineas": "wondergreen-guide-pastos",
+} as const;
+
+export type WondergreenDocumentedCropSlug = keyof typeof cropGuideResourceIds;
+
+export type WondergreenCropDocument = PublicResource & {
+  resourceId: string;
+  openHref: string;
+  attachmentHref: string;
+  coverImage: string;
+  masterLabel: string;
+};
+
+export const wondergreenDocumentedCropSlugs = Object.keys(cropGuideResourceIds) as WondergreenDocumentedCropSlug[];
+
+export function getWondergreenCropDocument(slug: string): WondergreenCropDocument | undefined {
+  if (!(slug in cropGuideResourceIds)) return undefined;
+  const resourceId = cropGuideResourceIds[slug as WondergreenDocumentedCropSlug];
+  const resource = publicResources.find((item) => item.id === resourceId);
+
+  if (
+    !resource ||
+    resource.kind !== "guide" ||
+    resource.delivery !== "public-download" ||
+    !resource.downloadHref ||
+    !resource.coverImage ||
+    !resource.masterLabel
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...resource,
+    resourceId,
+    openHref: resource.downloadHref,
+    attachmentHref: `${resource.downloadHref}?download=1`,
+    coverImage: resource.coverImage,
+    masterLabel: resource.masterLabel,
+  };
+}


### PR DESCRIPTION
## Objetivo
Convertir las rutas `/wondergreen/cultivos/[slug]` en una capa documental real: la web contextualiza y navega, mientras el PDF publicado permanece como documento completo y autoridad editorial.

## Cambios
- Relación gobernada única entre los cinco cultivos publicados y sus masters PDF.
- Hero document-first con portada real, master, autoridad de fuente y estado de entrega.
- Acciones separadas para abrir el PDF inline y descargarlo como attachment.
- API pública soporta `?download=1` sin exponer URLs privadas ni credenciales.
- Navegación interna por etapas, comprobaciones, seguimiento y referencias relacionadas.
- Bloque explícito de autoridad: web ≠ PDF ≠ Product Master.
- Product Master exacto sigue conectado por referencia y estado público.
- Cobertura E2E para Café, Cacao, Aguacate, Limón Tahití y Pastos/Gramíneas.
- Unit contract para evitar que un cultivo sin master publicado fabrique una guía.

## Truth / Brand locks
- No se reconstruye ni resume como sustituto el contenido integral de los PDFs aprobados.
- No se inventan dosis, frecuencias, compatibilidades, eficacia o resultados.
- El PDF completo se sirve same-origin; SharePoint/Graph permanece server-only.
- Las referencias de producto siguen gobernadas por Product Master.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile