### PR TITLE
feat(casa-jardin): profundiza catálogo comercial V2.1

### DIFF
--- a/e2e/home-garden-commercial-depth.spec.ts
+++ b/e2e/home-garden-commercial-depth.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+
+const productStages = [
+  ["COMPOST", "prepara"],
+  ["CRECE", "crece"],
+  ["EQUILIBRA", "equilibra"],
+  ["FLORECE", "florece"],
+  ["FRUCTIFICA", "fructifica"],
+] as const;
+
+const visibleKits = [
+  ["Kit Plantas Verdes", "plantas-verdes"],
+  ["Kit Plantas con Flor", "plantas-con-flor"],
+  ["Kit Mi Huerta", "mi-huerta"],
+  ["Kit Casa Completa", "casa-completa"],
+  ["Casa Completa XL", "casa-completa-xl"],
+] as const;
+
+test("Casa Jardin product catalog exposes governed stages before orientation", async ({ page }) => {
+  await page.goto("/casa-jardin/productos");
+
+  await expect(page.getByRole("heading", { name: "Primero la etapa. Después la referencia." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Producto visible antes que orientador." })).toBeVisible();
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
+  await expect(page.getByRole("banner")).toBeVisible();
+  await expect(page.getByRole("contentinfo")).toBeVisible();
+
+  for (const [name, slug] of productStages) {
+    const card = page.getByRole("article").filter({ has: page.getByRole("heading", { name, exact: true }) });
+    await expect(card).toHaveCount(1);
+    await expect(card.getByRole("link", { name: /Ver producto y formatos propuestos/ })).toHaveAttribute("href", `/casa-jardin/productos/${slug}`);
+  }
+
+  await expect(page.getByRole("link", { name: "Usar orientador de etapa y condición", exact: true })).toHaveAttribute("href", "/casa-jardin/diagnostico");
+  await expect(page.getByRole("link", { name: /Comprar|Añadir al carrito|Checkout/i })).toHaveCount(0);
+});
+
+test("Casa Jardin product detail puts technical product truth before diagnostic orientation", async ({ page }) => {
+  await page.goto("/casa-jardin/productos/crece");
+
+  await expect(page.getByRole("heading", { name: "CRECE", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "← Volver a productos", exact: true })).toHaveAttribute("href", "/casa-jardin/productos");
+  await expect(page.getByRole("link", { name: "Ver Product Truth técnico", exact: true })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
+  await expect(page.getByRole("link", { name: "Ver kits por uso", exact: true })).toHaveAttribute("href", "/casa-jardin/kits");
+  await expect(page.getByRole("link", { name: "No sé si corresponde a mi planta", exact: true })).toHaveAttribute("href", "/casa-jardin/diagnostico");
+  await expect(page.getByText(/Sin precio público, cobertura ni dosis/i).first()).toBeVisible();
+});
+
+test("Casa Jardin kit catalog exposes only prelaunch compositions and keeps blocked kit out", async ({ page }) => {
+  await page.goto("/casa-jardin/kits");
+
+  await expect(page.getByRole("heading", { name: "Kits por uso. Etapas separadas." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Elige por contexto. Después revisa cada etapa." })).toBeVisible();
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
+
+  for (const [name, slug] of visibleKits) {
+    const card = page.getByRole("article").filter({ has: page.getByRole("heading", { name, exact: true }) });
+    await expect(card).toHaveCount(1);
+    await expect(card.getByRole("link", { name: /Ver composición y ruta/ })).toHaveAttribute("href", `/casa-jardin/kits/${slug}`);
+    await expect(card.getByText("Pre-lanzamiento · compra deshabilitada", { exact: true })).toBeVisible();
+  }
+
+  await expect(page.getByRole("heading", { name: "Kit Trasplanta & Arranca", exact: true })).toHaveCount(0);
+  await expect(page.getByText(/Trasplanta & Arranca sigue fuera del catálogo visible/i)).toBeVisible();
+});
+
+test("Casa Jardin kit detail leads with composition and product route, not diagnosis", async ({ page }) => {
+  await page.goto("/casa-jardin/kits/mi-huerta");
+
+  await expect(page.getByRole("heading", { name: "Kit Mi Huerta", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "← Volver a kits", exact: true })).toHaveAttribute("href", "/casa-jardin/kits");
+  await expect(page.getByRole("link", { name: "Ver productos del kit", exact: true })).toHaveAttribute("href", "#ruta-kit");
+  await expect(page.getByRole("link", { name: "Explorar productos por etapa", exact: true })).toHaveAttribute("href", "/casa-jardin/productos");
+  await expect(page.getByRole("link", { name: "No sé si este kit encaja", exact: true })).toHaveAttribute("href", "/casa-jardin/diagnostico");
+
+  const productLinks = page.getByRole("link", { name: "Ver producto →", exact: true });
+  await expect(productLinks).toHaveCount(4);
+  await expect(productLinks.nth(0)).toHaveAttribute("href", "/casa-jardin/productos/prepara");
+  await expect(productLinks.nth(1)).toHaveAttribute("href", "/casa-jardin/productos/crece");
+  await expect(productLinks.nth(2)).toHaveAttribute("href", "/casa-jardin/productos/florece");
+  await expect(productLinks.nth(3)).toHaveAttribute("href", "/casa-jardin/productos/fructifica");
+});

--- a/src/app/casa-jardin/kits/[slug]/page.tsx
+++ b/src/app/casa-jardin/kits/[slug]/page.tsx
@@ -36,12 +36,14 @@ export default async function HomeGardenKitPage({ params }: { params: Promise<{ 
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div>
-              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin#kits">← Volver a kits</Link>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/kits">← Volver a kits</Link>
               <span className={styles.eyebrow}>Wondergreen Casa & Jardín · kit de pre-lanzamiento</span>
               <h1>{kit.name}</h1>
               <p className={styles.lead}>{kit.audience}. <strong>{kit.promise}</strong></p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Confirmar si encaja contigo</Link>
+                <a className={`${styles.button} ${styles.primary}`} href="#ruta-kit">Ver productos del kit</a>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/productos">Explorar productos por etapa</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/diagnostico">No sé si este kit encaja</Link>
               </div>
             </div>
             <aside className={styles.heroVisual}>
@@ -68,7 +70,7 @@ export default async function HomeGardenKitPage({ params }: { params: Promise<{ 
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.soft}`}>
+        <section className={`${styles.section} ${styles.soft}`} id="ruta-kit">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>Ruta del kit</span><h2>Cada etapa se usa cuando corresponde.</h2></div>
@@ -81,7 +83,7 @@ export default async function HomeGardenKitPage({ params }: { params: Promise<{ 
                   <article key={stage}>
                     <strong>{String(index + 1).padStart(2, "0")} · {product?.consumerName ?? stage}</strong>
                     <p>{product?.role}</p>
-                    {product ? <Link href={`/casa-jardin/productos/${product.id}`}>Ver etapa →</Link> : null}
+                    {product ? <Link href={`/casa-jardin/productos/${product.id}`}>Ver producto →</Link> : null}
                   </article>
                 );
               })}

--- a/src/app/casa-jardin/kits/page.tsx
+++ b/src/app/casa-jardin/kits/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { getHomeGardenProduct, visibleHomeGardenKits } from "@/data/home-garden";
+import styles from "../casa-jardin.module.css";
+
+export const metadata: Metadata = {
+  title: "Kits por uso | Wondergreen Casa & Jardín",
+  description:
+    "Kits Casa & Jardín organizados por contexto de uso y etapas Wondergreen, en pre-lanzamiento y sin checkout, PVP ni dosis universales publicadas.",
+  alternates: { canonical: "/casa-jardin/kits" },
+  robots: { index: false, follow: true },
+};
+
+export default function HomeGardenKitsPage() {
+  return (
+    <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Casa & Jardín", path: "/casa-jardin" },
+        { name: "Kits", path: "/casa-jardin/kits" },
+      ]} />
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin">← Casa & Jardín</Link>
+              <span className={styles.eyebrow}>Wondergreen Casa & Jardín · kits</span>
+              <h1>Kits por uso. Etapas separadas.</h1>
+              <p className={styles.lead}>
+                Los kits reúnen referencias Wondergreen para contextos concretos —plantas verdes, floración, huerta o colecciones más amplias— sin convertir el conjunto en una mezcla ni en una secuencia obligatoria. Cada planta entra por su etapa y condición.
+              </p>
+              <div className={styles.actions}>
+                <a className={`${styles.button} ${styles.primary}`} href="#catalogo">Ver kits</a>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/productos">Ver productos por etapa</Link>
+              </div>
+            </div>
+            <aside className={styles.heroVisual}>
+              <p className={styles.heroNote}>PRE-LANZAMIENTO · SIN CHECKOUT</p>
+              <strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>
+                El kit organiza opciones. No prescribe aplicaciones.
+              </strong>
+              <p style={{ color: "#d5e2dc", maxWidth: "26rem" }}>
+                PVP, cobertura, dosificador, empaque, etiquetado, stock y logística permanecen cerrados hasta completar validación comercial, técnica y regulatoria.
+              </p>
+            </aside>
+          </div>
+        </section>
+
+        <section className={styles.section} id="catalogo">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div>
+                <span className={styles.eyebrow}>Kits visibles</span>
+                <h2>Elige por contexto. Después revisa cada etapa.</h2>
+              </div>
+              <p>
+                Solo aparecen las composiciones V1 con estado de pre-lanzamiento. Trasplanta & Arranca permanece bloqueado y no se presenta como kit disponible mientras su componente radicular siga sin Product Truth reconciliado.
+              </p>
+            </div>
+            <div className={styles.kitGrid}>
+              {visibleHomeGardenKits.map((kit) => (
+                <article className={styles.kitCard} key={kit.id}>
+                  <span className={styles.eyebrow}>{kit.audience}</span>
+                  <h3>{kit.name}</h3>
+                  <p><strong>{kit.promise}</strong></p>
+                  <ul>
+                    {kit.pathway.map((stage) => {
+                      const product = getHomeGardenProduct(stage);
+                      return <li key={stage}>{product?.consumerName ?? stage}</li>;
+                    })}
+                  </ul>
+                  <p>{kit.guardrail}</p>
+                  <Link href={`/casa-jardin/kits/${kit.id}`}>Ver composición y ruta →</Link>
+                  <div className={styles.status}>Pre-lanzamiento · compra deshabilitada</div>
+                </article>
+              ))}
+            </div>
+            <div className={styles.guardrail}>
+              <strong>Trasplanta & Arranca sigue fuera del catálogo visible.</strong>
+              <p>La guía educativa de trasplante puede consultarse, pero el kit no se publica hasta que el componente radicular/bioinsumo tenga soporte técnico, regulatorio y comercial suficiente.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div>
+                <span className={styles.eyebrow}>Si no sabes cuál encaja</span>
+                <h2>La orientación es una capa secundaria.</h2>
+              </div>
+              <p>
+                El orientador ayuda cuando no está clara la etapa o cuando una condición de agua, drenaje, raíces, estrés o sanidad puede hacer que fertilizar todavía no sea el siguiente paso.
+              </p>
+            </div>
+            <div className={styles.actions}>
+              <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Usar orientador</Link>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/guias">Consultar guías</Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/casa-jardin/productos/[slug]/page.tsx
+++ b/src/app/casa-jardin/productos/[slug]/page.tsx
@@ -36,13 +36,14 @@ export default async function HomeGardenProductPage({ params }: { params: Promis
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div>
-              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin#etapas">← Volver al sistema</Link>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/productos">← Volver a productos</Link>
               <span className={styles.eyebrow}>Wondergreen Casa & Jardín · {product.id === "prepara" ? "suelo" : "etapa"}</span>
               <h1>{product.consumerName}</h1>
               <p className={styles.lead}>{product.role}</p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Confirmar si es tu etapa</Link>
-                <Link className={`${styles.button} ${styles.ghost}`} href={`/wondergreen/productos/${product.technicalSlug}`}>Ver Product Truth técnico</Link>
+                <Link className={`${styles.button} ${styles.primary}`} href={`/wondergreen/productos/${product.technicalSlug}`}>Ver Product Truth técnico</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/kits">Ver kits por uso</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/diagnostico">No sé si corresponde a mi planta</Link>
               </div>
             </div>
             <aside className={styles.heroVisual}>

--- a/src/app/casa-jardin/productos/page.tsx
+++ b/src/app/casa-jardin/productos/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { homeGardenProducts } from "@/data/home-garden";
+import styles from "../casa-jardin.module.css";
+
+export const metadata: Metadata = {
+  title: "Productos por etapa | Wondergreen Casa & Jardín",
+  description:
+    "Catálogo Casa & Jardín organizado por etapa: compost, crecimiento, equilibrio, floración y fructificación, con referencias técnicas gobernadas y formatos domésticos aún en validación.",
+  alternates: { canonical: "/casa-jardin/productos" },
+  robots: { index: false, follow: true },
+};
+
+export default function HomeGardenProductsPage() {
+  return (
+    <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Casa & Jardín", path: "/casa-jardin" },
+        { name: "Productos", path: "/casa-jardin/productos" },
+      ]} />
+      <main>
+        <section className={styles.hero}>
+          <div className={`${styles.container} ${styles.heroGrid}`}>
+            <div>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin">← Casa & Jardín</Link>
+              <span className={styles.eyebrow}>Wondergreen Casa & Jardín · productos</span>
+              <h1>Primero la etapa. Después la referencia.</h1>
+              <p className={styles.lead}>
+                El catálogo doméstico organiza cinco entradas gobernadas: suelo, crecimiento, equilibrio, floración y fructificación. Cada una se conecta con una referencia técnica Wondergreen existente; los formatos pequeños siguen en validación y no se publican como SKU comprable.
+              </p>
+              <div className={styles.actions}>
+                <a className={`${styles.button} ${styles.primary}`} href="#catalogo">Ver productos</a>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/kits">Ver kits por uso</Link>
+              </div>
+            </div>
+            <aside className={styles.heroVisual}>
+              <p className={styles.heroNote}>PRODUCT TRUTH TÉCNICO · B2C EN PRE-LANZAMIENTO</p>
+              <strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>
+                Cinco entradas. Una lógica por etapa.
+              </strong>
+              <p style={{ color: "#d5e2dc", maxWidth: "26rem" }}>
+                Explorar una etapa no equivale a prescribir fertilización. Agua, drenaje, raíces, estrés y sanidad siguen gobernando si corresponde aplicar o detenerse.
+              </p>
+            </aside>
+          </div>
+        </section>
+
+        <section className={styles.section} id="catalogo">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div>
+                <span className={styles.eyebrow}>Catálogo por etapa</span>
+                <h2>Producto visible antes que orientador.</h2>
+              </div>
+              <p>
+                Si ya reconoces la etapa, entra directamente a la referencia. El orientador se reserva para cuando la etapa o la condición de la planta no estén claras.
+              </p>
+            </div>
+            <div className={styles.productGrid}>
+              {homeGardenProducts.map((product) => (
+                <article className={`${styles.card} ${styles[product.accent]}`} key={product.id}>
+                  <div className={styles.stageBar} />
+                  <small>{product.id === "prepara" ? "Suelo" : "Etapa"}</small>
+                  <h3>{product.consumerName}</h3>
+                  <span className={styles.formula}>{product.formula ?? "Compost"}</span>
+                  <p>{product.role}</p>
+                  <p><strong>{product.prompt}</strong></p>
+                  <Link href={`/casa-jardin/productos/${product.id}`}>Ver producto y formatos propuestos →</Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div>
+                <span className={styles.eyebrow}>Cuando hay duda</span>
+                <h2>El orientador entra después, no antes.</h2>
+              </div>
+              <p>
+                Si no puedes reconocer la etapa, o hay encharcamiento, raíces comprometidas, marchitez severa, estrés o señales sanitarias, primero revisa la condición. El sistema no calcula dosis universales ni convierte un síntoma aislado en una receta.
+              </p>
+            </div>
+            <div className={styles.actions}>
+              <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Usar orientador de etapa y condición</Link>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/guias">Consultar guías</Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Objetivo
Profundizar Casa & Jardín como superficie comercial navegable sin adelantar el lanzamiento B2C: productos y kits se vuelven destinos propios y el orientador queda como capa secundaria cuando la etapa o condición de la planta no están claras.

## Cambios
- Nueva ruta `/casa-jardin/productos` con catálogo real de las cinco entradas gobernadas: COMPOST, CRECE, EQUILIBRA, FLORECE y FRUCTIFICA.
- Nueva ruta `/casa-jardin/kits` con los cinco kits V1 en pre-lanzamiento y exclusión explícita de Trasplanta & Arranca mientras siga bloqueado.
- Las fichas de producto priorizan el Product Truth técnico y la exploración comercial antes del orientador.
- Las fichas de kit priorizan composición y productos de la ruta antes del orientador.
- Breadcrumbs, canonicals y robots `noindex,follow` preservan el estado B2C actual.
- Cobertura E2E nueva para índices, rutas, jerarquía comercial, bloqueo del kit no validado y ausencia de checkout.

## Truth / safety locks
- Sin PVP, checkout, stock, cobertura, frecuencia ni dosis universal inventada.
- Los formatos domésticos permanecen en validación y no se presentan como SKUs reconciliados.
- Trasplanta & Arranca permanece fuera del catálogo visible hasta cerrar Product Truth del componente radicular/bioinsumo.
- El orientador conserva sus paradas de seguridad frente a agua, drenaje, raíces, estrés y sanidad; no prescribe por un síntoma aislado.
- La nueva jerarquía no modifica la verdad técnica de Wondergreen ni el gate regulatorio existente.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile