### PR TITLE
feat(wondergreen): convierte cultivos en biblioteca documental V2.2

### DIFF
--- a/e2e/wondergreen-crop-library.spec.ts
+++ b/e2e/wondergreen-crop-library.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+
+const cropGuides = [
+  ["Café", "cafe", "Guía Wondergreen para café", "wondergreen-guide-cafe"],
+  ["Cacao", "cacao", "Guía Wondergreen para cacao", "wondergreen-guide-cacao"],
+  ["Aguacate", "aguacate", "Guía Wondergreen para aguacate", "wondergreen-guide-aguacate"],
+  ["Limón Tahití", "limon-tahiti", "Guía Wondergreen para limón Tahití", "wondergreen-guide-limon-tahiti"],
+  ["Pastos y gramíneas", "pastos-gramineas", "Guía Wondergreen para pastos y gramíneas", "wondergreen-guide-pastos"],
+] as const;
+
+test("crop index makes every published guide directly visible without replacing the program route", async ({ page }) => {
+  await page.goto("/wondergreen/cultivos");
+
+  await expect(page.getByRole("heading", { name: "El cultivo cambia la pregunta." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Cinco programas. Cinco guías completas." })).toBeVisible();
+  await expect(page.getByText("5", { exact: true })).toHaveCount(2);
+
+  for (const [crop, slug, guideTitle, resourceId] of cropGuides) {
+    const card = page.getByRole("article").filter({
+      has: page.getByRole("heading", { name: crop, exact: true }),
+    }).filter({
+      has: page.getByRole("img", { name: `Portada de ${guideTitle}` }),
+    });
+
+    await expect(card).toHaveCount(1);
+    await expect(card.getByText("Guía PDF publicada", { exact: true })).toBeVisible();
+    await expect(card.getByText(/20 páginas/i)).toBeVisible();
+    await expect(card.getByRole("link", { name: "Abrir programa →" })).toHaveAttribute("href", `/wondergreen/cultivos/${slug}`);
+    await expect(card.getByRole("link", { name: "Abrir PDF ↗" })).toHaveAttribute("href", `/api/public-resources/${resourceId}`);
+    await expect(card.getByRole("link", { name: "Descargar ↓" })).toHaveAttribute("href", `/api/public-resources/${resourceId}?download=1`);
+  }
+});
+
+test("crop library keeps guide, web program and Product Master responsibilities separate", async ({ page }) => {
+  await page.goto("/wondergreen/cultivos");
+
+  await expect(page.getByRole("heading", { name: "Tres capas, tres responsabilidades distintas." })).toBeVisible();
+  await expect(page.getByText("Guía PDF", { exact: true })).toBeVisible();
+  await expect(page.getByText("Programa web", { exact: true })).toBeVisible();
+  await expect(page.getByText("Product Master", { exact: true })).toBeVisible();
+  await expect(page.getByText(/no los fusiona en una sola fuente/i)).toBeVisible();
+  await expect(page.getByText(/no se interprete como dosis cerrada/i)).toBeVisible();
+
+  await expect(page.getByRole("link", { name: "Usar Finder Wondergreen" }).first()).toHaveAttribute("href", "/wondergreen/finder");
+  await expect(page.getByRole("link", { name: "Ver Product Master" })).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(page.getByRole("link", { name: "Abrir Biblioteca técnica" })).toHaveAttribute("href", "/biblioteca");
+});

--- a/e2e/wondergreen-crop-library.spec.ts
+++ b/e2e/wondergreen-crop-library.spec.ts
@@ -41,7 +41,7 @@ test("crop library keeps guide, web program and Product Master responsibilities 
   await expect(page.getByText("Programa web", { exact: true })).toBeVisible();
   await expect(page.getByText("Product Master", { exact: true })).toBeVisible();
   await expect(page.getByText(/no los fusiona en una sola fuente/i)).toBeVisible();
-  await expect(page.getByText(/no se interprete como dosis cerrada/i)).toBeVisible();
+  await expect(page.getByText(/evita que una guía general se interprete como dosis cerrada/i)).toBeVisible();
 
   await expect(page.getByRole("link", { name: "Usar Finder Wondergreen" }).first()).toHaveAttribute("href", "/wondergreen/finder");
   await expect(page.getByRole("link", { name: "Ver Product Master" })).toHaveAttribute("href", "/wondergreen/productos");

--- a/e2e/wondergreen-crop-library.spec.ts
+++ b/e2e/wondergreen-crop-library.spec.ts
@@ -44,6 +44,6 @@ test("crop library keeps guide, web program and Product Master responsibilities 
   await expect(page.getByText(/evita que una guía general se interprete como dosis cerrada/i)).toBeVisible();
 
   await expect(page.getByRole("link", { name: "Usar Finder Wondergreen" }).first()).toHaveAttribute("href", "/wondergreen/finder");
-  await expect(page.getByRole("link", { name: "Ver Product Master" })).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(page.getByRole("link", { name: "Ver Product Master", exact: true })).toHaveAttribute("href", "/wondergreen/productos");
   await expect(page.getByRole("link", { name: "Abrir Biblioteca técnica" })).toHaveAttribute("href", "/biblioteca");
 });

--- a/e2e/wondergreen-crop-library.spec.ts
+++ b/e2e/wondergreen-crop-library.spec.ts
@@ -13,7 +13,9 @@ test("crop index makes every published guide directly visible without replacing 
 
   await expect(page.getByRole("heading", { name: "El cultivo cambia la pregunta." })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Cinco programas. Cinco guías completas." })).toBeVisible();
-  await expect(page.getByText("5", { exact: true })).toHaveCount(2);
+  const summary = page.getByLabel("Resumen de la biblioteca por cultivo");
+  await expect(summary.getByText("5", { exact: true })).toHaveCount(2);
+  await expect(summary.getByText("3", { exact: true })).toHaveCount(1);
 
   for (const [crop, slug, guideTitle, resourceId] of cropGuides) {
     const card = page.getByRole("article").filter({

--- a/e2e/wondergreen-finder.spec.ts
+++ b/e2e/wondergreen-finder.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 test("crop library exposes the governed Wondergreen Finder", async ({ page }) => {
   await page.goto("/wondergreen/cultivos");
-  await expect(page.getByRole("link", { name: "Abrir Finder Wondergreen" })).toHaveAttribute("href", "/wondergreen/finder");
+  await expect(page.getByRole("link", { name: "Usar Finder Wondergreen" }).first()).toHaveAttribute("href", "/wondergreen/finder");
 });
 
 test("Wondergreen Finder is limited to the five published crop programs", async ({ page }) => {

--- a/src/app/wondergreen/cultivos/crops-library.module.css
+++ b/src/app/wondergreen/cultivos/crops-library.module.css
@@ -1,0 +1,249 @@
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+.heroSecondary {
+  background: transparent;
+  border-color: rgba(47, 125, 50, .35) !important;
+  color: #2f7d32 !important;
+}
+
+.librarySummary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 26px;
+}
+
+.librarySummary article {
+  padding: 18px;
+  border: 1px solid rgba(6, 61, 44, .13);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, .78);
+}
+
+.librarySummary strong {
+  display: block;
+  color: #063d2c;
+  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, Georgia, serif;
+  font-size: 1.65rem;
+  line-height: 1;
+}
+
+.librarySummary span {
+  display: block;
+  margin-top: 7px;
+  color: #65776e;
+  font-size: .74rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.guideGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.guideCard {
+  display: grid;
+  grid-template-columns: 176px minmax(0, 1fr);
+  min-height: 330px;
+  overflow: hidden;
+  border: 1px solid rgba(6, 61, 44, .14);
+  border-radius: 26px;
+  background: #fff;
+  box-shadow: 0 18px 46px rgba(6, 61, 44, .07);
+}
+
+.guideVisual {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  padding: 18px;
+  background: linear-gradient(155deg, #edf5e9, #f8faf7);
+}
+
+.guideCover {
+  display: block;
+  width: 100%;
+  height: auto;
+  border: 1px solid rgba(6, 61, 44, .14);
+  border-radius: 12px;
+  box-shadow: 0 18px 38px rgba(6, 61, 44, .14);
+}
+
+.guideBody {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 24px;
+}
+
+.guideStatus {
+  display: inline-flex;
+  align-self: flex-start;
+  min-height: 26px;
+  align-items: center;
+  padding: 0 9px;
+  border-radius: 999px;
+  background: #e7f2e2;
+  color: #2f7d32;
+  font-size: .66rem;
+  font-weight: 900;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.guideBody h3 {
+  margin-top: 13px !important;
+  font-size: 1.75rem !important;
+}
+
+.guideHeadline {
+  margin: 9px 0 0;
+  color: #43564d;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.guideIntro {
+  color: #65776e;
+  font-size: .9rem;
+  line-height: 1.55;
+}
+
+.guideMeta {
+  display: grid;
+  gap: 7px;
+  margin: auto 0 18px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(6, 61, 44, .1);
+}
+
+.guideMeta span {
+  color: #65776e;
+  font-size: .72rem;
+  line-height: 1.4;
+}
+
+.guideMeta strong {
+  color: #263b32;
+}
+
+.guideActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+}
+
+.programLink,
+.pdfLink,
+.downloadLink {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0 14px;
+  font-size: .78rem;
+  font-weight: 900;
+}
+
+.programLink {
+  background: #2f7d32;
+  color: #fff !important;
+}
+
+.pdfLink {
+  border: 1px solid #2f7d32;
+  color: #2f7d32 !important;
+}
+
+.downloadLink {
+  padding-inline: 4px;
+  color: #2f7d32 !important;
+}
+
+.fallbackCard {
+  display: flex;
+  min-height: 280px;
+  flex-direction: column;
+  padding: 26px;
+  border: 1px solid rgba(6, 61, 44, .14);
+  border-radius: 24px;
+  background: #fff;
+}
+
+.fallbackCard p { color: #65776e; }
+.fallbackCard a { margin-top: auto; color: #2f7d32 !important; font-weight: 900; }
+
+.authorityBand {
+  padding: 76px 0;
+  background: #063d2c;
+  color: #fff;
+}
+
+.authorityGrid {
+  display: grid;
+  grid-template-columns: .8fr 1.2fr;
+  gap: 56px;
+  align-items: start;
+}
+
+.authorityEyebrow { color: #9bcf72 !important; }
+.authorityGrid p { margin: 0; color: #c3d2cb; line-height: 1.7; }
+
+.authorityList {
+  display: grid;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.authorityList article {
+  display: grid;
+  grid-template-columns: 42px 1fr;
+  gap: 14px;
+  padding: 17px 18px;
+  border: 1px solid rgba(255, 255, 255, .13);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, .055);
+}
+
+.authorityList span {
+  color: #9bcf72;
+  font-size: .7rem;
+  font-weight: 900;
+}
+
+.authorityList strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: .93rem;
+}
+
+.authorityList small { color: #c3d2cb; line-height: 1.45; }
+
+@media (max-width: 980px) {
+  .guideGrid { grid-template-columns: 1fr; }
+  .authorityGrid { grid-template-columns: 1fr; gap: 28px; }
+}
+
+@media (max-width: 700px) {
+  .librarySummary { grid-template-columns: 1fr; }
+  .guideCard { grid-template-columns: 132px minmax(0, 1fr); }
+  .guideBody { padding: 20px; }
+  .guideBody h3 { font-size: 1.45rem !important; }
+}
+
+@media (max-width: 520px) {
+  .guideCard { grid-template-columns: 1fr; }
+  .guideVisual { min-height: auto; }
+  .guideCover { width: min(58%, 210px); }
+  .guideActions { align-items: stretch; }
+  .programLink, .pdfLink { width: 100%; }
+}

--- a/src/app/wondergreen/cultivos/layout.tsx
+++ b/src/app/wondergreen/cultivos/layout.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
 import { publicSocialMetadata } from "@/lib/public-social-metadata";
 
+const description = "Programas Wondergreen por cultivo con guías PDF publicadas, lectura por etapa, contexto agronómico y referencias relacionadas.";
+
 const social = publicSocialMetadata({
   title: "Cultivos | Wondergreen",
-  description: "Programas orientativos Wondergreen por cultivo, etapa, condición del lote y objetivo agronómico.",
+  description,
   path: "/wondergreen/cultivos",
 });
 

--- a/src/app/wondergreen/cultivos/page.tsx
+++ b/src/app/wondergreen/cultivos/page.tsx
@@ -1,47 +1,92 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
+import { getWondergreenCropDocument } from "@/data/wondergreen-crop-documents";
 import { wondergreenCrops } from "@/data/wondergreen-crops";
 import styles from "./crops.module.css";
 import refresh from "./crops-refresh.module.css";
+import library from "./crops-library.module.css";
 
 export const metadata: Metadata = {
   title: "Cultivos | Wondergreen",
-  description: "Programas orientativos Wondergreen por cultivo, etapa, condición del lote y objetivo agronómico.",
+  description: "Programas Wondergreen por cultivo con guías PDF publicadas, lectura por etapa, contexto agronómico y referencias relacionadas.",
 };
 
 export default function WondergreenCropsPage() {
+  const entries = wondergreenCrops.map((crop) => ({ crop, guide: getWondergreenCropDocument(crop.slug) }));
+  const publishedGuides = entries.filter((entry) => entry.guide).length;
+
   return (
     <div className={`${styles.page} ${refresh.page}`}>
       <main>
-        <section className={styles.hero}>
+        <section className={styles.hero} aria-labelledby="crop-library-title">
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Wondergreen · por cultivo</span>
-              <h1>El cultivo cambia la pregunta.</h1>
-              <p className={styles.lead}>Una misma referencia no debe explicarse igual para café, cacao, aguacate, cítricos o pastos. Estas rutas convierten las guías ya construidas en programas web orientativos, con alertas y seguimiento.</p>
-              <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen/finder">Abrir Finder Wondergreen</Link>
+              <span className={styles.eyebrow}>Wondergreen · cultivos + documentos</span>
+              <h1 id="crop-library-title">El cultivo cambia la pregunta.</h1>
+              <p className={styles.lead}>Café, cacao, aguacate, limón Tahití y pastos tienen recorridos distintos. Aquí puedes entrar al programa web o abrir directamente la guía PDF publicada de cada cultivo, sin convertir una orientación general en una receta automática.</p>
+              <div className={library.heroActions}>
+                <a className={`${styles.button} ${styles.primary}`} href="#guias">Explorar guías</a>
+                <Link className={`${styles.button} ${library.heroSecondary}`} href="/wondergreen/finder">Usar Finder Wondergreen</Link>
+                <Link className={`${styles.button} ${library.heroSecondary}`} href="/wondergreen/productos">Ver Product Master</Link>
+              </div>
+              <div className={library.librarySummary} aria-label="Resumen de la biblioteca por cultivo">
+                <article><strong>{wondergreenCrops.length}</strong><span>programas por cultivo publicados</span></article>
+                <article><strong>{publishedGuides}</strong><span>guías PDF vinculadas a sus rutas</span></article>
+                <article><strong>3</strong><span>capas separadas: guía, programa web y Product Master</span></article>
+              </div>
             </div>
             <aside className={styles.heroAside}>
-              <strong>No es una receta automática.</strong>
-              <p>Cada programa debe cruzarse con etapa real, suelo, agua, manejo, carga productiva y análisis disponibles antes de cerrar una recomendación.</p>
+              <strong>Documento primero cuando necesitas profundidad.</strong>
+              <p>La guía conserva el desarrollo editorial completo. La ruta web ayuda a navegar etapas, alertas y seguimiento. El Product Master gobierna la referencia concreta de producto.</p>
             </aside>
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.sectionWhite}`}>
+        <section className={`${styles.section} ${styles.sectionWhite}`} id="guias" aria-labelledby="guide-library-title">
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
-              <span className={styles.eyebrow}>Biblioteca inicial</span>
-              <h2>Cinco programas técnicos ya estructurados.</h2>
-              <p>Los conservamos desde el trabajo previo y los hacemos navegables sin forzarlos a una secuencia idéntica.</p>
+              <span className={styles.eyebrow}>Biblioteca por cultivo</span>
+              <h2 id="guide-library-title">Cinco programas. Cinco guías completas.</h2>
+              <p>Cada entrada mantiene visibles el documento publicado y la ruta web. Puedes leer el contexto navegable, abrir el PDF original o descargarlo sin pasar por una fuente privada.</p>
             </div>
-            <div className={styles.cropGrid}>
-              {wondergreenCrops.map((crop) => (
-                <article className={styles.cropCard} key={crop.slug}>
-                  <span className={styles.eyebrow}>Programa de campo</span>
+
+            <div className={library.guideGrid}>
+              {entries.map(({ crop, guide }) => guide ? (
+                <article className={library.guideCard} key={crop.slug}>
+                  <div className={library.guideVisual}>
+                    <Image
+                      className={library.guideCover}
+                      src={guide.coverImage}
+                      alt={`Portada de ${guide.title}`}
+                      width={640}
+                      height={905}
+                      sizes="(max-width: 520px) 58vw, 176px"
+                      unoptimized
+                    />
+                  </div>
+                  <div className={library.guideBody}>
+                    <span className={library.guideStatus}>Guía PDF publicada</span>
+                    <h3>{crop.name}</h3>
+                    <p className={library.guideHeadline}>{crop.headline}</p>
+                    <p className={library.guideIntro}>{crop.intro}</p>
+                    <div className={library.guideMeta}>
+                      <span><strong>Documento:</strong> {guide.masterLabel}</span>
+                      <span><strong>Fuente:</strong> {guide.sourceAuthority}</span>
+                    </div>
+                    <div className={library.guideActions}>
+                      <Link className={library.programLink} href={`/wondergreen/cultivos/${crop.slug}`}>Abrir programa →</Link>
+                      <a className={library.pdfLink} href={guide.openHref} target="_blank" rel="noreferrer">Abrir PDF ↗</a>
+                      <a className={library.downloadLink} href={guide.attachmentHref}>Descargar ↓</a>
+                    </div>
+                  </div>
+                </article>
+              ) : (
+                <article className={library.fallbackCard} key={crop.slug}>
+                  <span className={styles.eyebrow}>Programa web</span>
                   <h3>{crop.name}</h3>
                   <p>{crop.headline}</p>
-                  <p>{crop.intro}</p>
+                  <p>La ruta está disponible, pero no se publica un PDF hasta que exista una relación documental gobernada.</p>
                   <Link href={`/wondergreen/cultivos/${crop.slug}`}>Abrir programa →</Link>
                 </article>
               ))}
@@ -49,16 +94,34 @@ export default function WondergreenCropsPage() {
           </div>
         </section>
 
-        <section className={styles.section}>
+        <section className={library.authorityBand} aria-labelledby="crop-authority-title">
+          <div className={`${styles.container} ${library.authorityGrid}`}>
+            <div>
+              <span className={`${styles.eyebrow} ${library.authorityEyebrow}`}>Cómo leer esta biblioteca</span>
+              <h2 id="crop-authority-title">Tres capas, tres responsabilidades distintas.</h2>
+            </div>
+            <div>
+              <p>Wondergreen conecta conocimiento, contexto de campo y referencias de producto, pero no los fusiona en una sola fuente. La separación evita que una guía general se interprete como dosis cerrada o que una ficha comercial se convierta en recomendación agronómica automática.</p>
+              <div className={library.authorityList}>
+                <article><span>01</span><div><strong>Guía PDF</strong><small>Conserva el desarrollo editorial completo publicado para el cultivo.</small></div></article>
+                <article><span>02</span><div><strong>Programa web</strong><small>Organiza etapa, contexto, alertas, seguimiento y navegación hacia referencias relacionadas.</small></div></article>
+                <article><span>03</span><div><strong>Product Master</strong><small>Gobierna formulación, formato, condición pública y ficha exacta de cada referencia.</small></div></article>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section} aria-labelledby="crop-flow-title">
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
-              <span className={styles.eyebrow}>Principio de uso</span>
-              <h2>Cultivo → etapa → objetivo → contexto → solución potencial.</h2>
-              <p>Las páginas de cultivo son una capa de orientación. El Finder organiza cultivo, etapa y evidencia disponible; después, el Product Master permite revisar una ficha concreta sin confundir pertinencia agronómica con disponibilidad comercial.</p>
+              <span className={styles.eyebrow}>Cuando todavía no sabes qué revisar</span>
+              <h2 id="crop-flow-title">Cultivo → etapa → objetivo → contexto → solución potencial.</h2>
+              <p>Si ya conoces el cultivo, entra a su guía o programa. Si todavía necesitas organizar etapa y evidencia disponible, el Finder funciona como orientación secundaria. Después puedes revisar la referencia exacta en Product Master.</p>
             </div>
-            <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+            <div className={library.heroActions}>
               <Link className={`${styles.button} ${styles.primary}`} href="/wondergreen/finder">Usar Finder Wondergreen</Link>
               <Link className={styles.button} href="/wondergreen/productos">Explorar Product Master</Link>
+              <Link className={styles.button} href="/biblioteca">Abrir Biblioteca técnica</Link>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Objetivo
Hacer que `/wondergreen/cultivos` sea la entrada documental real a los cinco programas publicados: el usuario puede reconocer cada cultivo, ver la portada de su guía, entrar al programa web o abrir/descargar el PDF sin pasar primero por Finder.

## Cambios
- Biblioteca visual con Café, Cacao, Aguacate, Limón Tahití y Pastos/Gramíneas.
- Portadas gobernadas de las cinco guías publicadas.
- Estado documental y master visible por cultivo.
- Acciones separadas: `Abrir programa`, `Abrir PDF` y `Descargar`.
- Hero mantiene `El cultivo cambia la pregunta.` y deja Finder como orientación secundaria.
- Product Master permanece como capa separada para la referencia exacta.
- Nueva explicación pública de las tres autoridades: Guía PDF / Programa web / Product Master.
- SEO/social description actualizado al estado documental real.
- Cobertura E2E de las cinco rutas, portadas y enlaces PDF same-origin.

## Truth / Brand locks
- No se inventan cultivos ni documentos adicionales.
- Si una relación documental desaparece, la UI falla cerrada y muestra solo el programa web.
- La guía no se presenta como dosis automática ni sustituye una recomendación específica.
- Finder permanece secundario; Product Master gobierna la referencia de producto.
- No se exponen fuentes privadas.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile