### PR TITLE
feat(casa-jardin): merchandising visual gobernado V2.2

### DIFF
--- a/e2e/home-garden-commercial-depth.spec.ts
+++ b/e2e/home-garden-commercial-depth.spec.ts
@@ -16,7 +16,7 @@ const visibleKits = [
   ["Casa Completa XL", "casa-completa-xl"],
 ] as const;
 
-test("Casa Jardin product catalog exposes governed stages before orientation", async ({ page }) => {
+test("Casa Jardin product catalog exposes governed stages and approved visuals before orientation", async ({ page }) => {
   await page.goto("/casa-jardin/productos");
 
   await expect(page.getByRole("heading", { name: "Primero la etapa. Después la referencia." })).toBeVisible();
@@ -28,14 +28,17 @@ test("Casa Jardin product catalog exposes governed stages before orientation", a
   for (const [name, slug] of productStages) {
     const card = page.getByRole("article").filter({ has: page.getByRole("heading", { name, exact: true }) });
     await expect(card).toHaveCount(1);
+    await expect(card.getByLabel(`Visual ${name}`, { exact: true })).toBeVisible();
     await expect(card.getByRole("link", { name: /Ver producto y formatos propuestos/ })).toHaveAttribute("href", `/casa-jardin/productos/${slug}`);
   }
 
+  await expect(page.getByText("Arte de línea aprobado · no packshot específico", { exact: true })).toHaveCount(4);
+  await expect(page.getByText("Base del sistema · representación editorial", { exact: true })).toHaveCount(1);
   await expect(page.getByRole("link", { name: "Usar orientador de etapa y condición", exact: true })).toHaveAttribute("href", "/casa-jardin/diagnostico");
   await expect(page.getByRole("link", { name: /Comprar|Añadir al carrito|Checkout/i })).toHaveCount(0);
 });
 
-test("Casa Jardin product detail puts technical product truth before diagnostic orientation", async ({ page }) => {
+test("Casa Jardin product detail puts technical product truth and approved line art before diagnostic orientation", async ({ page }) => {
   await page.goto("/casa-jardin/productos/crece");
 
   await expect(page.getByRole("heading", { name: "CRECE", exact: true })).toBeVisible();
@@ -43,10 +46,15 @@ test("Casa Jardin product detail puts technical product truth before diagnostic 
   await expect(page.getByRole("link", { name: "Ver Product Truth técnico", exact: true })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
   await expect(page.getByRole("link", { name: "Ver kits por uso", exact: true })).toHaveAttribute("href", "/casa-jardin/kits");
   await expect(page.getByRole("link", { name: "No sé si corresponde a mi planta", exact: true })).toHaveAttribute("href", "/casa-jardin/diagnostico");
+
+  const visual = page.getByLabel("Visual CRECE", { exact: true });
+  await expect(visual).toBeVisible();
+  await expect(visual.getByRole("img", { name: "Arte aprobado de la línea Wondergreen 2Grow para la etapa CRECE", exact: true })).toHaveAttribute("src", "/api/public-media/wondergreen-2grow");
+  await expect(page.getByText(/no representa un packshot específico/i)).toBeVisible();
   await expect(page.getByText(/Sin precio público, cobertura ni dosis/i).first()).toBeVisible();
 });
 
-test("Casa Jardin kit catalog exposes only prelaunch compositions and keeps blocked kit out", async ({ page }) => {
+test("Casa Jardin kit catalog exposes visual prelaunch compositions and keeps blocked kit out", async ({ page }) => {
   await page.goto("/casa-jardin/kits");
 
   await expect(page.getByRole("heading", { name: "Kits por uso. Etapas separadas." })).toBeVisible();
@@ -56,6 +64,7 @@ test("Casa Jardin kit catalog exposes only prelaunch compositions and keeps bloc
   for (const [name, slug] of visibleKits) {
     const card = page.getByRole("article").filter({ has: page.getByRole("heading", { name, exact: true }) });
     await expect(card).toHaveCount(1);
+    await expect(card.getByLabel(`Composición visual ${name}`, { exact: true })).toBeVisible();
     await expect(card.getByRole("link", { name: /Ver composición y ruta/ })).toHaveAttribute("href", `/casa-jardin/kits/${slug}`);
     await expect(card.getByText("Pre-lanzamiento · compra deshabilitada", { exact: true })).toBeVisible();
   }
@@ -64,7 +73,7 @@ test("Casa Jardin kit catalog exposes only prelaunch compositions and keeps bloc
   await expect(page.getByText(/Trasplanta & Arranca sigue fuera del catálogo visible/i)).toBeVisible();
 });
 
-test("Casa Jardin kit detail leads with composition and product route, not diagnosis", async ({ page }) => {
+test("Casa Jardin kit detail leads with governed visual composition and product route, not diagnosis", async ({ page }) => {
   await page.goto("/casa-jardin/kits/mi-huerta");
 
   await expect(page.getByRole("heading", { name: "Kit Mi Huerta", exact: true })).toBeVisible();
@@ -72,6 +81,13 @@ test("Casa Jardin kit detail leads with composition and product route, not diagn
   await expect(page.getByRole("link", { name: "Ver productos del kit", exact: true })).toHaveAttribute("href", "#ruta-kit");
   await expect(page.getByRole("link", { name: "Explorar productos por etapa", exact: true })).toHaveAttribute("href", "/casa-jardin/productos");
   await expect(page.getByRole("link", { name: "No sé si este kit encaja", exact: true })).toHaveAttribute("href", "/casa-jardin/diagnostico");
+
+  const visualRail = page.getByLabel("Etapas incluidas en Kit Mi Huerta", { exact: true });
+  await expect(visualRail).toBeVisible();
+  for (const stage of ["COMPOST", "CRECE", "FLORECE", "FRUCTIFICA"]) {
+    await expect(visualRail.getByLabel(`Visual ${stage}`, { exact: true })).toBeVisible();
+  }
+  await expect(page.getByText(/No son packshots finales del kit/i)).toBeVisible();
 
   const productLinks = page.getByRole("link", { name: "Ver producto →", exact: true });
   await expect(productLinks).toHaveCount(4);

--- a/src/app/casa-jardin/kits/[slug]/page.tsx
+++ b/src/app/casa-jardin/kits/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { HomeGardenKitStageRail } from "@/components/home-garden-kit-stage-rail";
 import {
   getHomeGardenKit,
   getHomeGardenProduct,
@@ -46,9 +47,12 @@ export default async function HomeGardenKitPage({ params }: { params: Promise<{ 
                 <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/diagnostico">No sé si este kit encaja</Link>
               </div>
             </div>
-            <aside className={styles.heroVisual}>
+            <aside className={styles.heroVisual} aria-label={`Composición ${kit.name}`}>
               <p className={styles.heroNote}>COMPOSICIÓN V1 · SIN CHECKOUT</p>
-              <strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>Un sistema por etapas, no una mezcla para aplicar de una vez.</strong>
+              <HomeGardenKitStageRail stages={kit.pathway} label={`Etapas incluidas en ${kit.name}`} tone="dark" />
+              <p style={{ color: "#d5e2dc", maxWidth: "28rem" }}>
+                Los artes identifican las líneas Wondergreen que componen la ruta. No son packshots finales del kit ni implican aplicación simultánea.
+              </p>
             </aside>
           </div>
         </section>

--- a/src/app/casa-jardin/kits/page.tsx
+++ b/src/app/casa-jardin/kits/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { HomeGardenKitStageRail } from "@/components/home-garden-kit-stage-rail";
 import { getHomeGardenProduct, visibleHomeGardenKits } from "@/data/home-garden";
 import styles from "../casa-jardin.module.css";
 
@@ -41,7 +42,7 @@ export default function HomeGardenKitsPage() {
                 El kit organiza opciones. No prescribe aplicaciones.
               </strong>
               <p style={{ color: "#d5e2dc", maxWidth: "26rem" }}>
-                PVP, cobertura, dosificador, empaque, etiquetado, stock y logística permanecen cerrados hasta completar validación comercial, técnica y regulatoria.
+                Las composiciones visuales usan artes aprobados de las líneas Wondergreen para identificar etapas. No son packshots finales de los futuros kits domésticos.
               </p>
             </aside>
           </div>
@@ -61,6 +62,7 @@ export default function HomeGardenKitsPage() {
             <div className={styles.kitGrid}>
               {visibleHomeGardenKits.map((kit) => (
                 <article className={styles.kitCard} key={kit.id}>
+                  <HomeGardenKitStageRail stages={kit.pathway} label={`Composición visual ${kit.name}`} />
                   <span className={styles.eyebrow}>{kit.audience}</span>
                   <h3>{kit.name}</h3>
                   <p><strong>{kit.promise}</strong></p>

--- a/src/app/casa-jardin/productos/[slug]/page.tsx
+++ b/src/app/casa-jardin/productos/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { HomeGardenStageVisual } from "@/components/home-garden-stage-visual";
 import {
   getHomeGardenProduct,
   homeGardenProducts,
@@ -46,10 +47,12 @@ export default async function HomeGardenProductPage({ params }: { params: Promis
                 <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/diagnostico">No sé si corresponde a mi planta</Link>
               </div>
             </div>
-            <aside className={styles.heroVisual}>
+            <aside className={styles.heroVisual} aria-label={`Identidad visual ${product.consumerName}`}>
               <p className={styles.heroNote}>PRESENTACIÓN DOMÉSTICA EN VALIDACIÓN</p>
-              <strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3.2rem", lineHeight: 1 }}>{product.technicalName}</strong>
-              <p style={{ color: "#d5e2dc", maxWidth: "26rem" }}>{product.formula ? `Fórmula técnica: ${product.formula}` : "Base orgánica para el sistema de suelo."}</p>
+              <HomeGardenStageVisual stage={product.id} size="hero" />
+              <p style={{ color: "#d5e2dc", maxWidth: "26rem" }}>
+                Referencia técnica: {product.technicalName}. El arte de línea identifica la familia aprobada; no representa un packshot específico de los formatos domésticos propuestos.
+              </p>
             </aside>
           </div>
         </section>

--- a/src/app/casa-jardin/productos/page.tsx
+++ b/src/app/casa-jardin/productos/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { HomeGardenStageVisual } from "@/components/home-garden-stage-visual";
 import { homeGardenProducts } from "@/data/home-garden";
 import styles from "../casa-jardin.module.css";
 
@@ -41,7 +42,7 @@ export default function HomeGardenProductsPage() {
                 Cinco entradas. Una lógica por etapa.
               </strong>
               <p style={{ color: "#d5e2dc", maxWidth: "26rem" }}>
-                Explorar una etapa no equivale a prescribir fertilización. Agua, drenaje, raíces, estrés y sanidad siguen gobernando si corresponde aplicar o detenerse.
+                Los artes visibles son activos aprobados de cada línea técnica; no se presentan como packshots específicos de las futuras presentaciones domésticas.
               </p>
             </aside>
           </div>
@@ -60,8 +61,9 @@ export default function HomeGardenProductsPage() {
             </div>
             <div className={styles.productGrid}>
               {homeGardenProducts.map((product) => (
-                <article className={`${styles.card} ${styles[product.accent]}`} key={product.id}>
+                <article className={`${styles.card} ${styles.cardWithVisual} ${styles[product.accent]}`} key={product.id}>
                   <div className={styles.stageBar} />
+                  <HomeGardenStageVisual stage={product.id} size="card" />
                   <small>{product.id === "prepara" ? "Suelo" : "Etapa"}</small>
                   <h3>{product.consumerName}</h3>
                   <span className={styles.formula}>{product.formula ?? "Compost"}</span>

--- a/src/components/home-garden-kit-stage-rail.module.css
+++ b/src/components/home-garden-kit-stage-rail.module.css
@@ -27,9 +27,14 @@
   letter-spacing: .06em;
 }
 
+.dark .item {
+  padding: 5px;
+  background: rgba(255, 255, 255, .96);
+}
+
 .dark .order {
-  background: rgba(255, 255, 255, .9);
-  color: #063d2c;
+  background: rgba(6, 61, 44, .9);
+  color: #fff;
 }
 
 @media (max-width: 560px) {

--- a/src/components/home-garden-kit-stage-rail.module.css
+++ b/src/components/home-garden-kit-stage-rail.module.css
@@ -1,6 +1,6 @@
 .rail {
   display: grid;
-  grid-template-columns: repeat(var(--rail-count, 4), minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
   gap: 8px;
 }
 
@@ -30,11 +30,6 @@
 .dark .order {
   background: rgba(255, 255, 255, .9);
   color: #063d2c;
-}
-
-.dark :global(figcaption),
-.dark :global([data-home-garden-stage]) {
-  color: inherit;
 }
 
 @media (max-width: 560px) {

--- a/src/components/home-garden-kit-stage-rail.module.css
+++ b/src/components/home-garden-kit-stage-rail.module.css
@@ -1,0 +1,44 @@
+.rail {
+  display: grid;
+  grid-template-columns: repeat(var(--rail-count, 4), minmax(0, 1fr));
+  gap: 8px;
+}
+
+.item {
+  position: relative;
+  min-width: 0;
+}
+
+.order {
+  position: absolute;
+  top: 6px;
+  left: 7px;
+  z-index: 3;
+  min-width: 24px;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 5px;
+  background: rgba(6, 61, 44, .88);
+  color: #fff;
+  font-size: .58rem;
+  font-weight: 900;
+  letter-spacing: .06em;
+}
+
+.dark .order {
+  background: rgba(255, 255, 255, .9);
+  color: #063d2c;
+}
+
+.dark :global(figcaption),
+.dark :global([data-home-garden-stage]) {
+  color: inherit;
+}
+
+@media (max-width: 560px) {
+  .rail {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/src/components/home-garden-kit-stage-rail.tsx
+++ b/src/components/home-garden-kit-stage-rail.tsx
@@ -1,0 +1,22 @@
+import type { HomeGardenStage } from "@/data/home-garden";
+import { HomeGardenStageVisual } from "./home-garden-stage-visual";
+import styles from "./home-garden-kit-stage-rail.module.css";
+
+type HomeGardenKitStageRailProps = {
+  stages: readonly HomeGardenStage[];
+  label: string;
+  tone?: "light" | "dark";
+};
+
+export function HomeGardenKitStageRail({ stages, label, tone = "light" }: HomeGardenKitStageRailProps) {
+  return (
+    <div className={`${styles.rail} ${styles[tone]}`} aria-label={label}>
+      {stages.map((stage, index) => (
+        <div className={styles.item} key={`${stage}-${index}`}>
+          <span className={styles.order}>{String(index + 1).padStart(2, "0")}</span>
+          <HomeGardenStageVisual stage={stage} size="mini" showTruthLabel={false} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/home-garden-stage-visual.module.css
+++ b/src/components/home-garden-stage-visual.module.css
@@ -1,0 +1,159 @@
+.figure {
+  --stage-accent: #2f7d32;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.figure[data-home-garden-stage="prepara"] { --stage-accent: #8b6d46; }
+.figure[data-home-garden-stage="crece"] { --stage-accent: #f28c28; }
+.figure[data-home-garden-stage="equilibra"] { --stage-accent: #7452a3; }
+.figure[data-home-garden-stage="florece"] { --stage-accent: #3b77b9; }
+.figure[data-home-garden-stage="fructifica"] { --stage-accent: #d95b50; }
+
+.imageFrame {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 760 / 1074;
+  border: 1px solid rgba(6, 61, 44, .14);
+  background: #f6f3e9;
+  box-shadow: 0 18px 44px rgba(6, 61, 44, .09);
+}
+
+.imageFrame::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  z-index: 2;
+  width: 5px;
+  background: var(--stage-accent);
+}
+
+.imageFrame img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  object-position: top center;
+}
+
+.identity {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.identity strong {
+  color: #17382d;
+  font-size: .83rem;
+  letter-spacing: .06em;
+}
+
+.identity small {
+  color: #2f7d32;
+  font-size: .72rem;
+  font-weight: 900;
+}
+
+.figure figcaption {
+  color: #66766f;
+  font-size: .67rem;
+  line-height: 1.4;
+}
+
+.compostBody {
+  min-height: 100%;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: end;
+  gap: 7px;
+  border: 1px solid rgba(6, 61, 44, .14);
+  border-left: 5px solid var(--stage-accent);
+  background: linear-gradient(155deg, #eadfc8 0%, #f8f4ea 60%, #d8e7cc 100%);
+  box-shadow: 0 18px 44px rgba(6, 61, 44, .09);
+}
+
+.compostBody span {
+  color: #8b6d46;
+  font-size: .68rem;
+  font-weight: 900;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.compostBody strong {
+  color: #5f492f;
+  font-family: var(--display);
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.compostBody small {
+  color: #745f45;
+  line-height: 1.35;
+}
+
+.card .imageFrame,
+.card .compostBody {
+  min-height: 260px;
+}
+
+.hero {
+  width: min(100%, 390px);
+  margin-inline: auto;
+}
+
+.hero .imageFrame,
+.hero .compostBody {
+  min-height: 420px;
+}
+
+.hero .identity strong,
+.hero .identity small,
+.hero figcaption {
+  color: #e5efe9;
+}
+
+.mini {
+  gap: 5px;
+}
+
+.mini .imageFrame,
+.mini .compostBody {
+  min-height: 118px;
+  box-shadow: none;
+}
+
+.mini .compostBody {
+  padding: 10px;
+}
+
+.mini .compostBody strong {
+  font-size: .9rem;
+}
+
+.mini .compostBody span,
+.mini .compostBody small,
+.mini .identity small,
+.mini figcaption {
+  display: none;
+}
+
+.mini .identity {
+  justify-content: center;
+}
+
+.mini .identity strong {
+  font-size: .62rem;
+  text-align: center;
+}
+
+@media (max-width: 620px) {
+  .hero .imageFrame,
+  .hero .compostBody {
+    min-height: 340px;
+  }
+}

--- a/src/components/home-garden-stage-visual.tsx
+++ b/src/components/home-garden-stage-visual.tsx
@@ -1,0 +1,73 @@
+import Image from "next/image";
+import { getHomeGardenProduct, type HomeGardenStage } from "@/data/home-garden";
+import styles from "./home-garden-stage-visual.module.css";
+
+const stageVisuals: Partial<Record<HomeGardenStage, { src: string; alt: string }>> = {
+  crece: {
+    src: "/api/public-media/wondergreen-2grow",
+    alt: "Arte aprobado de la línea Wondergreen 2Grow para la etapa CRECE",
+  },
+  equilibra: {
+    src: "/api/public-media/wondergreen-2balance",
+    alt: "Arte aprobado de la línea Wondergreen 2Balance para la etapa EQUILIBRA",
+  },
+  florece: {
+    src: "/api/public-media/wondergreen-2bloom",
+    alt: "Arte aprobado de la línea Wondergreen 2Bloom para la etapa FLORECE",
+  },
+  fructifica: {
+    src: "/api/public-media/wondergreen-2fruit",
+    alt: "Arte aprobado de la línea Wondergreen 2Fruit para la etapa FRUCTIFICA",
+  },
+};
+
+type HomeGardenStageVisualProps = {
+  stage: HomeGardenStage;
+  size?: "mini" | "card" | "hero";
+  showTruthLabel?: boolean;
+};
+
+export function HomeGardenStageVisual({
+  stage,
+  size = "card",
+  showTruthLabel = true,
+}: HomeGardenStageVisualProps) {
+  const product = getHomeGardenProduct(stage);
+  if (!product) return null;
+
+  const visual = stageVisuals[stage];
+  const className = `${styles.figure} ${styles[size]}`;
+
+  if (!visual) {
+    return (
+      <figure className={`${className} ${styles.compost}`} aria-label={`Visual ${product.consumerName}`} data-home-garden-stage={stage}>
+        <div className={styles.compostBody}>
+          <span>Suelo primero</span>
+          <strong>{product.consumerName}</strong>
+          <small>{product.technicalName}</small>
+        </div>
+        {showTruthLabel ? <figcaption>Base del sistema · representación editorial</figcaption> : null}
+      </figure>
+    );
+  }
+
+  return (
+    <figure className={className} aria-label={`Visual ${product.consumerName}`} data-home-garden-stage={stage}>
+      <div className={styles.imageFrame}>
+        <Image
+          src={visual.src}
+          alt={visual.alt}
+          width={760}
+          height={1074}
+          sizes={size === "mini" ? "120px" : size === "hero" ? "420px" : "320px"}
+          unoptimized
+        />
+      </div>
+      <div className={styles.identity}>
+        <strong>{product.consumerName}</strong>
+        <small>{product.formula ?? "Compost"}</small>
+      </div>
+      {showTruthLabel ? <figcaption>Arte de línea aprobado · no packshot específico</figcaption> : null}
+    </figure>
+  );
+}


### PR DESCRIPTION
## Objetivo
Dar profundidad visual al catálogo Casa & Jardín usando únicamente activos Wondergreen ya aprobados, sin convertir artes de línea en packshots ni adelantar SKUs, precios o disponibilidad B2C.

## Cambios
- Nuevo componente compartido de visual por etapa para COMPOST, CRECE, EQUILIBRA, FLORECE y FRUCTIFICA.
- Los cuatro productos nutricionales consumen los activos públicos aprobados 2Grow, 2Balance, 2Bloom y 2Fruit; COMPOST conserva una representación editorial explícita de base del sistema.
- `/casa-jardin/productos` incorpora visual gobernado en cada tarjeta del catálogo.
- Las fichas de producto muestran la identidad visual aprobada en hero y separan explícitamente arte de línea de packshot doméstico.
- Nuevo rail visual reusable para composiciones de kits.
- `/casa-jardin/kits` visualiza las etapas de cada kit sin sugerir mezcla o aplicación simultánea.
- Las fichas de kit muestran su composición visual V1 en hero.
- E2E certifica activos, composición, jerarquía comercial y los disclaimers de packshot.

## Brand / Truth locks
- No se sintetizan empaques ni logos nuevos.
- Los artes de línea aprobados no se presentan como packshots específicos.
- No se crean SKUs, PVP, stock, checkout, dosis, frecuencia, cobertura ni claims de eficacia.
- Trasplanta & Arranca continúa bloqueado.
- El orientador y las paradas de seguridad permanecen sin cambios.
- Casa & Jardín continúa `noindex,follow` durante el pre-lanzamiento.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile