### PR TITLE
feat(solutions): prioriza servicios y entregables V2.1

### DIFF
--- a/e2e/public-initial-diagnostic.spec.ts
+++ b/e2e/public-initial-diagnostic.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 test("solutions uncertainty CTA opens the initial diagnostic instead of the technical service", async ({ page }) => {
   await page.goto("/soluciones");
-  const start = page.getByRole("link", { name: "No sé por dónde empezar", exact: true });
+  const start = page.getByRole("link", { name: "Usar orientador inicial", exact: true });
   await expect(start).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
   await start.click();
   await expect(page).toHaveURL(/\/soluciones\/diagnostico-inicial$/);

--- a/e2e/public-seo-contract.spec.ts
+++ b/e2e/public-seo-contract.spec.ts
@@ -11,6 +11,8 @@ const publicRoutes = [
   "/soluciones/propiedad-horizontal",
   "/soluciones/plantas",
   "/soluciones/diagnostico-caracterizacion",
+  "/soluciones/gestion-juridica-regulatoria",
+  "/soluciones/valorizacion-productos",
   "/wondergreen",
   "/wondergreen/cultivos",
   "/wondergreen/cultivos/cafe",

--- a/e2e/public-shell-seo.spec.ts
+++ b/e2e/public-shell-seo.spec.ts
@@ -6,7 +6,8 @@ const shellRoutes = [
   "/soluciones", "/soluciones/esp", "/soluciones/municipios", "/soluciones/empresas",
   "/soluciones/propiedad-horizontal", "/soluciones/plantas",
   "/soluciones/residuos-organicos", "/soluciones/infraestructura-plantas", "/soluciones/propiedad-horizontal-redes",
-  "/soluciones/diagnostico-caracterizacion", "/recursos", "/proyectos", "/proyectos/yarumal", "/impacto",
+  "/soluciones/diagnostico-caracterizacion", "/soluciones/gestion-juridica-regulatoria", "/soluciones/valorizacion-productos",
+  "/recursos", "/proyectos", "/proyectos/yarumal", "/impacto",
   "/biblioteca", "/biblioteca/guia-deficiencias", "/nosotros", "/contacto",
 ];
 
@@ -132,6 +133,8 @@ test("sitemap exposes canonical audience routes while legacy combined routes sta
     "/soluciones/infraestructura-plantas",
     "/soluciones/propiedad-horizontal-redes",
     "/soluciones/diagnostico-caracterizacion",
+    "/soluciones/gestion-juridica-regulatoria",
+    "/soluciones/valorizacion-productos",
     "/recursos",
     "/biblioteca",
   ]) expect(sitemapText).toContain(`https://greenatics.com.co${path}`);

--- a/e2e/public-social.spec.ts
+++ b/e2e/public-social.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 
 const routes = [
+  "/soluciones/gestion-juridica-regulatoria",
+  "/soluciones/valorizacion-productos",
   "/wondergreen",
   "/wondergreen/cultivos",
   "/wondergreen/cultivos/cafe",

--- a/e2e/public-solutions.spec.ts
+++ b/e2e/public-solutions.spec.ts
@@ -19,26 +19,16 @@ async function clickDigitalBridge(page: import("@playwright/test").Page) {
   await page.getByRole("dialog", { name: "Navegación Greenatics" }).getByRole("link", { name: "Ingresar", exact: true }).click();
 }
 
-test("solutions hub routes by audience, service family, process and evidence", async ({ page }) => {
+test("solutions hub leads with services and keeps orientation secondary", async ({ page }) => {
   await page.goto("/soluciones");
 
-  await expect(page.getByRole("heading", { name: /Empieza por tu contexto. Después elegimos el servicio./i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Servicios para convertir necesidades de gestión en resultados concretos./i })).toBeVisible();
   await expect(page.getByRole("img", { name: "Vista aérea documentada del caso Greenatics en Yarumal", exact: true })).toBeVisible();
-  await expect(page.getByRole("link", { name: "No sé por dónde empezar", exact: true })).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
+  await expect(page.getByRole("link", { name: "Ver servicios y entregables", exact: true })).toHaveAttribute("href", "#servicios");
 
-  for (const audience of [
-    "ESP / Prestadores",
-    "Municipios",
-    "Empresas / Grandes generadores",
-    "Propiedad horizontal / Instituciones",
-    "Plantas / Operadores",
-  ]) {
-    await expect(page.getByRole("heading", { name: audience, exact: true })).toBeVisible();
-  }
-
-  await expect(page.getByRole("heading", { name: "Ocho familias para contratar actividades y resultados concretos." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Ocho familias para contratar actividades, entregables y capacidad de ejecución." })).toBeVisible();
   for (const family of [
-    "Diagnóstico y gestión de residuos",
+    "Caracterización y línea base",
     "Planeación y programas",
     "Gestión jurídica y regulatoria",
     "Rutas y logística",
@@ -50,15 +40,32 @@ test("solutions hub routes by audience, service family, process and evidence", a
     await expect(page.getByRole("heading", { name: family, exact: true })).toBeVisible();
   }
 
-  await expect(page.getByRole("link", { name: /Diagnóstico y gestión de residuos/ })).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
+  await expect(page.getByRole("link", { name: /Caracterización y línea base/ })).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
+  await expect(page.getByRole("link", { name: /Gestión jurídica y regulatoria/ })).toHaveAttribute("href", "/soluciones/gestion-juridica-regulatoria");
   await expect(page.getByRole("link", { name: /Rutas y logística/ })).toHaveAttribute("href", "/soluciones/rutas-selectivas");
   await expect(page.getByRole("link", { name: /Datos, trazabilidad y OPS/ })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
+  await expect(page.getByRole("link", { name: /Valorización y desarrollo de productos/ })).toHaveAttribute("href", "/soluciones/valorizacion-productos");
 
-  await expect(page.getByRole("heading", { name: "El diagnóstico ordena la ruta; no reemplaza el servicio." })).toBeVisible();
+  for (const audience of [
+    "ESP / Prestadores",
+    "Municipios",
+    "Empresas / Grandes generadores",
+    "Propiedad horizontal / Instituciones",
+    "Plantas / Operadores",
+  ]) {
+    await expect(page.getByRole("heading", { name: audience, exact: true })).toBeVisible();
+  }
+
+  const serviceTop = await page.locator("#servicios").evaluate((element) => (element as HTMLElement).offsetTop);
+  const audienceTop = await page.locator("#audiencias").evaluate((element) => (element as HTMLElement).offsetTop);
+  expect(serviceTop).toBeLessThan(audienceTop);
+
+  await expect(page.getByRole("heading", { name: "El servicio define el resultado; la línea base solo entra cuando es necesaria." })).toBeVisible();
   await expect(page.getByRole("heading", { name: /Antes de reemplazar una planta/ })).toBeVisible();
   await expect(page.getByRole("img", { name: "Segunda vista aérea documentada del caso Greenatics en Yarumal", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: /La consultoría gana valor cuando la información sigue viva después del informe./i })).toBeVisible();
-  await expect(page.getByRole("heading", { name: /Si todavía no sabes qué contratar, empieza por una línea base./i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /¿No sabes cuál de estas soluciones corresponde a tu caso?/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Usar orientador inicial", exact: true })).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
 });
 
 test("ESP READY keeps the ten sourced preparation dimensions and decision outputs", async ({ page }) => {
@@ -115,22 +122,50 @@ test("PMIRS RED separates unit-level implementation from network intelligence", 
   await expect(page.getByText(/24 no es un mínimo ni una promesa universal/i)).toBeVisible();
 });
 
-test("diagnostic service separates technical measurement from regulatory aforo", async ({ page }) => {
+test("service detail puts deliverables before activities and keeps diagnosis conditional", async ({ page }) => {
   await page.goto("/soluciones/diagnostico-caracterizacion");
 
   await expect(page.getByRole("heading", { name: "Diagnóstico y caracterización de residuos orgánicos" })).toBeVisible();
   await expect(page.getByText("Qué problema busca resolver", { exact: true })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Qué puede incluir" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Entregables típicos" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Qué recibe", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Qué hacemos", exact: true })).toBeVisible();
   await expect(page.getByText("mediciones de generación y caracterización", { exact: true })).toBeVisible();
   await expect(page.getByText("aforos y caracterización", { exact: true })).toHaveCount(0);
   await expect(page.getByText("Alcance y precisión", { exact: true })).toBeVisible();
   await expect(page.getByText(/no constituyen por sí solas un aforo regulatorio/i)).toBeVisible();
+  await expect(page.getByText(/la línea base o el diagnóstico se incorpora como una actividad inicial; no sustituye el servicio contratado/i)).toBeVisible();
 
   const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
   expect(breadcrumbs).toHaveLength(1);
   expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/diagnostico-caracterizacion");
   expect(JSON.stringify(breadcrumbs[0])).toContain("Diagnóstico y caracterización de residuos orgánicos");
+});
+
+test("legal and regulatory family has a deep commercial route with authority guardrails", async ({ page }) => {
+  await page.goto("/soluciones/gestion-juridica-regulatoria");
+
+  await expect(page.getByRole("heading", { name: "Gestión jurídica y regulatoria para residuos, aseo y proyectos." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Qué recibe", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Qué hacemos", exact: true })).toBeVisible();
+  await expect(page.getByText("matriz de obligaciones, competencias y responsables según el alcance", { exact: true })).toBeVisible();
+  await expect(page.getByText(/no sustituye a la autoridad competente ni garantiza decisiones administrativas/i)).toBeVisible();
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/gestion-juridica-regulatoria");
+});
+
+test("valorization family reaches product preparation without inventing approvals or claims", async ({ page }) => {
+  await page.goto("/soluciones/valorizacion-productos");
+
+  await expect(page.getByRole("heading", { name: "Convertir una salida del proceso en un producto técnicamente preparado para vender." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Qué recibe", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Qué hacemos", exact: true })).toBeVisible();
+  await expect(page.getByText("matriz de preparación comercial para llevar el producto a una condición vendible", { exact: true })).toBeVisible();
+  await expect(page.getByText(/no presenta como aprobado, certificado o eficaz aquello que todavía está en validación/i)).toBeVisible();
+  await expect(page.getByText(/registros, certificaciones, autorizaciones y resultados de laboratorio dependen/i)).toBeVisible();
+
+  const breadcrumbs = await jsonLdByType(page, "BreadcrumbList");
+  expect(JSON.stringify(breadcrumbs[0])).toContain("https://greenatics.com.co/soluciones/valorizacion-productos");
 });
 
 test("PGIRS and plant operation expose their responsibility boundaries", async ({ page }) => {

--- a/src/app/soluciones/[slug]/page.tsx
+++ b/src/app/soluciones/[slug]/page.tsx
@@ -45,6 +45,10 @@ export default async function SolutionDetailPage({ params }: Props) {
                 <span className={styles.eyebrow}>{service.audience} · {service.category}</span>
                 <h1>{service.name}</h1>
                 <p className={styles.detailLead}>{service.summary}</p>
+                <div className={styles.actions}>
+                  <a className={`${styles.button} ${styles.primary}`} href="#entregables">Ver qué recibe el cliente</a>
+                  <Link className={styles.button} href="/contacto">Solicitar conversación comercial</Link>
+                </div>
               </div>
               <aside className={styles.detailAside}>
                 <span>Problema de partida</span>
@@ -58,13 +62,13 @@ export default async function SolutionDetailPage({ params }: Props) {
         <section className={styles.detailBody}>
           <div className={styles.container}>
             <div className={styles.detailColumns}>
-              <article className={styles.listBox}>
+              <article className={styles.listBox} id="entregables">
                 <span className={styles.detailIndex}>01</span>
-                <div><span className={styles.eyebrow}>Alcance posible</span><h2>Qué puede incluir</h2><ul>{service.includes.map((item) => <li key={item}>{item}</li>)}</ul></div>
+                <div><span className={styles.eyebrow}>Resultado contratado</span><h2>Qué recibe</h2><ul>{service.deliverables.map((item) => <li key={item}>{item}</li>)}</ul></div>
               </article>
               <article className={styles.listBox}>
                 <span className={styles.detailIndex}>02</span>
-                <div><span className={styles.eyebrow}>Salida esperada</span><h2>Entregables típicos</h2><ul>{service.deliverables.map((item) => <li key={item}>{item}</li>)}</ul></div>
+                <div><span className={styles.eyebrow}>Actividades y alcance</span><h2>Qué hacemos</h2><ul>{service.includes.map((item) => <li key={item}>{item}</li>)}</ul></div>
               </article>
             </div>
             {service.scopeNote ? (
@@ -75,7 +79,11 @@ export default async function SolutionDetailPage({ params }: Props) {
               </aside>
             ) : null}
             <div className={styles.detailCta}>
-              <div><span className={styles.eyebrow}>Siguiente paso</span><h3>{service.cta}</h3><p>El alcance final depende del diagnóstico, la información disponible y las responsabilidades acordadas para el proyecto.</p></div>
+              <div>
+                <span className={styles.eyebrow}>Siguiente paso</span>
+                <h3>{service.cta}</h3>
+                <p>El alcance final depende de la información disponible, las condiciones del proyecto y las responsabilidades acordadas. Cuando falte información crítica, la línea base o el diagnóstico se incorpora como una actividad inicial; no sustituye el servicio contratado.</p>
+              </div>
               <Link className={`${styles.button} ${styles.primary}`} href="/contacto">Hablar con Greenatics</Link>
             </div>
           </div>

--- a/src/app/soluciones/gestion-juridica-regulatoria/page.tsx
+++ b/src/app/soluciones/gestion-juridica-regulatoria/page.tsx
@@ -1,13 +1,18 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import styles from "../solutions.module.css";
 import refresh from "../solutions-refresh.module.css";
 
+const title = "Gestión jurídica y regulatoria | Greenatics";
+const description = "Asesoría jurídica y regulatoria para estructurar responsabilidades, instrumentos, contratos, trámites y decisiones asociadas a residuos, aseo y proyectos de aprovechamiento.";
+
 export const metadata: Metadata = {
-  title: "Gestión jurídica y regulatoria | Greenatics",
-  description: "Asesoría jurídica y regulatoria para estructurar responsabilidades, instrumentos, contratos, trámites y decisiones asociadas a residuos, aseo y proyectos de aprovechamiento.",
+  title,
+  description,
   alternates: { canonical: "/soluciones/gestion-juridica-regulatoria" },
+  ...publicSocialMetadata({ title, description, path: "/soluciones/gestion-juridica-regulatoria" }),
 };
 
 const deliverables = [

--- a/src/app/soluciones/gestion-juridica-regulatoria/page.tsx
+++ b/src/app/soluciones/gestion-juridica-regulatoria/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import styles from "../solutions.module.css";
+import refresh from "../solutions-refresh.module.css";
+
+export const metadata: Metadata = {
+  title: "Gestión jurídica y regulatoria | Greenatics",
+  description: "Asesoría jurídica y regulatoria para estructurar responsabilidades, instrumentos, contratos, trámites y decisiones asociadas a residuos, aseo y proyectos de aprovechamiento.",
+  alternates: { canonical: "/soluciones/gestion-juridica-regulatoria" },
+};
+
+const deliverables = [
+  "matriz de obligaciones, competencias y responsables según el alcance",
+  "conceptos, memorandos o documentos jurídicos para la decisión requerida",
+  "ruta de actuaciones, soportes y trámites aplicables",
+  "documentos contractuales o instrumentos de coordinación cuando formen parte del encargo",
+  "checklist regulatorio para seguimiento y cierre de pendientes",
+];
+
+const activities = [
+  "lectura del marco jurídico aplicable al actor, territorio, corriente y servicio involucrado",
+  "revisión de PGIRS, PMIRS y otros instrumentos desde su dimensión jurídica cuando corresponda",
+  "análisis de responsabilidades entre municipio, ESP, generador, operador, gestor, contratista y terceros",
+  "apoyo en estructuración contractual y distribución de riesgos y obligaciones",
+  "acompañamiento documental frente a registros, reportes, permisos o actuaciones administrativas incluidos en el alcance",
+  "soporte en asuntos tarifarios y regulatorios de aseo cuando el encargo lo requiera",
+];
+
+export default function RegulatoryLegalSolutionPage() {
+  return (
+    <div className={`${styles.page} ${refresh.page}`}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Soluciones", path: "/soluciones" },
+        { name: "Gestión jurídica y regulatoria", path: "/soluciones/gestion-juridica-regulatoria" },
+      ]} />
+      <main>
+        <section className={styles.detailHero}>
+          <div className={styles.heroAccent} aria-hidden="true" />
+          <div className={styles.container}>
+            <div className={styles.breadcrumb}><Link href="/soluciones">Soluciones</Link><span>→</span><span>Jurídica y regulación</span></div>
+            <div className={styles.detailGrid}>
+              <div>
+                <span className={styles.eyebrow}>ESP · Municipios · Empresas · Operadores</span>
+                <h1>Gestión jurídica y regulatoria para residuos, aseo y proyectos.</h1>
+                <p className={styles.detailLead}>Estructuramos actividades, responsabilidades y documentos frente al marco aplicable al alcance, para que la decisión técnica tenga una ruta jurídica clara y ejecutable.</p>
+                <div className={styles.actions}>
+                  <a className={`${styles.button} ${styles.primary}`} href="#entregables">Ver entregables</a>
+                  <Link className={styles.button} href="/contacto">Plantear el caso</Link>
+                </div>
+              </div>
+              <aside className={styles.detailAside}>
+                <span>Problema de partida</span>
+                <strong>Una solución técnica puede fracasar si no están claras las competencias, obligaciones y relaciones contractuales.</strong>
+                <p>La asesoría jurídica se integra al proyecto cuando hay decisiones regulatorias, instrumentos territoriales o internos, trámites, tarifas, contratos o responsabilidades que deben ordenarse antes o durante la ejecución.</p>
+              </aside>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.detailBody}>
+          <div className={styles.container}>
+            <div className={styles.detailColumns}>
+              <article className={styles.listBox} id="entregables">
+                <span className={styles.detailIndex}>01</span>
+                <div><span className={styles.eyebrow}>Resultado contratado</span><h2>Qué recibe</h2><ul>{deliverables.map((item) => <li key={item}>{item}</li>)}</ul></div>
+              </article>
+              <article className={styles.listBox}>
+                <span className={styles.detailIndex}>02</span>
+                <div><span className={styles.eyebrow}>Actividades y alcance</span><h2>Qué hacemos</h2><ul>{activities.map((item) => <li key={item}>{item}</li>)}</ul></div>
+              </article>
+            </div>
+
+            <aside className={styles.detailAside}>
+              <span>Límite de responsabilidad</span>
+              <strong>Greenatics estructura y acompaña; no sustituye a la autoridad competente ni garantiza decisiones administrativas.</strong>
+              <p>Permisos, registros, conceptos, certificaciones, adopciones, aprobaciones o resultados frente a autoridades dependen del procedimiento aplicable, de la documentación y de la decisión de cada entidad competente. Su gestión se incluye únicamente cuando el contrato lo establezca.</p>
+            </aside>
+
+            <div className={styles.detailCta}>
+              <div><span className={styles.eyebrow}>Siguiente paso</span><h3>Definir el problema jurídico y el resultado que necesita el proyecto.</h3><p>Si el asunto ya está identificado, podemos estructurar directamente el alcance. Si todavía existen vacíos de información, la revisión documental inicial se incorpora como actividad de trabajo y no como sustituto del servicio.</p></div>
+              <Link className={`${styles.button} ${styles.primary}`} href="/contacto">Hablar con Greenatics</Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -7,7 +7,7 @@ import styles from "./solutions-v2.module.css";
 export const metadata: Metadata = {
   title: "Soluciones | Greenatics",
   description:
-    "Diagnóstico, planeación, regulación, logística, plantas, dirección técnica, datos y valorización para ESP, municipios, empresas, instituciones y operadores.",
+    "Servicios de planeación, regulación, logística, plantas, dirección técnica, operación, datos, valorización y caracterización para ESP, municipios, empresas, instituciones y operadores.",
   alternates: { canonical: "/soluciones" },
 };
 
@@ -36,14 +36,14 @@ const audiences = [
   {
     number: "04",
     title: "Propiedad horizontal / Instituciones",
-    copy: "Estandarizar diagnóstico, separación, almacenamiento, rutas, indicadores y oportunidades de gestión en una o varias sedes.",
+    copy: "Estandarizar separación, almacenamiento, rutas, responsables, indicadores y oportunidades de gestión en una o varias sedes.",
     href: "/soluciones/propiedad-horizontal",
     cta: "Ver ruta multiunidad",
   },
   {
     number: "05",
     title: "Plantas / Operadores",
-    copy: "Diagnosticar, recuperar, optimizar, dirigir o madurar infraestructura de tratamiento antes de comprometer nuevas inversiones.",
+    copy: "Recuperar, optimizar, dirigir, operar o madurar infraestructura de tratamiento según el estado real del sistema.",
     href: "/soluciones/plantas",
     cta: "Ver ruta de plantas",
   },
@@ -52,58 +52,58 @@ const audiences = [
 const serviceFamilies = [
   {
     number: "01",
-    title: "Diagnóstico y gestión de residuos",
-    copy: "Línea base, caracterización, flujos, brechas y priorización para decidir con información real.",
+    title: "Caracterización y línea base",
+    copy: "Mediciones, caracterización, mapa de flujos, brechas y criterios de decisión cuando el proyecto necesita información de partida verificable.",
     href: "/soluciones/diagnostico-caracterizacion",
   },
   {
     number: "02",
     title: "Planeación y programas",
-    copy: "PGIRS, PMIRS, programas internos, hojas de ruta e implementación según actor, territorio y obligación aplicable.",
+    copy: "PGIRS, PMIRS, programas internos, matrices, hojas de ruta, responsables, indicadores e implementación según el actor y el alcance.",
     href: "/soluciones/pmirs",
   },
   {
     number: "03",
     title: "Gestión jurídica y regulatoria",
-    copy: "Lectura del marco aplicable, responsabilidades, instrumentos, relaciones contractuales y ruta de cumplimiento dentro del alcance definido.",
-    href: "/contacto",
+    copy: "Obligaciones, competencias, conceptos, contratos, trámites y soporte regulatorio para que la decisión técnica tenga una ruta jurídica clara.",
+    href: "/soluciones/gestion-juridica-regulatoria",
   },
   {
     number: "04",
     title: "Rutas y logística",
-    copy: "Diseño de rutas y microrrutas, frecuencias, puntos, pilotos, datos operativos y criterios de escalamiento.",
+    copy: "Diseño de rutas y microrrutas, frecuencias, puntos, pilotos, protocolos, datos operativos y criterios de escalamiento.",
     href: "/soluciones/rutas-selectivas",
   },
   {
     number: "05",
     title: "Plantas y tratamiento",
-    copy: "Prefactibilidad, ingeniería, construcción, rehabilitación y optimización según la madurez y el problema real del sistema.",
+    copy: "Prefactibilidad, ingeniería, construcción, rehabilitación, puesta en marcha y optimización según la madurez y el problema real del sistema.",
     href: "/soluciones/infraestructura-plantas",
   },
   {
     number: "06",
     title: "Dirección técnica y operación asistida",
-    copy: "Protocolos, programación, mantenimiento, calidad, roles, seguimiento y fortalecimiento de la operación sin presumir un modelo único.",
+    copy: "Protocolos, programación, mantenimiento, calidad, personas, inventarios, informes y fortalecimiento sostenido de la operación.",
     href: "/soluciones/direccion-operacion",
   },
   {
     number: "07",
     title: "Datos, trazabilidad y OPS",
-    copy: "Captura, indicadores, evidencia, inventarios y seguimiento para convertir la actividad operativa en información útil para decidir.",
+    copy: "Captura, indicadores, evidencia, lotes, inventarios y seguimiento para convertir la actividad operativa en información útil para decidir.",
     href: "/soluciones/trazabilidad-datos",
   },
   {
     number: "08",
     title: "Valorización y desarrollo de productos",
-    copy: "Ruta técnica para convertir salidas del tratamiento en productos con especificaciones, control, documentación y estrategia de aprovechamiento según el caso.",
-    href: "/contacto",
+    copy: "Especificaciones, control, documentación, ruta regulatoria, presentación y preparación comercial para convertir una salida en un producto vendible.",
+    href: "/soluciones/valorizacion-productos",
   },
 ];
 
 const process = [
-  ["01", "Diagnosticar", "Entender generación, corrientes, infraestructura, operación, datos, restricciones y objetivos."],
-  ["02", "Definir la ruta", "Separar lo urgente de lo estructural y ordenar decisiones técnicas, jurídicas, operativas y económicas."],
-  ["03", "Implementar", "Ejecutar el alcance contratado: programas, rutas, adecuaciones, protocolos, puesta en marcha o herramientas."],
+  ["01", "Entender", "Leer el problema, el resultado esperado, la información disponible y las restricciones del proyecto."],
+  ["02", "Definir el alcance", "Traducir la necesidad en actividades, entregables, responsables, exclusiones y criterios de cierre."],
+  ["03", "Implementar", "Ejecutar el alcance contratado: programas, rutas, adecuaciones, protocolos, puesta en marcha, operación o herramientas."],
   ["04", "Acompañar", "Dirigir, medir, documentar y corregir con responsables y una cadencia de seguimiento definida."],
   ["05", "Mejorar y valorizar", "Usar la evidencia para optimizar el sistema y abrir nuevas oportunidades de aprovechamiento cuando sean viables."],
 ];
@@ -126,17 +126,17 @@ export default function SolutionsPage() {
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div className={styles.heroCopy}>
               <span className={styles.eyebrow}>Soluciones Greenatics · Organizaciones</span>
-              <h1 id="solutions-title">Empieza por tu contexto. Después elegimos el servicio.</h1>
+              <h1 id="solutions-title">Servicios para convertir necesidades de gestión en resultados concretos.</h1>
               <p className={styles.lead}>
-                Greenatics conecta diagnóstico, planeación, regulación, logística, plantas, dirección técnica, datos y valorización para convertir necesidades de gestión en decisiones, entregables y capacidad operativa.
+                Greenatics estructura y ejecuta servicios de planeación, regulación, logística, plantas, operación, datos, valorización y caracterización. Cada ruta baja hasta actividades, entregables, responsabilidades y límites del alcance.
               </p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/soluciones/diagnostico-inicial">No sé por dónde empezar</Link>
-                <a className={`${styles.button} ${styles.buttonGhost}`} href="#servicios">Ya sé qué necesito</a>
+                <a className={`${styles.button} ${styles.buttonPrimary}`} href="#servicios">Ver servicios y entregables</a>
+                <Link className={`${styles.button} ${styles.buttonGhost}`} href="/contacto">Hablar con Greenatics</Link>
               </div>
               <div className={styles.heroPrinciple}>
-                <span>Principio de trabajo</span>
-                <strong>Primero claridad. Después inversión y ejecución.</strong>
+                <span>Principio comercial</span>
+                <strong>Primero mostramos qué puede contratar el cliente. El diagnóstico se usa solo cuando hace falta aclarar el punto de partida.</strong>
               </div>
             </div>
 
@@ -153,14 +153,37 @@ export default function SolutionsPage() {
           </div>
         </section>
 
-        <section className={styles.audiences} aria-labelledby="audiences-title">
+        <section className={styles.services} id="servicios" aria-labelledby="services-title">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div>
-                <span className={styles.eyebrow}>¿Quién eres?</span>
-                <h2 id="audiences-title">El mismo residuo exige decisiones distintas según quién lo gestiona.</h2>
+                <span className={styles.eyebrow}>Qué puedes contratar</span>
+                <h2 id="services-title">Ocho familias para contratar actividades, entregables y capacidad de ejecución.</h2>
               </div>
-              <p>La ruta cambia por competencia, responsabilidad, escala, infraestructura, tipo de generador y relación con usuarios. Por eso la primera entrada es el contexto.</p>
+              <p>Cada familia conduce a una ruta concreta. La página de detalle explica primero qué recibe el cliente y después qué actividades puede incluir el servicio.</p>
+            </div>
+
+            <div className={styles.serviceList}>
+              {serviceFamilies.map((family) => (
+                <Link className={styles.serviceRow} href={family.href} key={family.number}>
+                  <span className={styles.index}>{family.number}</span>
+                  <h3>{family.title}</h3>
+                  <p>{family.copy}</p>
+                  <span className={styles.arrow} aria-hidden="true">→</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.audiences} id="audiencias" aria-labelledby="audiences-title">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div>
+                <span className={styles.eyebrow}>Rutas por organización</span>
+                <h2 id="audiences-title">La misma familia de servicio cambia según quién la contrata y qué responsabilidad tiene.</h2>
+              </div>
+              <p>Si prefieres entrar por tu tipo de organización, estas rutas combinan los servicios y programas más relevantes sin convertir la audiencia en una oferta distinta o cerrada.</p>
             </div>
 
             <div className={styles.audienceGrid}>
@@ -178,36 +201,13 @@ export default function SolutionsPage() {
           </div>
         </section>
 
-        <section className={styles.services} id="servicios" aria-labelledby="services-title">
-          <div className={styles.container}>
-            <div className={styles.sectionHead}>
-              <div>
-                <span className={styles.eyebrow}>Ya sé qué necesito</span>
-                <h2 id="services-title">Ocho familias para contratar actividades y resultados concretos.</h2>
-              </div>
-              <p>Las familias organizan la conversación comercial. El alcance contractual define estudios, entregables, permisos, personal, operación, herramientas y responsabilidades realmente incluidos.</p>
-            </div>
-
-            <div className={styles.serviceList}>
-              {serviceFamilies.map((family) => (
-                <Link className={styles.serviceRow} href={family.href} key={family.number}>
-                  <span className={styles.index}>{family.number}</span>
-                  <h3>{family.title}</h3>
-                  <p>{family.copy}</p>
-                  <span className={styles.arrow} aria-hidden="true">→</span>
-                </Link>
-              ))}
-            </div>
-          </div>
-        </section>
-
         <section className={styles.process} aria-labelledby="process-title">
           <div className={`${styles.container} ${styles.processGrid}`}>
             <div className={styles.processIntro}>
               <span className={styles.eyebrow}>Cómo trabajamos</span>
-              <h2 id="process-title">El diagnóstico ordena la ruta; no reemplaza el servicio.</h2>
+              <h2 id="process-title">El servicio define el resultado; la línea base solo entra cuando es necesaria.</h2>
               <p>
-                Cuando el alcance ya está claro podemos entrar directamente a una fase específica. Cuando no lo está, la línea base evita diseñar rutas, comprar equipos o intervenir infraestructura sobre supuestos débiles.
+                Si el cliente ya conoce el problema y existe información suficiente, Greenatics puede entrar directamente a una fase específica. Cuando faltan datos críticos, la caracterización o el diagnóstico se incorpora como una actividad inicial para reducir incertidumbre.
               </p>
             </div>
             <div className={styles.processRail}>
@@ -251,7 +251,7 @@ export default function SolutionsPage() {
               <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Tecnología y datos</span>
               <h2 id="digital-title">La consultoría gana valor cuando la información sigue viva después del informe.</h2>
               <p>
-                GREENATICS OPS funciona como capa de operación y trazabilidad para procesos activos. La arquitectura deja espacio para incorporar nuevas herramientas de captura de campo, diagnóstico y seguimiento sin convertir cada servicio en una aplicación aislada.
+                GREENATICS OPS funciona como capa de operación y trazabilidad para procesos activos. La arquitectura deja espacio para incorporar herramientas de captura de campo y seguimiento sin convertir cada servicio en una aplicación aislada.
               </p>
               <div className={styles.actions}>
                 <Link className={`${styles.button} ${styles.buttonLight}`} href="/soluciones/trazabilidad-datos">Ver trazabilidad y datos</Link>
@@ -269,13 +269,13 @@ export default function SolutionsPage() {
         <section className={styles.finalCta} aria-labelledby="final-cta-title">
           <div className={`${styles.container} ${styles.finalGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Punto de entrada recomendado</span>
-              <h2 id="final-cta-title">Si todavía no sabes qué contratar, empieza por una línea base.</h2>
+              <span className={styles.eyebrow}>Cuando todavía hay incertidumbre</span>
+              <h2 id="final-cta-title">¿No sabes cuál de estas soluciones corresponde a tu caso?</h2>
             </div>
             <div>
-              <p>El diagnóstico permite identificar brechas, prioridades y la siguiente fase sin obligar a convertir todo el problema en un proyecto de infraestructura o en una operación integral.</p>
+              <p>El orientador inicial organiza actor, necesidad y estado para sugerir qué servicio revisar. No es el producto principal de Greenatics y no sustituye el alcance comercial ni técnico que finalmente se contrate.</p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/soluciones/diagnostico-caracterizacion">Conocer diagnóstico y caracterización</Link>
+                <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/soluciones/diagnostico-inicial">Usar orientador inicial</Link>
                 <Link className={`${styles.button} ${styles.buttonGhost}`} href="/contacto">Hablar con Greenatics</Link>
               </div>
             </div>

--- a/src/app/soluciones/valorizacion-productos/page.tsx
+++ b/src/app/soluciones/valorizacion-productos/page.tsx
@@ -1,0 +1,93 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import styles from "../solutions.module.css";
+import refresh from "../solutions-refresh.module.css";
+
+export const metadata: Metadata = {
+  title: "Valorización y desarrollo de productos | Greenatics",
+  description: "Ruta técnica, documental y comercial para convertir salidas del tratamiento en productos con especificaciones, control, documentación y condiciones de comercialización definidas.",
+  alternates: { canonical: "/soluciones/valorizacion-productos" },
+};
+
+const deliverables = [
+  "especificación técnica preliminar o definitiva según la madurez del producto",
+  "matriz de parámetros de calidad y controles requeridos",
+  "dossier documental del producto y sus soportes disponibles",
+  "ruta regulatoria, de registro o certificación cuando resulte aplicable",
+  "criterios de presentación, etiquetado y empaque dentro del alcance contratado",
+  "plan de validación, producción piloto o escalamiento cuando corresponda",
+  "matriz de preparación comercial para llevar el producto a una condición vendible",
+];
+
+const activities = [
+  "caracterizar la corriente o salida del proceso y definir su condición técnica actual",
+  "identificar usos potenciales y restricciones sin convertir hipótesis en claims comerciales",
+  "definir especificaciones, formulación o acondicionamiento cuando aplique",
+  "estructurar controles de calidad, trazabilidad de lote y documentación de producción",
+  "organizar ensayos, análisis de laboratorio o validaciones requeridas dentro del proyecto",
+  "estructurar la ruta de registros, permisos o certificaciones aplicables sin atribuir a Greenatics facultades de autoridad o certificador",
+  "conectar producto, presentación, documentación técnica y estrategia comercial de lanzamiento",
+];
+
+export default function ValorizationProductSolutionPage() {
+  return (
+    <div className={`${styles.page} ${refresh.page}`}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Soluciones", path: "/soluciones" },
+        { name: "Valorización y desarrollo de productos", path: "/soluciones/valorizacion-productos" },
+      ]} />
+      <main>
+        <section className={styles.detailHero}>
+          <div className={styles.heroAccent} aria-hidden="true" />
+          <div className={styles.container}>
+            <div className={styles.breadcrumb}><Link href="/soluciones">Soluciones</Link><span>→</span><span>Valorización</span></div>
+            <div className={styles.detailGrid}>
+              <div>
+                <span className={styles.eyebrow}>Plantas · Operadores · Empresas · Proyectos</span>
+                <h1>Convertir una salida del proceso en un producto técnicamente preparado para vender.</h1>
+                <p className={styles.detailLead}>Acompañamos la ruta desde la caracterización y especificación hasta la documentación, controles, presentación y preparación regulatoria o comercial que correspondan al producto.</p>
+                <div className={styles.actions}>
+                  <a className={`${styles.button} ${styles.primary}`} href="#entregables">Ver entregables</a>
+                  <Link className={styles.button} href="/contacto">Evaluar un producto</Link>
+                </div>
+              </div>
+              <aside className={styles.detailAside}>
+                <span>Problema de partida</span>
+                <strong>Producir un material no significa que exista todavía un producto vendible.</strong>
+                <p>La valorización exige separar la existencia física del material de su especificación, calidad, trazabilidad, soporte técnico, condición regulatoria, presentación y posibilidad real de comercialización.</p>
+              </aside>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.detailBody}>
+          <div className={styles.container}>
+            <div className={styles.detailColumns}>
+              <article className={styles.listBox} id="entregables">
+                <span className={styles.detailIndex}>01</span>
+                <div><span className={styles.eyebrow}>Resultado contratado</span><h2>Qué recibe</h2><ul>{deliverables.map((item) => <li key={item}>{item}</li>)}</ul></div>
+              </article>
+              <article className={styles.listBox}>
+                <span className={styles.detailIndex}>02</span>
+                <div><span className={styles.eyebrow}>Actividades y alcance</span><h2>Qué hacemos</h2><ul>{activities.map((item) => <li key={item}>{item}</li>)}</ul></div>
+              </article>
+            </div>
+
+            <aside className={styles.detailAside}>
+              <span>Truth Lock</span>
+              <strong>Greenatics no presenta como aprobado, certificado o eficaz aquello que todavía está en validación.</strong>
+              <p>Registros, certificaciones, autorizaciones y resultados de laboratorio dependen de las autoridades, organismos o laboratorios competentes. Los beneficios agronómicos, ambientales o de desempeño solo se publican al nivel que permita la evidencia disponible.</p>
+            </aside>
+
+            <div className={styles.detailCta}>
+              <div><span className={styles.eyebrow}>Siguiente paso</span><h3>Definir qué material existe hoy y qué condición comercial se quiere alcanzar.</h3><p>La ruta puede iniciar en una caracterización, una formulación ya desarrollada, un producto en trámite o una referencia comercial existente. El alcance se diseña desde ese punto real, no desde una etapa obligatoria de diagnóstico.</p></div>
+              <Link className={`${styles.button} ${styles.primary}`} href="/contacto">Hablar con Greenatics</Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/soluciones/valorizacion-productos/page.tsx
+++ b/src/app/soluciones/valorizacion-productos/page.tsx
@@ -1,13 +1,18 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import styles from "../solutions.module.css";
 import refresh from "../solutions-refresh.module.css";
 
+const title = "Valorización y desarrollo de productos | Greenatics";
+const description = "Ruta técnica, documental y comercial para convertir salidas del tratamiento en productos con especificaciones, control, documentación y condiciones de comercialización definidas.";
+
 export const metadata: Metadata = {
-  title: "Valorización y desarrollo de productos | Greenatics",
-  description: "Ruta técnica, documental y comercial para convertir salidas del tratamiento en productos con especificaciones, control, documentación y condiciones de comercialización definidas.",
+  title,
+  description,
   alternates: { canonical: "/soluciones/valorizacion-productos" },
+  ...publicSocialMetadata({ title, description, path: "/soluciones/valorizacion-productos" }),
 };
 
 const deliverables = [

--- a/src/data/public-site.ts
+++ b/src/data/public-site.ts
@@ -51,6 +51,8 @@ export const publicStaticRoutes = [
   "/",
   "/soluciones",
   "/soluciones/diagnostico-inicial",
+  "/soluciones/gestion-juridica-regulatoria",
+  "/soluciones/valorizacion-productos",
   "/wondergreen",
   "/wondergreen/productos",
   "/wondergreen/cultivos",


### PR DESCRIPTION
## Objetivo
Reordenar `/soluciones` y las fichas de servicio para que la oferta comercial de Greenatics —servicios, actividades, entregables y capacidad de ejecución— tenga preponderancia sobre el diagnóstico. El diagnóstico/orientador se conserva como herramienta secundaria cuando el cliente todavía no sabe qué ruta revisar.

## Cambios
- Hero de Soluciones ahora abre con la oferta: `Servicios para convertir necesidades de gestión en resultados concretos.`
- Las ocho familias de servicio aparecen antes de las rutas por audiencia.
- `Caracterización y línea base` reemplaza al diagnóstico como etiqueta dominante de la primera familia.
- El orientador inicial queda al final como ruta de incertidumbre, no como producto principal.
- La metodología pasa a `Entender → Definir el alcance → Implementar → Acompañar → Mejorar y valorizar`.
- Fichas dinámicas de servicio muestran primero `Qué recibe` y después `Qué hacemos`.
- La línea base/diagnóstico se incorpora solo cuando falta información crítica; no sustituye el servicio contratado.
- Nueva ruta profunda `/soluciones/gestion-juridica-regulatoria` con entregables, actividades y límites de autoridad.
- Nueva ruta profunda `/soluciones/valorizacion-productos` para llevar una salida desde especificación/control/documentación hasta preparación regulatoria y comercial, sin inventar aprobaciones ni claims.
- Las dos nuevas rutas quedan en sitemap, shell público, contrato SEO y metadata social.

## Truth / regulatory locks
- No se promete cumplimiento, permisos, certificaciones, registros o decisiones administrativas.
- Greenatics estructura y acompaña; no sustituye a autoridades ni organismos certificadores.
- Claims agronómicos, ambientales o de desempeño solo se publican al nivel permitido por la evidencia.
- El alcance contractual, no la capacidad general de Greenatics, gobierna lo incluido.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile