### PR TITLE
feat(wondergreen): separa lectura y descarga documental V2.3

### DIFF
--- a/e2e/wondergreen-product-depth.spec.ts
+++ b/e2e/wondergreen-product-depth.spec.ts
@@ -15,12 +15,13 @@ test("Wondergreen catalog starts with commercial products and keeps orientation 
 test("Wondergreen product page exposes presentations plus open and download PDF actions without inventing an individual technical sheet", async ({ page }) => {
   await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
 
-  await expect(page.getByRole("heading", { name: /2Grow Sólido/ })).toBeVisible();
-  await expect(page.getByRole("img", { name: "Identidad visual aprobada de la línea Wondergreen 2Grow" })).toBeVisible();
-  await expect(page.getByText("Documentación oficial", { exact: true })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Abre o descarga los documentos aprobados, no una reconstrucción de ellos." })).toBeVisible();
-  await expect(page.getByText("5 kg", { exact: true })).toBeVisible();
-  await expect(page.getByText("40 kg", { exact: true })).toBeVisible();
+  const main = page.getByRole("main");
+  await expect(main.getByRole("heading", { name: /2Grow Sólido/ })).toBeVisible();
+  await expect(main.getByRole("img", { name: "Identidad visual aprobada de la línea Wondergreen 2Grow" })).toBeVisible();
+  await expect(main.getByText("Documentación oficial", { exact: true })).toBeVisible();
+  await expect(main.getByRole("heading", { name: "Abre o descarga los documentos aprobados, no una reconstrucción de ellos." })).toBeVisible();
+  await expect(main.getByText("5 kg", { exact: true })).toBeVisible();
+  await expect(main.getByText("40 kg", { exact: true })).toBeVisible();
 
   const hrefs = await page.locator("a").evaluateAll((links) => links.map((link) => link.getAttribute("href") ?? ""));
   expect(hrefs).toContain("/api/public-resources/wondergreen-product-master");
@@ -31,8 +32,8 @@ test("Wondergreen product page exposes presentations plus open and download PDF 
   expect(hrefs).toContain("/api/public-resources/wondergreen-guide-cacao?download=1");
   expect(hrefs.join(" ")).not.toMatch(/sharepoint|graph\.microsoft/i);
 
-  await expect(page.getByRole("link", { name: /Descargar catálogo PDF/ })).toHaveAttribute("href", "/api/public-resources/wondergreen-product-master?download=1");
-  await expect(page.getByRole("link", { name: /Descargar guía PDF/ }).first()).toHaveAttribute("href", /\?download=1$/);
-  await expect(page.getByRole("heading", { name: "Ficha técnica específica" })).toBeVisible();
-  await expect(page.getByText("Pendiente de vincular master público", { exact: true })).toBeVisible();
+  await expect(main.getByRole("link", { name: /Descargar catálogo PDF/ })).toHaveAttribute("href", "/api/public-resources/wondergreen-product-master?download=1");
+  await expect(main.getByRole("link", { name: /Descargar guía PDF/ }).first()).toHaveAttribute("href", /\?download=1$/);
+  await expect(main.getByRole("heading", { name: "Ficha técnica específica" })).toBeVisible();
+  await expect(main.getByText("Pendiente de vincular master público", { exact: true })).toBeVisible();
 });

--- a/e2e/wondergreen-product-depth.spec.ts
+++ b/e2e/wondergreen-product-depth.spec.ts
@@ -12,22 +12,27 @@ test("Wondergreen catalog starts with commercial products and keeps orientation 
   await expect(growCard.getByRole("img", { name: "Identidad visual aprobada de la línea Wondergreen 2Grow" })).toBeVisible();
 });
 
-test("Wondergreen product page exposes presentations and official PDF relationships without inventing an individual technical sheet", async ({ page }) => {
+test("Wondergreen product page exposes presentations plus open and download PDF actions without inventing an individual technical sheet", async ({ page }) => {
   await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
 
   await expect(page.getByRole("heading", { name: /2Grow Sólido/ })).toBeVisible();
   await expect(page.getByRole("img", { name: "Identidad visual aprobada de la línea Wondergreen 2Grow" })).toBeVisible();
   await expect(page.getByText("Documentación oficial", { exact: true })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Abre los documentos aprobados, no una reconstrucción de ellos." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Abre o descarga los documentos aprobados, no una reconstrucción de ellos." })).toBeVisible();
   await expect(page.getByText("5 kg", { exact: true })).toBeVisible();
   await expect(page.getByText("40 kg", { exact: true })).toBeVisible();
 
   const hrefs = await page.locator("a").evaluateAll((links) => links.map((link) => link.getAttribute("href") ?? ""));
   expect(hrefs).toContain("/api/public-resources/wondergreen-product-master");
+  expect(hrefs).toContain("/api/public-resources/wondergreen-product-master?download=1");
   expect(hrefs).toContain("/api/public-resources/wondergreen-guide-cafe");
+  expect(hrefs).toContain("/api/public-resources/wondergreen-guide-cafe?download=1");
   expect(hrefs).toContain("/api/public-resources/wondergreen-guide-cacao");
+  expect(hrefs).toContain("/api/public-resources/wondergreen-guide-cacao?download=1");
   expect(hrefs.join(" ")).not.toMatch(/sharepoint|graph\.microsoft/i);
 
+  await expect(page.getByRole("link", { name: /Descargar catálogo PDF/ })).toHaveAttribute("href", "/api/public-resources/wondergreen-product-master?download=1");
+  await expect(page.getByRole("link", { name: /Descargar guía PDF/ }).first()).toHaveAttribute("href", /\?download=1$/);
   await expect(page.getByRole("heading", { name: "Ficha técnica específica" })).toBeVisible();
   await expect(page.getByText("Pendiente de vincular master público", { exact: true })).toBeVisible();
 });

--- a/e2e/wondergreen-visual-band.spec.ts
+++ b/e2e/wondergreen-visual-band.spec.ts
@@ -8,17 +8,18 @@ const expectedVisuals = [
 ] as const;
 
 async function expectWondergreenVisualBand(page: import("@playwright/test").Page) {
-  await expect(page.getByRole("heading", { name: "Del suelo a cada etapa de la planta." })).toBeVisible();
-  await expect(page.getByRole("img", { name: "Sistema Wondergreen por etapas", exact: true })).toHaveAttribute("src", "/api/public-media/wondergreen-system-stages");
-  await expect(page.getByRole("img", { name: "Bioinsumos Wondergreen", exact: true })).toHaveAttribute("src", "/api/public-media/wondergreen-bioinsumos");
+  const band = page.getByLabel("Del suelo a cada etapa de la planta.");
+  await expect(band.getByRole("heading", { name: "Del suelo a cada etapa de la planta." })).toBeVisible();
+  await expect(band.getByRole("img", { name: "Sistema Wondergreen por etapas", exact: true })).toHaveAttribute("src", "/api/public-media/wondergreen-system-stages");
+  await expect(band.getByRole("img", { name: "Bioinsumos Wondergreen", exact: true })).toHaveAttribute("src", "/api/public-media/wondergreen-bioinsumos");
 
   for (const [alt, src] of expectedVisuals) {
-    await expect(page.getByRole("img", { name: alt, exact: true })).toHaveAttribute("src", src);
+    await expect(band.getByRole("img", { name: alt, exact: true })).toHaveAttribute("src", src);
   }
 
-  await expect(page.getByRole("link", { name: /Descargar catálogo PDF/i })).toHaveAttribute("href", "/api/public-resources/wondergreen-product-master");
-  await expect(page.getByRole("link", { name: "Ver Product Master →", exact: true })).toHaveAttribute("href", "/wondergreen/productos");
-  await expect(page.getByRole("link", { name: "Casa & Jardín →", exact: true })).toHaveAttribute("href", "/casa-jardin");
+  await expect(band.getByRole("link", { name: /Descargar catálogo PDF/i })).toHaveAttribute("href", "/api/public-resources/wondergreen-product-master");
+  await expect(band.getByRole("link", { name: "Ver Product Master →", exact: true })).toHaveAttribute("href", "/wondergreen/productos");
+  await expect(band.getByRole("link", { name: "Casa & Jardín →", exact: true })).toHaveAttribute("href", "/casa-jardin");
 }
 
 test("Wondergreen landing closes with the real visual product system", async ({ page }) => {

--- a/src/app/wondergreen/productos/[slug]/page.tsx
+++ b/src/app/wondergreen/productos/[slug]/page.tsx
@@ -42,6 +42,10 @@ function formatLabel(format: string) {
   return labels[format] ?? format;
 }
 
+function forceDownloadHref(href: string) {
+  return `${href}${href.includes("?") ? "&" : "?"}download=1`;
+}
+
 export default async function WondergreenProductPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const reference = getWondergreenReference(slug);
@@ -149,21 +153,38 @@ export default async function WondergreenProductPage({ params }: { params: Promi
           <div className={styles.container}>
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Documentación oficial</span>
-              <h2>Abre los documentos aprobados, no una reconstrucción de ellos.</h2>
-              <p>La página web organiza la referencia y sus relaciones. Los PDF publicados conservan el diseño y contenido del master editorial aprobado.</p>
+              <h2>Abre o descarga los documentos aprobados, no una reconstrucción de ellos.</h2>
+              <p>La página web organiza la referencia y sus relaciones. Los PDF publicados conservan el diseño y contenido del master editorial aprobado, con acciones separadas para lectura y descarga.</p>
             </div>
             <div className={depth.documentGrid}>
               {documents.catalog?.downloadHref ? (
                 <article className={depth.documentCard}>
                   {documents.catalog.coverImage ? <Image src={documents.catalog.coverImage} alt={`Portada de ${documents.catalog.title}`} width={520} height={735} unoptimized /> : null}
-                  <div><span>{documents.catalog.statusLabel}</span><h3>{documents.catalog.title}</h3><p>{documents.catalog.masterLabel}</p><a href={documents.catalog.downloadHref} target="_blank" rel="noreferrer">Abrir catálogo PDF →</a></div>
+                  <div>
+                    <span>{documents.catalog.statusLabel}</span>
+                    <h3>{documents.catalog.title}</h3>
+                    <p>{documents.catalog.masterLabel}</p>
+                    <div className={depth.documentActions}>
+                      <a href={documents.catalog.downloadHref} target="_blank" rel="noreferrer">Abrir catálogo PDF →</a>
+                      <a href={forceDownloadHref(documents.catalog.downloadHref)}>{documents.catalog.downloadLabel ?? "Descargar catálogo PDF"} ↓</a>
+                    </div>
+                  </div>
                 </article>
               ) : null}
 
               {documents.guides.map((guide) => (
                 <article className={depth.documentCard} key={guide.id}>
                   {guide.coverImage ? <Image src={guide.coverImage} alt={`Portada de ${guide.title}`} width={520} height={735} unoptimized /> : null}
-                  <div><span>{guide.statusLabel}</span><h3>{guide.title}</h3><p>{guide.masterLabel}</p><div className={depth.documentActions}><Link href={guide.href}>Ver programa web</Link>{guide.downloadHref ? <a href={guide.downloadHref} target="_blank" rel="noreferrer">Abrir PDF →</a> : null}</div></div>
+                  <div>
+                    <span>{guide.statusLabel}</span>
+                    <h3>{guide.title}</h3>
+                    <p>{guide.masterLabel}</p>
+                    <div className={depth.documentActions}>
+                      <Link href={guide.href}>Ver programa web</Link>
+                      {guide.downloadHref ? <a href={guide.downloadHref} target="_blank" rel="noreferrer">Abrir PDF →</a> : null}
+                      {guide.downloadHref ? <a href={forceDownloadHref(guide.downloadHref)}>{guide.downloadLabel ?? "Descargar guía PDF"} ↓</a> : null}
+                    </div>
+                  </div>
                 </article>
               ))}
 


### PR DESCRIPTION
## Objetivo
Profundizar la ficha individual Wondergreen para que la documentación oficial pueda abrirse o descargarse explícitamente desde el producto, manteniendo el PDF aprobado como master editorial y la web como capa de contexto.

## Cambios
- La sección documental de cada producto distingue `Abrir` y `Descargar`.
- Catálogo Wondergreen: lectura same-origin y descarga forzada `?download=1`.
- Guías de cultivo relacionadas: programa web, apertura del PDF original y descarga del PDF original.
- Se reutilizan `downloadHref` y `downloadLabel` del registro gobernado de recursos; no se duplican masters.
- La ficha técnica individual sigue mostrando `Pendiente de vincular master público` cuando no existe documento específico aprobado.
- E2E verifica rutas de apertura y descarga de catálogo y guías, y que no se expongan URLs privadas de SharePoint/Graph.

## Truth / Asset locks
- No se reconstruyen fichas técnicas inexistentes.
- No se inventan dosis, frecuencia, compatibilidad, eficacia, formulaciones ni presentaciones.
- Los PDFs siguen saliendo por el proxy público same-origin existente.
- La descarga no modifica ni reinterpreta el master aprobado.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile