### PR TITLE
feat(public): alinea home y navegación a oferta comercial V2.2

### DIFF
--- a/e2e/public-editorial-home.spec.ts
+++ b/e2e/public-editorial-home.spec.ts
@@ -9,15 +9,20 @@ test("public HOME opens with the approved Greenatics hero and governed Yarumal m
   await expect(page.getByText("Proyecto Yarumal", { exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: "Soluciones para organizaciones", exact: true })).toHaveAttribute("href", "/soluciones");
   await expect(page.getByRole("link", { name: "Descubrir Wondergreen", exact: true }).first()).toHaveAttribute("href", "/wondergreen");
+  for (const capability of ["Planeación", "Infraestructura", "Operación", "Valorización"]) {
+    await expect(page.getByLabel("Capacidades Greenatics").getByText(capability, { exact: true })).toBeVisible();
+  }
 });
 
-test("public HOME reduces discovery to three clear Greenatics universes", async ({ page }) => {
+test("public HOME reduces discovery to three commercial Greenatics universes", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByRole("heading", { name: "Una marca. Tres formas claras de entrar." })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Soluciones para organizaciones", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Wondergreen", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Casa & Jardín", exact: true })).toBeVisible();
+  await expect(page.getByText(/Planeación, regulación, rutas, plantas, dirección técnica, operación, datos y valorización/i)).toBeVisible();
+  await expect(page.getByText(/Productos por etapa, kits y guías/i)).toBeVisible();
   await expect(page.getByRole("link", { name: /Explorar soluciones/ }).first()).toHaveAttribute("href", "/soluciones");
   await expect(page.getByRole("link", { name: /Descubrir Wondergreen/ }).last()).toHaveAttribute("href", "/wondergreen");
   await expect(page.getByRole("link", { name: /Explorar Casa & Jardín/ })).toHaveAttribute("href", "/casa-jardin");
@@ -30,18 +35,27 @@ test("public HOME explains Greenatics as an operating logic instead of stacked s
   for (const step of ["Entender", "Diseñar", "Implementar", "Medir y mejorar"]) {
     await expect(page.getByText(step, { exact: true })).toBeVisible();
   }
+  await expect(page.getByText(/Objetivo, contexto, restricciones, operación existente e información disponible/i)).toBeVisible();
   await expect(page.getByRole("link", { name: "Conocer cómo trabajamos →" })).toHaveAttribute("href", "/soluciones");
 });
 
-test("public HOME elevates Wondergreen without publishing unsupported universal claims", async ({ page }) => {
+test("public HOME elevates Wondergreen products before orientation without publishing unsupported universal claims", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByRole("heading", { name: "Nutrición que trabaja con el suelo." })).toBeVisible();
   await expect(page.getByText(/matriz organomineral, la oclusión y la lenta liberación documentada para esa versión/i)).toBeVisible();
   await expect(page.getByText(/sin convertir una característica del producto en una promesa agronómica universal/i)).toBeVisible();
-  await expect(page.getByRole("link", { name: "Encontrar mi programa →" })).toHaveAttribute("href", "/wondergreen/finder");
-  await expect(page.getByRole("link", { name: "Productos →" })).toHaveAttribute("href", "/wondergreen/productos");
-  await expect(page.getByRole("link", { name: "Cultivos →" })).toHaveAttribute("href", "/wondergreen/cultivos");
+
+  const links = page.getByLabel("Profundizar en Wondergreen").getByRole("link");
+  await expect(links).toHaveCount(4);
+  await expect(links.nth(0)).toHaveText("Productos →");
+  await expect(links.nth(0)).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(links.nth(1)).toHaveText("Cultivos →");
+  await expect(links.nth(1)).toHaveAttribute("href", "/wondergreen/cultivos");
+  await expect(links.nth(2)).toHaveText("Guías →");
+  await expect(links.nth(2)).toHaveAttribute("href", "/biblioteca");
+  await expect(links.nth(3)).toHaveText("Encontrar mi programa →");
+  await expect(links.nth(3)).toHaveAttribute("href", "/wondergreen/finder");
 });
 
 test("public HOME keeps evidence, digital tools and resources as distinct layers", async ({ page }) => {
@@ -55,11 +69,13 @@ test("public HOME keeps evidence, digital tools and resources as distinct layers
   await expect(page.getByRole("link", { name: /Ver impacto/ })).toHaveAttribute("href", "/impacto");
 });
 
-test("public HOME closes with a commercial route while keeping OPS separate", async ({ page }) => {
+test("public HOME closes with direct offers while keeping orientation optional and OPS separate", async ({ page }) => {
   await page.goto("/");
   const main = page.getByRole("main");
 
-  await expect(main.getByRole("heading", { name: "Empieza por el problema. Construimos la ruta contigo." })).toBeVisible();
+  await expect(main.getByRole("heading", { name: "Elige una solución y profundiza hasta el alcance que necesitas." })).toBeVisible();
+  await expect(main.getByText(/Puedes entrar directamente por servicios para organizaciones, productos Wondergreen o Casa & Jardín/i)).toBeVisible();
+  await expect(main.getByRole("link", { name: "Explorar soluciones", exact: true }).last()).toHaveAttribute("href", "/soluciones");
   await expect(main.getByRole("link", { name: "Hablar con nosotros", exact: true })).toHaveAttribute("href", "/contacto");
   await expect(main.getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
 });

--- a/e2e/public-shell-v2.spec.ts
+++ b/e2e/public-shell-v2.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test("desktop shell exposes the approved Soluciones mega-menu and closes with Escape", async ({ page }, testInfo) => {
+test("desktop shell exposes direct commercial solutions and closes with Escape", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "desktop-chromium", "desktop shell contract");
   await page.goto("/");
 
@@ -15,18 +15,21 @@ test("desktop shell exposes the approved Soluciones mega-menu and closes with Es
   await header.getByRole("button", { name: "Abrir menú Soluciones" }).click();
   const menu = header.getByRole("group", { name: "Menú Soluciones" });
   await expect(menu).toBeVisible();
+  await expect(menu.getByText("Elige el servicio que necesitas o entra por tu tipo de organización.", { exact: true })).toBeVisible();
   await expect(menu.getByRole("link", { name: /ESP \/ Prestador/ })).toHaveAttribute("href", "/soluciones/esp");
   await expect(menu.getByRole("link", { name: /Municipio/ }).first()).toHaveAttribute("href", "/soluciones/municipios");
   await expect(menu.getByRole("link", { name: /Empresa \/ Gran generador/ })).toHaveAttribute("href", "/soluciones/empresas");
   await expect(menu.getByRole("link", { name: /Propiedad horizontal \/ Institución/ })).toHaveAttribute("href", "/soluciones/propiedad-horizontal");
   await expect(menu.getByRole("link", { name: /Planta \/ Operador/ })).toHaveAttribute("href", "/soluciones/plantas");
-  await expect(menu.getByRole("link", { name: /Diagnóstico inicial Greenatics/ })).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
+  await expect(menu.getByRole("link", { name: /Gestión jurídica y regulatoria/ })).toHaveAttribute("href", "/soluciones/gestion-juridica-regulatoria");
+  await expect(menu.getByRole("link", { name: /Valorizar y desarrollar productos/ })).toHaveAttribute("href", "/soluciones/valorizacion-productos");
+  await expect(menu.getByRole("link", { name: /Usar orientador inicial/ })).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
 
   await page.keyboard.press("Escape");
   await expect(menu).toHaveCount(0);
 });
 
-test("mobile shell uses a two-level drawer and returns focus after Escape", async ({ page }, testInfo) => {
+test("mobile shell uses a two-level drawer with direct services and optional orientation", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "mobile-chromium", "mobile shell contract");
   await page.goto("/");
 
@@ -42,13 +45,16 @@ test("mobile shell uses a two-level drawer and returns focus after Escape", asyn
   await expect(dialog.getByRole("link", { name: "Ingresar", exact: true })).toHaveAttribute("href", "/app");
 
   await dialog.getByRole("button", { name: /Soluciones/ }).click();
+  await expect(dialog.getByText("Elige el servicio que necesitas o entra por tu tipo de organización.", { exact: true })).toBeVisible();
   await expect(dialog.getByText("Por organización", { exact: true })).toBeVisible();
   await expect(dialog.getByRole("link", { name: /ESP \/ Prestador/ })).toHaveAttribute("href", "/soluciones/esp");
   await expect(dialog.getByRole("link", { name: /Municipio/ }).first()).toHaveAttribute("href", "/soluciones/municipios");
   await expect(dialog.getByRole("link", { name: /Empresa \/ Gran generador/ })).toHaveAttribute("href", "/soluciones/empresas");
   await expect(dialog.getByRole("link", { name: /Propiedad horizontal \/ Institución/ })).toHaveAttribute("href", "/soluciones/propiedad-horizontal");
   await expect(dialog.getByRole("link", { name: /Planta \/ Operador/ })).toHaveAttribute("href", "/soluciones/plantas");
-  await expect(dialog.getByRole("link", { name: /Iniciar diagnóstico inicial/ })).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
+  await expect(dialog.getByRole("link", { name: /Gestión jurídica y regulatoria/ })).toHaveAttribute("href", "/soluciones/gestion-juridica-regulatoria");
+  await expect(dialog.getByRole("link", { name: /Valorizar y desarrollar productos/ })).toHaveAttribute("href", "/soluciones/valorizacion-productos");
+  await expect(dialog.getByRole("link", { name: /Usar orientador inicial/ })).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
 
   await page.keyboard.press("Escape");
   await expect(dialog).toHaveCount(0);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ const universes = [
     number: "01",
     kicker: "Organizaciones",
     title: "Soluciones para organizaciones",
-    copy: "Diagnóstico, planeación, regulación, rutas, plantas, dirección técnica y datos para convertir necesidades de gestión en decisiones y entregables concretos.",
+    copy: "Planeación, regulación, rutas, plantas, dirección técnica, operación, datos y valorización convertidos en actividades y entregables concretos.",
     href: "/soluciones",
     cta: "Explorar soluciones",
   },
@@ -25,7 +25,7 @@ const universes = [
     number: "02",
     kicker: "Agro",
     title: "Wondergreen",
-    copy: "Nutrición organomineral, bioinsumos, programas por cultivo, guías y acompañamiento técnico dentro de una misma lógica de suelo, nutrición y seguimiento.",
+    copy: "Productos, nutrición organomineral, bioinsumos, programas por cultivo, guías y acompañamiento técnico dentro de una misma lógica de suelo y seguimiento.",
     href: "/wondergreen",
     cta: "Descubrir Wondergreen",
   },
@@ -33,14 +33,14 @@ const universes = [
     number: "03",
     kicker: "Hogar · jardín · huerta",
     title: "Casa & Jardín",
-    copy: "Nutrición por etapas, diagnóstico orientativo y guías para plantas de casa, jardines, huertas y viveros, con el comercio aún separado de la validación técnica.",
+    copy: "Productos por etapa, kits y guías para plantas de casa, jardines, huertas y viveros, con un orientador disponible cuando la etapa o condición todavía no están claras.",
     href: "/casa-jardin",
     cta: "Explorar Casa & Jardín",
   },
 ];
 
 const operatingLogic = [
-  ["01", "Entender", "Caracterización, contexto, restricciones, operación existente y datos disponibles."],
+  ["01", "Entender", "Objetivo, contexto, restricciones, operación existente e información disponible para definir el punto de partida."],
   ["02", "Diseñar", "Ruta técnica, jurídica, operativa y económica adecuada al problema real."],
   ["03", "Implementar", "Protocolos, infraestructura, acompañamiento, puesta en marcha o dirección técnica según el alcance."],
   ["04", "Medir y mejorar", "Trazabilidad, indicadores, seguimiento y nuevas decisiones sobre información verificable."],
@@ -89,11 +89,11 @@ export default function Home() {
                 <Link className={`${styles.button} ${styles.buttonPrimary}`} href="/soluciones">Soluciones para organizaciones</Link>
                 <Link className={`${styles.button} ${styles.buttonGhost}`} href="/wondergreen">Descubrir Wondergreen</Link>
               </div>
-              <div className={styles.capabilityLine} aria-label="Lógica de trabajo Greenatics">
-                <span>Diagnóstico</span>
+              <div className={styles.capabilityLine} aria-label="Capacidades Greenatics">
+                <span>Planeación</span>
                 <span>Infraestructura</span>
                 <span>Operación</span>
-                <span>Datos</span>
+                <span>Valorización</span>
               </div>
             </div>
 
@@ -122,7 +122,7 @@ export default function Home() {
                 <h2 id="home-universes-title">Una marca. Tres formas claras de entrar.</h2>
               </div>
               <p>
-                La web separa la consultoría para organizaciones, la línea agro Wondergreen y la experiencia Casa & Jardín para que cada visitante llegue rápido al contexto que le corresponde.
+                La web separa las soluciones para organizaciones, la línea agro Wondergreen y la experiencia Casa & Jardín para que cada visitante llegue rápido a la oferta que le corresponde.
               </p>
             </div>
 
@@ -185,11 +185,11 @@ export default function Home() {
               <p>
                 Wondergreen organiza el portafolio alrededor del suelo, la nutrición, la biología, el cultivo y el seguimiento. En las referencias sólidas que correspondan, la explicación técnica parte de la matriz organomineral, la oclusión y la lenta liberación documentada para esa versión, sin convertir una característica del producto en una promesa agronómica universal.
               </p>
-              <div className={styles.wondergreenLinks}>
-                <Link href="/wondergreen/finder">Encontrar mi programa →</Link>
+              <div className={styles.wondergreenLinks} aria-label="Profundizar en Wondergreen">
                 <Link href="/wondergreen/productos">Productos →</Link>
                 <Link href="/wondergreen/cultivos">Cultivos →</Link>
                 <Link href="/biblioteca">Guías →</Link>
+                <Link href="/wondergreen/finder">Encontrar mi programa →</Link>
               </div>
             </div>
           </div>
@@ -203,7 +203,7 @@ export default function Home() {
               <span className={styles.eyebrow}>Tecnología y datos</span>
               <h2 id="home-digital-title">La operación también necesita una capa digital.</h2>
               <p>
-                GREENATICS OPS conecta datos operativos, trazabilidad y seguimiento para los procesos que ya están en ejecución. La arquitectura digital de Greenatics está pensada para crecer con nuevas herramientas de captura en campo, diagnóstico y acompañamiento sin fragmentar la experiencia del cliente.
+                GREENATICS OPS conecta datos operativos, trazabilidad y seguimiento para los procesos que ya están en ejecución. La arquitectura digital de Greenatics está pensada para crecer con nuevas herramientas de captura en campo y acompañamiento sin fragmentar la experiencia del cliente.
               </p>
               <div className={styles.actions}>
                 <a className={`${styles.button} ${styles.buttonDark}`} href="/app">Ingresar</a>
@@ -251,15 +251,15 @@ export default function Home() {
           <div className={`${styles.container} ${styles.closingGrid}`}>
             <div>
               <span className={`${styles.eyebrow} ${styles.eyebrowLight}`}>Greenatics</span>
-              <h2 id="home-closing-title">Empieza por el problema. Construimos la ruta contigo.</h2>
+              <h2 id="home-closing-title">Elige una solución y profundiza hasta el alcance que necesitas.</h2>
             </div>
             <div>
               <p>
-                Residuos, operación, plantas, cumplimiento, datos, valorización o nutrición pueden ser el punto de entrada. La primera conversación sirve para ubicar el contexto y definir el siguiente paso.
+                Puedes entrar directamente por servicios para organizaciones, productos Wondergreen o Casa & Jardín. Si todavía no sabes qué ruta corresponde, cada universo conserva herramientas de orientación sin convertirlas en la oferta principal.
               </p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.buttonLight}`} href="/contacto">Hablar con nosotros</Link>
-                <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/soluciones">Explorar soluciones</Link>
+                <Link className={`${styles.button} ${styles.buttonLight}`} href="/soluciones">Explorar soluciones</Link>
+                <Link className={`${styles.button} ${styles.buttonOutlineLight}`} href="/contacto">Hablar con nosotros</Link>
               </div>
             </div>
           </div>

--- a/src/components/public-header.tsx
+++ b/src/components/public-header.tsx
@@ -110,7 +110,7 @@ export function PublicHeader() {
           </button>
           <div className={styles.mobilePanelHead}>
             <span>Soluciones Greenatics</span>
-            <strong>Empieza por quién eres o por lo que necesitas resolver.</strong>
+            <strong>Elige el servicio que necesitas o entra por tu tipo de organización.</strong>
           </div>
           <Link className={styles.mobileFeaturedLink} href="/soluciones" onClick={closeMobile}>
             Ver todas las soluciones <span aria-hidden="true">→</span>
@@ -124,8 +124,8 @@ export function PublicHeader() {
             {publicSolutionNeeds.map((item) => <MenuLink key={item.label} item={item} onNavigate={closeMobile} />)}
           </div>
           <Link className={styles.mobileDiagnostic} href="/soluciones/diagnostico-inicial" onClick={closeMobile}>
-            <span>No sé por dónde empezar</span>
-            <strong>Iniciar diagnóstico inicial</strong>
+            <span>¿Todavía no sabes qué servicio revisar?</span>
+            <strong>Usar orientador inicial</strong>
             <span aria-hidden="true">→</span>
           </Link>
         </>
@@ -236,7 +236,7 @@ export function PublicHeader() {
                   <div className={`${styles.megaMenu} ${styles.solutionsMenu}`} role="group" aria-label="Menú Soluciones">
                     <div className={styles.megaIntro}>
                       <span>Soluciones Greenatics</span>
-                      <strong>Empieza por tu contexto. Después profundizamos en el servicio.</strong>
+                      <strong>Elige el servicio que necesitas o entra por tu tipo de organización.</strong>
                       <Link href="/soluciones" onClick={() => setDesktopMenu(null)}>Ver todas las soluciones →</Link>
                     </div>
                     <div className={styles.megaColumn}>
@@ -248,8 +248,8 @@ export function PublicHeader() {
                       {publicSolutionNeeds.map((item) => <MenuLink key={item.label} item={item} onNavigate={() => setDesktopMenu(null)} />)}
                     </div>
                     <Link className={styles.megaDiagnostic} href="/soluciones/diagnostico-inicial" onClick={() => setDesktopMenu(null)}>
-                      <span>No sé por dónde empezar</span>
-                      <strong>Diagnóstico inicial Greenatics</strong>
+                      <span>¿Todavía no sabes qué servicio revisar?</span>
+                      <strong>Usar orientador inicial</strong>
                       <span aria-hidden="true">→</span>
                     </Link>
                   </div>

--- a/src/data/public-navigation.ts
+++ b/src/data/public-navigation.ts
@@ -8,7 +8,6 @@ export type PublicMenuItem = {
   label: string;
   description: string;
   href: string;
-  canonicalHref?: string;
 };
 
 export const publicPrimaryNav: readonly PublicPrimaryNavItem[] = [
@@ -37,7 +36,7 @@ export const publicSolutionAudiences: readonly PublicMenuItem[] = [
   },
   {
     label: "Propiedad horizontal / Institución",
-    description: "Diagnóstico por unidad, PMIRS, redes e información comparable.",
+    description: "Gestión por unidad, PMIRS, redes, implementación e información comparable.",
     href: "/soluciones/propiedad-horizontal",
   },
   {
@@ -60,9 +59,8 @@ export const publicSolutionNeeds: readonly PublicMenuItem[] = [
   },
   {
     label: "Gestión jurídica y regulatoria",
-    description: "Obligaciones, decisiones regulatorias y acciones concretas.",
-    href: "/soluciones",
-    canonicalHref: "/soluciones/juridica-regulacion",
+    description: "Obligaciones, competencias, documentos, contratos, trámites y soporte regulatorio.",
+    href: "/soluciones/gestion-juridica-regulatoria",
   },
   {
     label: "Mejorar rutas y logística",
@@ -86,9 +84,8 @@ export const publicSolutionNeeds: readonly PublicMenuItem[] = [
   },
   {
     label: "Valorizar y desarrollar productos",
-    description: "Calidad, destinos y nuevas rutas de aprovechamiento.",
-    href: "/soluciones/residuos-organicos",
-    canonicalHref: "/soluciones/valorizacion-productos",
+    description: "Especificaciones, calidad, documentación, ruta regulatoria y preparación comercial.",
+    href: "/soluciones/valorizacion-productos",
   },
 ] as const;
 


### PR DESCRIPTION
## Objetivo
Cerrar la jerarquía comercial pública después de profundizar Soluciones, Wondergreen y Casa & Jardín: la HOME y el header deben mostrar primero servicios, productos, kits y destinos profundos; el orientador queda disponible únicamente como ruta secundaria cuando todavía existe incertidumbre.

## Cambios
- HOME conserva el H1 aprobado `Transformamos residuos en vida.`.
- El universo Soluciones deja de abrir con diagnóstico y enumera planeación, regulación, rutas, plantas, dirección técnica, operación, datos y valorización.
- Casa & Jardín presenta productos por etapa, kits y guías antes de mencionar orientación.
- La línea de capacidades del hero pasa a `Planeación · Infraestructura · Operación · Valorización`.
- Wondergreen ordena sus accesos `Productos → Cultivos → Guías → Finder`, dejando Finder al final.
- El cierre de HOME invita a entrar directamente por las ofertas y explica la orientación como recurso opcional.
- Mega-menú y drawer móvil de Soluciones usan lenguaje comercial-first y renombran la tarjeta secundaria como `Usar orientador inicial`.
- Gestión jurídica y regulatoria enlaza directamente a `/soluciones/gestion-juridica-regulatoria`.
- Valorización y desarrollo de productos enlaza directamente a `/soluciones/valorizacion-productos`.
- Se elimina `canonicalHref` del modelo de navegación porque no participaba en el routing real.
- E2E fija el orden comercial de Wondergreen y las rutas profundas del mega-menú en desktop y mobile.

## Truth / UX locks
- Diagnóstico/orientación sigue disponible, pero no se presenta como oferta central.
- No cambia el H1 aprobado de HOME ni el H1 de Wondergreen.
- No se agregan servicios, productos, SKUs, claims, métricas, PVP, checkout ni promesas regulatorias.
- Las rutas profundas existentes siguen gobernando sus propios límites y entregables.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile