### PR TITLE
feat(home-garden): profundiza productos kits y guías V2.1

### DIFF
--- a/e2e/home-garden-commercial-depth.spec.ts
+++ b/e2e/home-garden-commercial-depth.spec.ts
@@ -38,20 +38,33 @@ test("Casa Jardin product catalog exposes governed stages and approved visuals b
   await expect(page.getByRole("link", { name: /Comprar|Añadir al carrito|Checkout/i })).toHaveCount(0);
 });
 
-test("Casa Jardin product detail puts technical product truth and approved line art before diagnostic orientation", async ({ page }) => {
+test("Casa Jardin product detail puts technical product truth, documents and kits before diagnostic orientation", async ({ page }) => {
   await page.goto("/casa-jardin/productos/crece");
 
-  await expect(page.getByRole("heading", { name: "CRECE", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1, name: "CRECE", exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: "← Volver a productos", exact: true })).toHaveAttribute("href", "/casa-jardin/productos");
-  await expect(page.getByRole("link", { name: "Ver Product Truth técnico", exact: true })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
-  await expect(page.getByRole("link", { name: "Ver kits por uso", exact: true })).toHaveAttribute("href", "/casa-jardin/kits");
-  await expect(page.getByRole("link", { name: "No sé si corresponde a mi planta", exact: true })).toHaveAttribute("href", "/casa-jardin/diagnostico");
+  await expect(page.getByRole("link", { name: "Ver referencia técnica", exact: true })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
+  await expect(page.getByRole("link", { name: "Ver documentación", exact: true })).toHaveAttribute("href", "#documentacion");
+  await expect(page.getByRole("link", { name: "Ver kits relacionados", exact: true })).toHaveAttribute("href", "#kits-relacionados");
 
   const visual = page.getByLabel("Visual CRECE", { exact: true });
   await expect(visual).toBeVisible();
   await expect(visual.getByRole("img", { name: "Arte aprobado de la línea Wondergreen 2Grow para la etapa CRECE", exact: true })).toHaveAttribute("src", "/api/public-media/wondergreen-2grow");
   await expect(page.getByText(/no representa un packshot específico/i)).toBeVisible();
   await expect(page.getByText(/Sin precio público, cobertura ni dosis/i).first()).toBeVisible();
+
+  const hierarchy = await page.evaluate(() => {
+    const documents = document.querySelector("#documentacion");
+    const kits = document.querySelector("#kits-relacionados");
+    const orientation = document.querySelector("#product-orientation-title");
+    if (!documents || !kits || !orientation) return { documentsBeforeOrientation: false, kitsBeforeOrientation: false };
+    return {
+      documentsBeforeOrientation: Boolean(documents.compareDocumentPosition(orientation) & Node.DOCUMENT_POSITION_FOLLOWING),
+      kitsBeforeOrientation: Boolean(kits.compareDocumentPosition(orientation) & Node.DOCUMENT_POSITION_FOLLOWING),
+    };
+  });
+  expect(hierarchy).toEqual({ documentsBeforeOrientation: true, kitsBeforeOrientation: true });
+  await expect(page.getByRole("link", { name: "Usar orientador de etapa y condición", exact: true })).toHaveAttribute("href", "/casa-jardin/diagnostico");
 });
 
 test("Casa Jardin kit catalog exposes visual prelaunch compositions and keeps blocked kit out", async ({ page }) => {
@@ -73,14 +86,14 @@ test("Casa Jardin kit catalog exposes visual prelaunch compositions and keeps bl
   await expect(page.getByText(/Trasplanta & Arranca sigue fuera del catálogo visible/i)).toBeVisible();
 });
 
-test("Casa Jardin kit detail leads with governed visual composition and product route, not diagnosis", async ({ page }) => {
+test("Casa Jardin kit detail leads with governed composition, products and documents before orientation", async ({ page }) => {
   await page.goto("/casa-jardin/kits/mi-huerta");
 
-  await expect(page.getByRole("heading", { name: "Kit Mi Huerta", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1, name: "Kit Mi Huerta", exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: "← Volver a kits", exact: true })).toHaveAttribute("href", "/casa-jardin/kits");
   await expect(page.getByRole("link", { name: "Ver productos del kit", exact: true })).toHaveAttribute("href", "#ruta-kit");
-  await expect(page.getByRole("link", { name: "Explorar productos por etapa", exact: true })).toHaveAttribute("href", "/casa-jardin/productos");
-  await expect(page.getByRole("link", { name: "No sé si este kit encaja", exact: true })).toHaveAttribute("href", "/casa-jardin/diagnostico");
+  await expect(page.getByRole("link", { name: "Ver documentación", exact: true })).toHaveAttribute("href", "#documentacion-kit");
+  await expect(page.getByRole("link", { name: "Explorar todos los productos", exact: true })).toHaveAttribute("href", "/casa-jardin/productos");
 
   const visualRail = page.getByLabel("Etapas incluidas en Kit Mi Huerta", { exact: true });
   await expect(visualRail).toBeVisible();
@@ -89,10 +102,23 @@ test("Casa Jardin kit detail leads with governed visual composition and product 
   }
   await expect(page.getByText(/No son packshots finales del kit/i)).toBeVisible();
 
-  const productLinks = page.getByRole("link", { name: "Ver producto →", exact: true });
+  const productLinks = page.getByRole("link", { name: "Abrir ficha de producto →", exact: true });
   await expect(productLinks).toHaveCount(4);
   await expect(productLinks.nth(0)).toHaveAttribute("href", "/casa-jardin/productos/prepara");
   await expect(productLinks.nth(1)).toHaveAttribute("href", "/casa-jardin/productos/crece");
   await expect(productLinks.nth(2)).toHaveAttribute("href", "/casa-jardin/productos/florece");
   await expect(productLinks.nth(3)).toHaveAttribute("href", "/casa-jardin/productos/fructifica");
+
+  const hierarchy = await page.evaluate(() => {
+    const products = document.querySelector("#ruta-kit");
+    const documents = document.querySelector("#documentacion-kit");
+    const orientation = document.querySelector("#kit-orientation-title");
+    if (!products || !documents || !orientation) return { productsBeforeOrientation: false, documentsBeforeOrientation: false };
+    return {
+      productsBeforeOrientation: Boolean(products.compareDocumentPosition(orientation) & Node.DOCUMENT_POSITION_FOLLOWING),
+      documentsBeforeOrientation: Boolean(documents.compareDocumentPosition(orientation) & Node.DOCUMENT_POSITION_FOLLOWING),
+    };
+  });
+  expect(hierarchy).toEqual({ productsBeforeOrientation: true, documentsBeforeOrientation: true });
+  await expect(page.getByRole("link", { name: "Usar orientador de etapa y condición", exact: true })).toHaveAttribute("href", "/casa-jardin/diagnostico");
 });

--- a/e2e/home-garden-product-depth.spec.ts
+++ b/e2e/home-garden-product-depth.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test("Casa product detail reaches technical truth, documents and related kits before orientation", async ({ page }) => {
   await page.goto("/casa-jardin/productos/crece");
 
-  await expect(page.getByRole("heading", { name: "CRECE", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1, name: "CRECE", exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: "Ver referencia técnica", exact: true })).toHaveAttribute(
     "href",
     "/wondergreen/productos/2grow-solido-15-3-3",
@@ -41,7 +41,7 @@ test("Casa product detail reaches technical truth, documents and related kits be
 test("Mi Huerta kit opens each product and its specific verified PDF", async ({ page }) => {
   await page.goto("/casa-jardin/kits/mi-huerta");
 
-  await expect(page.getByRole("heading", { name: "Kit Mi Huerta", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1, name: "Kit Mi Huerta", exact: true })).toBeVisible();
   const productRoute = page.locator("#ruta-kit");
   for (const href of [
     "/casa-jardin/productos/prepara",
@@ -54,9 +54,8 @@ test("Mi Huerta kit opens each product and its specific verified PDF", async ({ 
 
   const documents = page.locator("#documentacion-kit");
   await expect(documents.getByRole("heading", { name: "Guía Mi Huerta", exact: true })).toBeVisible();
-  const miHuertaCard = documents.getByRole("article").filter({
-    has: documents.getByRole("heading", { name: "Guía Mi Huerta", exact: true }),
-  });
+  const miHuertaCard = documents.locator("article").filter({ hasText: "Guía Mi Huerta" });
+  await expect(miHuertaCard).toHaveCount(1);
   await expect(miHuertaCard.getByRole("link", { name: "Abrir PDF ↗" })).toHaveAttribute(
     "href",
     "/api/public-resources/home-garden-guide-mi-huerta",

--- a/e2e/home-garden-product-depth.spec.ts
+++ b/e2e/home-garden-product-depth.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+test("Casa product detail reaches technical truth, documents and related kits before orientation", async ({ page }) => {
+  await page.goto("/casa-jardin/productos/crece");
+
+  await expect(page.getByRole("heading", { name: "CRECE", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Ver referencia técnica", exact: true })).toHaveAttribute(
+    "href",
+    "/wondergreen/productos/2grow-solido-15-3-3",
+  );
+  await expect(page.getByRole("heading", { name: "La referencia existe antes que la presentación doméstica." })).toBeVisible();
+  await expect(page.getByText("2Grow Sólido", { exact: true })).toBeVisible();
+  await expect(page.getByText("Formulación 15-3-3.", { exact: true })).toBeVisible();
+
+  const documents = page.locator("#documentacion");
+  await expect(documents.getByRole("heading", { name: "Producto, guía y Product Truth permanecen conectados, pero no se confunden." })).toBeVisible();
+  await expect(documents.getByRole("heading", { name: "Guía Wondergreen Casa & Jardín", exact: true })).toBeVisible();
+  await expect(documents.getByRole("heading", { name: "Guía rápida de etapas", exact: true })).toBeVisible();
+  await expect(documents.getByRole("link", { name: "Abrir PDF ↗" }).first()).toHaveAttribute(
+    "href",
+    "/api/public-resources/home-garden-guide-casa-jardin",
+  );
+  await expect(documents.getByRole("link", { name: "Descargar ↓" }).first()).toHaveAttribute(
+    "href",
+    "/api/public-resources/home-garden-guide-casa-jardin?download=1",
+  );
+
+  const kits = page.locator("#kits-relacionados");
+  await expect(kits.getByRole("heading", { name: "Kit Plantas Verdes", exact: true })).toBeVisible();
+  await expect(kits.getByRole("heading", { name: "Kit Mi Huerta", exact: true })).toBeVisible();
+  await expect(kits.getByRole("heading", { name: "Kit Casa Completa", exact: true })).toBeVisible();
+
+  const orientation = page.getByRole("heading", { name: "¿No sabes si CRECE corresponde a tu planta?" });
+  await expect(orientation).toBeVisible();
+  await expect(page.getByRole("link", { name: "Usar orientador de etapa y condición", exact: true })).toHaveAttribute(
+    "href",
+    "/casa-jardin/diagnostico",
+  );
+});
+
+test("Mi Huerta kit opens each product and its specific verified PDF", async ({ page }) => {
+  await page.goto("/casa-jardin/kits/mi-huerta");
+
+  await expect(page.getByRole("heading", { name: "Kit Mi Huerta", exact: true })).toBeVisible();
+  const productRoute = page.locator("#ruta-kit");
+  for (const href of [
+    "/casa-jardin/productos/prepara",
+    "/casa-jardin/productos/crece",
+    "/casa-jardin/productos/florece",
+    "/casa-jardin/productos/fructifica",
+  ]) {
+    await expect(productRoute.locator(`a[href="${href}"]`)).toHaveCount(1);
+  }
+
+  const documents = page.locator("#documentacion-kit");
+  await expect(documents.getByRole("heading", { name: "Guía Mi Huerta", exact: true })).toBeVisible();
+  const miHuertaCard = documents.getByRole("article").filter({
+    has: documents.getByRole("heading", { name: "Guía Mi Huerta", exact: true }),
+  });
+  await expect(miHuertaCard.getByRole("link", { name: "Abrir PDF ↗" })).toHaveAttribute(
+    "href",
+    "/api/public-resources/home-garden-guide-mi-huerta",
+  );
+  await expect(miHuertaCard.getByRole("link", { name: "Descargar ↓" })).toHaveAttribute(
+    "href",
+    "/api/public-resources/home-garden-guide-mi-huerta?download=1",
+  );
+
+  await expect(page.getByRole("heading", { name: "¿No sabes si este kit encaja con tus plantas?" })).toBeVisible();
+});

--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -83,7 +83,10 @@ test("Casa product detail exposes proposed household formats without making them
   }
   await expect(page.getByText(/Sin precio público, cobertura ni dosis/i).first()).toBeVisible();
   await expect(page.getByText(/La presentación pequeña no se presume habilitada/i)).toBeVisible();
-  await expect(page.getByRole("link", { name: "Ver Product Truth técnico" })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
+  await expect(page.getByRole("link", { name: "Ver referencia técnica", exact: true })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
+  await expect(page.getByRole("heading", { name: "Producto, guía y Product Truth permanecen conectados, pero no se confunden." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Este producto puede aparecer dentro de rutas de uso distintas." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "¿No sabes si CRECE corresponde a tu planta?" })).toBeVisible();
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
   await expect(page.getByText(/\$\s*[0-9]/)).toHaveCount(0);
 });
@@ -95,6 +98,8 @@ test("Casa kit detail preserves exact sourced composition without checkout or sa
   for (const component of ["COMPOST · 2 kg", "CRECE · 500 g", "FLORECE · 500 g", "FRUCTIFICA · 500 g"]) {
     await expect(page.getByRole("heading", { name: component, exact: true })).toBeVisible();
   }
+  await expect(page.getByRole("heading", { name: "Cada etapa abre su propia ficha antes de cualquier orientación." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "El kit también debe poder abrirse hasta sus guías." })).toBeVisible();
   await expect(page.getByText(/hipótesis comercial de precios/i)).toBeVisible();
   await expect(page.getByText(/Tampoco se anuncia ahorro/i)).toBeVisible();
   await expect(page.getByRole("button", { name: /comprar/i })).toHaveCount(0);
@@ -188,24 +193,38 @@ test("extremely dry substrate stays in review instead of recommending fertilizer
   await expect(page.getByRole("link", { name: "Llevar este contexto a soporte técnico →" })).toBeVisible();
 });
 
-test("Casa guide library publishes four reconstructed same-origin PDFs", async ({ page }) => {
+test("Casa guide library presents four complete same-origin PDFs instead of HTML replacements", async ({ page }) => {
   await page.goto("/casa-jardin/guias");
+
+  await expect(page.getByRole("heading", { name: "Las guías se consultan como documentos completos." })).toBeVisible();
+  await expect(page.getByText("WEB = CONTEXTO · PDF = DOCUMENTO", { exact: true })).toBeVisible();
 
   for (const guide of ["Guía Wondergreen Casa & Jardín", "Guía Mi Huerta", "Guía rápida de etapas", "Guía de trasplante"]) {
     await expect(page.getByRole("heading", { name: guide, exact: true })).toBeVisible();
   }
 
-  const downloads = page.getByRole("link", { name: "Descargar PDF →", exact: true });
-  await expect(downloads).toHaveCount(4);
-  const hrefs = await downloads.evaluateAll((links) => links.map((link) => link.getAttribute("href") ?? ""));
-  expect(hrefs.sort()).toEqual([
+  const opens = page.getByRole("link", { name: "Abrir PDF ↗", exact: true });
+  await expect(opens).toHaveCount(4);
+  const openHrefs = await opens.evaluateAll((links) => links.map((link) => link.getAttribute("href") ?? ""));
+  expect(openHrefs.sort()).toEqual([
     "/api/public-resources/home-garden-guide-casa-jardin",
     "/api/public-resources/home-garden-guide-etapas",
     "/api/public-resources/home-garden-guide-mi-huerta",
     "/api/public-resources/home-garden-guide-trasplante",
   ]);
-  expect(hrefs.join(" ")).not.toMatch(/sharepoint|graph\.microsoft/i);
-  await expect(page.getByText(/Master público reconstruido y verificado/i).first()).toBeVisible();
-  await expect(page.getByText(/no se presenta como una copia byte a byte/i).first()).toBeVisible();
+
+  const downloads = page.getByRole("link", { name: "Descargar ↓", exact: true });
+  await expect(downloads).toHaveCount(4);
+  const downloadHrefs = await downloads.evaluateAll((links) => links.map((link) => link.getAttribute("href") ?? ""));
+  expect(downloadHrefs.sort()).toEqual([
+    "/api/public-resources/home-garden-guide-casa-jardin?download=1",
+    "/api/public-resources/home-garden-guide-etapas?download=1",
+    "/api/public-resources/home-garden-guide-mi-huerta?download=1",
+    "/api/public-resources/home-garden-guide-trasplante?download=1",
+  ]);
+  expect(`${openHrefs.join(" ")} ${downloadHrefs.join(" ")}`).not.toMatch(/sharepoint|graph\.microsoft/i);
+  await expect(page.getByText(/reconstruidos y verificados desde contenido gobernado/i).first()).toBeVisible();
+  await expect(page.getByText(/no se presentan como copias byte a byte/i).first()).toBeVisible();
+  await expect(page.getByText("DEL PDF A CONTENIDO NAVEGABLE", { exact: true })).toHaveCount(0);
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", /noindex/i);
 });

--- a/e2e/public-home-garden.spec.ts
+++ b/e2e/public-home-garden.spec.ts
@@ -77,7 +77,7 @@ test("Casa Jardín and Vivero leads with products and kits while keeping safe or
 test("Casa product detail exposes proposed household formats without making them commercial SKUs", async ({ page }) => {
   await page.goto("/casa-jardin/productos/crece");
 
-  await expect(page.getByRole("heading", { name: "CRECE", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1, name: "CRECE", exact: true })).toBeVisible();
   for (const variant of ["500 g", "1 kg", "2 kg", "5 kg"]) {
     await expect(page.getByRole("heading", { name: variant, exact: true })).toBeVisible();
   }

--- a/src/app/casa-jardin/guias/page.tsx
+++ b/src/app/casa-jardin/guias/page.tsx
@@ -1,67 +1,103 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { homeGardenGuides } from "@/data/home-garden";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import {
+  homeGardenPublicDocuments,
+  publicDocumentDownloadHref,
+  publicDocumentHref,
+} from "@/data/home-garden-public-documents";
 import styles from "../casa-jardin.module.css";
 
 export const metadata: Metadata = {
-  title: "Guías | Casa, Jardín y Vivero",
-  description: "Guías Wondergreen Casa & Jardín sobre etapas, huerta y trasplante, acompañadas por contenido navegable y guardrails de uso.",
+  title: "Guías PDF | Casa, Jardín y Vivero",
+  description: "Biblioteca documental Wondergreen Casa & Jardín con PDFs públicos para etapas, huerta y trasplante, conectados con productos y guardrails de uso.",
   alternates: { canonical: "/casa-jardin/guias" },
   robots: { index: false, follow: true },
-};
-
-const guideContent = {
-  "casa-jardin": ["Identifica primero la etapa: suelo, crecimiento, mantenimiento, floración o producción.", "Usa OBSERVA → IDENTIFICA → ELIGE → APLICA → REVISA.", "No conviertas un síntoma aislado en una receta nutricional.", "Trabaja con humedad adecuada y no acumules pellets contra el tallo.", "Detén la fertilización si hay encharcamiento, raíces comprometidas o marchitez severa."],
-  "mi-huerta": ["PREPARA: condición del sustrato antes de exigir producción.", "CRECE: etapa vegetativa.", "FLORECE: cambia de lógica cuando aparecen botones y flores.", "FRUCTIFICA: acompaña la etapa productiva sin prometer rendimiento.", "La secuencia es por etapas; no significa aplicar todo al mismo tiempo."],
-  etapas: ["CRECE = 2Grow Sólido 15-3-3.", "EQUILIBRA = 2Balance Sólido 7-7-7.", "FLORECE = 2Bloom Sólido 3-8-3.", "FRUCTIFICA = 2Fruit Sólido 3-3-8.", "COMPOST = materia orgánica y acondicionamiento del sustrato."],
-  trasplante: ["Prioriza drenaje y estructura del sustrato.", "Manipula raíces con cuidado y evita sobrecompactar.", "Mantén humedad adecuada sin encharcar.", "Espera estabilidad antes de escoger una etapa nutricional.", "La guía es educativa; no habilita el Kit Trasplanta & Arranca bloqueado."],
-} as const;
-
-const guideDownloads: Record<string, string> = {
-  "casa-jardin": "/api/public-resources/home-garden-guide-casa-jardin",
-  "mi-huerta": "/api/public-resources/home-garden-guide-mi-huerta",
-  etapas: "/api/public-resources/home-garden-guide-etapas",
-  trasplante: "/api/public-resources/home-garden-guide-trasplante",
 };
 
 export default function CasaJardinGuiasPage() {
   return (
     <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Casa & Jardín", path: "/casa-jardin" },
+        { name: "Guías PDF", path: "/casa-jardin/guias" },
+      ]} />
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Wondergreen Casa & Jardín · biblioteca</span>
-              <h1>Guías para observar antes de aplicar.</h1>
-              <p className={styles.lead}>El conocimiento del handoff vive aquí de forma navegable y ahora se acompaña por cuatro masters públicos reconstruidos desde el contenido gobernado y los activos Wondergreen aprobados. La web sigue siendo la autoridad para límites, estados y actualizaciones.</p>
-              <div className={styles.actions}><Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin">← Volver a Casa, Jardín y Vivero</Link></div>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin">← Casa & Jardín</Link>
+              <span className={styles.eyebrow}>Wondergreen Casa & Jardín · documentos</span>
+              <h1>Las guías se consultan como documentos completos.</h1>
+              <p className={styles.lead}>
+                Esta sección deja de reconstruir cada guía como una sucesión de extractos web. La página sirve para descubrir, relacionar y abrir el documento; el PDF público conserva la pieza completa y puede abrirse o descargarse directamente.
+              </p>
+              <div className={styles.actions}>
+                <a className={`${styles.button} ${styles.primary}`} href="#documentos">Ver guías PDF</a>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/productos">Ver productos</Link>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/kits">Ver kits</Link>
+              </div>
             </div>
-            <aside className={styles.heroVisual}><p className={styles.heroNote}>DEL PDF A CONTENIDO NAVEGABLE</p><strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>Conocimiento que acompaña la decisión.</strong></aside>
+            <aside className={styles.heroVisual}>
+              <p className={styles.heroNote}>WEB = CONTEXTO · PDF = DOCUMENTO</p>
+              <strong style={{ color: "white", fontFamily: "var(--display)", fontSize: "3rem", lineHeight: 1 }}>
+                Abrir. Leer. Descargar.
+              </strong>
+              <p style={{ color: "#d5e2dc", maxWidth: "28rem" }}>
+                Los PDFs públicos actuales fueron reconstruidos y verificados desde contenido gobernado y activos aprobados. No se presentan como copias byte a byte de los binarios históricos del handoff.
+              </p>
+            </aside>
           </div>
         </section>
 
-        {homeGardenGuides.map((guide, index) => (
-          <section className={`${styles.section} ${index % 2 ? styles.soft : ""}`} id={guide.id} key={guide.id}>
-            <div className={styles.container}>
-              <div className={styles.sectionHead}>
-                <div><span className={styles.eyebrow}>Guía {String(index + 1).padStart(2, "0")}</span><h2>{guide.title}</h2></div>
-                <p>{guide.summary}</p>
-              </div>
-              <div className={styles.decisionGrid}>
-                {guideContent[guide.id as keyof typeof guideContent].map((item, itemIndex) => <article className={styles.decisionCard} key={item}><span className={styles.eyebrow}>{String(itemIndex + 1).padStart(2, "0")}</span><p><strong>{item}</strong></p></article>)}
-              </div>
-              <div className={styles.guardrail}>
-                <strong>Master público reconstruido y verificado.</strong>
-                <p>El PDF descargable fue reconstruido desde este contenido gobernado y activos Wondergreen aprobados, renderizado y revisado antes de publicación. No se presenta como una copia byte a byte del binario histórico del handoff.</p>
-                <div className={styles.actions}>
-                  <a className={`${styles.button} ${styles.primary}`} href={guideDownloads[guide.id]} target="_blank" rel="noreferrer">Descargar PDF →</a>
-                </div>
+        <section className={styles.section} id="documentos">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Biblioteca PDF</span><h2>Cuatro documentos públicos. Sin sustituirlos por resúmenes.</h2></div>
+              <p>Cada tarjeta identifica el master fuente, abre el PDF inline y ofrece descarga directa. El contenido técnico de producto sigue gobernado por Product Truth y los límites de uso siguen vigentes aunque la guía sea pública.</p>
+            </div>
+            <div className={styles.productGrid}>
+              {homeGardenPublicDocuments.map((document, index) => (
+                <article className={styles.card} key={document.id}>
+                  <small>Guía {String(index + 1).padStart(2, "0")} · PDF público verificado</small>
+                  <h3>{document.title}</h3>
+                  <p>{document.summary}</p>
+                  <p><strong>Master fuente</strong><br />{document.sourceMaster}</p>
+                  <div className={styles.actions}>
+                    <a className={`${styles.button} ${styles.primary}`} href={publicDocumentHref(document)} target="_blank" rel="noreferrer">Abrir PDF ↗</a>
+                    <a className={`${styles.button} ${styles.ghost}`} href={publicDocumentDownloadHref(document)}>Descargar ↓</a>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Conectar documento y producto</span><h2>La guía acompaña; la ficha de producto profundiza la referencia.</h2></div>
+              <p>Si una guía menciona una etapa, puedes volver al catálogo Casa & Jardín y abrir la ficha correspondiente para revisar referencia técnica, fórmula cuando aplique, formatos domésticos propuestos, kits relacionados y estado comercial.</p>
+            </div>
+            <div className={styles.actions}>
+              <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/productos">Explorar productos por etapa</Link>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/wondergreen/productos">Abrir Product Master Wondergreen</Link>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.release}`}>
+          <div className={styles.container}>
+            <div className={styles.guardrail}>
+              <strong>Las guías no convierten una etapa en prescripción.</strong>
+              <p>Dosis domésticas, frecuencia, equivalencias del dosificador, presentaciones B2C y claims finales siguen subordinados a validación técnica, comercial y regulatoria. Si la condición de la planta no está clara, el orientador permanece disponible como ruta secundaria.</p>
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/diagnostico">Usar orientador solo si hay duda</Link>
               </div>
             </div>
-          </section>
-        ))}
-
-        <section className={`${styles.section} ${styles.release}`}><div className={styles.container}><div className={styles.guardrail}><strong>Las guías no reemplazan diagnóstico ni Product Truth.</strong><p>Dosis domésticas, frecuencia, equivalencias del dosificador, presentaciones B2C y claims finales siguen subordinados a validación técnica y comercial.</p></div></div></section>
+          </div>
+        </section>
       </main>
     </div>
   );

--- a/src/app/casa-jardin/guias/page.tsx
+++ b/src/app/casa-jardin/guias/page.tsx
@@ -59,7 +59,7 @@ export default function CasaJardinGuiasPage() {
             </div>
             <div className={styles.productGrid}>
               {homeGardenPublicDocuments.map((document, index) => (
-                <article className={styles.card} key={document.id}>
+                <article className={styles.card} id={document.id} key={document.id}>
                   <small>Guía {String(index + 1).padStart(2, "0")} · PDF público verificado</small>
                   <h3>{document.title}</h3>
                   <p>{document.summary}</p>

--- a/src/app/casa-jardin/kits/[slug]/page.tsx
+++ b/src/app/casa-jardin/kits/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
 import { HomeGardenKitStageRail } from "@/components/home-garden-kit-stage-rail";
 import {
   getHomeGardenKit,
@@ -8,6 +9,11 @@ import {
   homeGardenKits,
   homeGardenRelease,
 } from "@/data/home-garden";
+import {
+  getHomeGardenDocumentsForKit,
+  publicDocumentDownloadHref,
+  publicDocumentHref,
+} from "@/data/home-garden-public-documents";
 import styles from "../../casa-jardin.module.css";
 
 export function generateStaticParams() {
@@ -20,7 +26,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   if (!kit || kit.availability === "blocked") return { title: "Kit Casa & Jardín | Wondergreen" };
   return {
     title: `${kit.name} | Wondergreen Casa, Jardín y Vivero`,
-    description: `${kit.promise} Composición de pre-lanzamiento; compra y precio aún no habilitados.`,
+    description: `${kit.promise} Composición, productos relacionados y documentación de pre-lanzamiento; compra y precio aún no habilitados.`,
     alternates: { canonical: `/casa-jardin/kits/${kit.id}` },
     robots: { index: false, follow: true },
   };
@@ -31,8 +37,16 @@ export default async function HomeGardenKitPage({ params }: { params: Promise<{ 
   const kit = getHomeGardenKit(slug);
   if (!kit || kit.availability === "blocked") notFound();
 
+  const documents = getHomeGardenDocumentsForKit(kit.id);
+
   return (
     <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Casa & Jardín", path: "/casa-jardin" },
+        { name: "Kits", path: "/casa-jardin/kits" },
+        { name: kit.name, path: `/casa-jardin/kits/${kit.id}` as `/${string}` },
+      ]} />
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
@@ -43,8 +57,8 @@ export default async function HomeGardenKitPage({ params }: { params: Promise<{ 
               <p className={styles.lead}>{kit.audience}. <strong>{kit.promise}</strong></p>
               <div className={styles.actions}>
                 <a className={`${styles.button} ${styles.primary}`} href="#ruta-kit">Ver productos del kit</a>
-                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/productos">Explorar productos por etapa</Link>
-                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/diagnostico">No sé si este kit encaja</Link>
+                <a className={`${styles.button} ${styles.ghost}`} href="#documentacion-kit">Ver documentación</a>
+                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/productos">Explorar todos los productos</Link>
               </div>
             </div>
             <aside className={styles.heroVisual} aria-label={`Composición ${kit.name}`}>
@@ -77,8 +91,8 @@ export default async function HomeGardenKitPage({ params }: { params: Promise<{ 
         <section className={`${styles.section} ${styles.soft}`} id="ruta-kit">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Ruta del kit</span><h2>Cada etapa se usa cuando corresponde.</h2></div>
-              <p>El kit agrupa posibilidades para distintas etapas. No implica aplicación simultánea ni reemplaza la lectura de condición de cada planta.</p>
+              <div><span className={styles.eyebrow}>Productos del kit</span><h2>Cada etapa abre su propia ficha antes de cualquier orientación.</h2></div>
+              <p>El kit agrupa posibilidades para distintas etapas. No implica aplicación simultánea ni reemplaza la lectura de condición de cada planta. Puedes abrir cada producto para revisar referencia técnica, formatos propuestos, documentación y estado B2C.</p>
             </div>
             <div className={styles.flow}>
               {kit.pathway.map((stage, index) => {
@@ -87,10 +101,36 @@ export default async function HomeGardenKitPage({ params }: { params: Promise<{ 
                   <article key={stage}>
                     <strong>{String(index + 1).padStart(2, "0")} · {product?.consumerName ?? stage}</strong>
                     <p>{product?.role}</p>
-                    {product ? <Link href={`/casa-jardin/productos/${product.id}`}>Ver producto →</Link> : null}
+                    {product ? <Link href={`/casa-jardin/productos/${product.id}`}>Abrir ficha de producto →</Link> : null}
                   </article>
                 );
               })}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section} id="documentacion-kit">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Documentación relacionada</span><h2>El kit también debe poder abrirse hasta sus guías.</h2></div>
+              <p>Los documentos públicos actuales son reconstrucciones verificadas desde contenido gobernado y activos aprobados. Conservamos visible su master fuente para no confundir la publicación web con el binario histórico del handoff.</p>
+            </div>
+            <div className={styles.decisionGrid}>
+              {documents.map((document) => (
+                <article className={styles.decisionCard} key={document.id}>
+                  <span className={styles.eyebrow}>PDF público verificado</span>
+                  <h3>{document.title}</h3>
+                  <p>{document.summary}</p>
+                  <p><small>Master fuente: {document.sourceMaster}</small></p>
+                  <div className={styles.actions}>
+                    <a className={`${styles.button} ${styles.primary}`} href={publicDocumentHref(document)} target="_blank" rel="noreferrer">Abrir PDF ↗</a>
+                    <a className={`${styles.button} ${styles.ghost}`} href={publicDocumentDownloadHref(document)}>Descargar ↓</a>
+                  </div>
+                </article>
+              ))}
+            </div>
+            <div className={styles.actions}>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/guias">Ver todas las guías</Link>
             </div>
           </div>
         </section>
@@ -103,6 +143,19 @@ export default async function HomeGardenKitPage({ params }: { params: Promise<{ 
             </div>
             <div className={styles.flow}>
               {homeGardenRelease.blockedReasons.map((reason, index) => <article key={reason}><strong>{String(index + 1).padStart(2, "0")}</strong><p>{reason}</p></article>)}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section} aria-labelledby="kit-orientation-title">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Orientación secundaria</span><h2 id="kit-orientation-title">¿No sabes si este kit encaja con tus plantas?</h2></div>
+              <p>Conoce primero qué contiene el kit. Si después sigue sin estar clara la etapa o la condición de una planta, usa el orientador; puede detener la fertilización cuando primero corresponda revisar agua, drenaje, raíces, estrés o sanidad.</p>
+            </div>
+            <div className={styles.actions}>
+              <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Usar orientador de etapa y condición</Link>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/kits">Comparar otros kits</Link>
             </div>
           </div>
         </section>

--- a/src/app/casa-jardin/productos/[slug]/page.tsx
+++ b/src/app/casa-jardin/productos/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
 import { HomeGardenStageVisual } from "@/components/home-garden-stage-visual";
 import {
   getHomeGardenProduct,
@@ -8,6 +9,12 @@ import {
   homeGardenRegulatoryGate,
   homeGardenRelease,
 } from "@/data/home-garden";
+import {
+  getHomeGardenDocumentsForStage,
+  getRelatedHomeGardenKitsForStage,
+  publicDocumentDownloadHref,
+  publicDocumentHref,
+} from "@/data/home-garden-public-documents";
 import styles from "../../casa-jardin.module.css";
 
 export function generateStaticParams() {
@@ -20,7 +27,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   if (!product) return { title: "Producto Casa & Jardín | Wondergreen" };
   return {
     title: `${product.consumerName} | Wondergreen Casa, Jardín y Vivero`,
-    description: `${product.role} Presentaciones domésticas en validación; compra y precio aún no habilitados.`,
+    description: `${product.role} Referencia técnica, formatos domésticos propuestos, documentación y kits relacionados; compra y precio aún no habilitados.`,
     alternates: { canonical: `/casa-jardin/productos/${product.id}` },
     robots: { index: false, follow: true },
   };
@@ -31,8 +38,17 @@ export default async function HomeGardenProductPage({ params }: { params: Promis
   const product = getHomeGardenProduct(slug);
   if (!product) notFound();
 
+  const documents = getHomeGardenDocumentsForStage(product.id);
+  const relatedKits = getRelatedHomeGardenKitsForStage(product.id);
+
   return (
     <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Casa & Jardín", path: "/casa-jardin" },
+        { name: "Productos", path: "/casa-jardin/productos" },
+        { name: product.consumerName, path: `/casa-jardin/productos/${product.id}` as `/${string}` },
+      ]} />
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>
@@ -42,16 +58,16 @@ export default async function HomeGardenProductPage({ params }: { params: Promis
               <h1>{product.consumerName}</h1>
               <p className={styles.lead}>{product.role}</p>
               <div className={styles.actions}>
-                <Link className={`${styles.button} ${styles.primary}`} href={`/wondergreen/productos/${product.technicalSlug}`}>Ver Product Truth técnico</Link>
-                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/kits">Ver kits por uso</Link>
-                <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/diagnostico">No sé si corresponde a mi planta</Link>
+                <Link className={`${styles.button} ${styles.primary}`} href={`/wondergreen/productos/${product.technicalSlug}`}>Ver referencia técnica</Link>
+                <a className={`${styles.button} ${styles.ghost}`} href="#documentacion">Ver documentación</a>
+                <a className={`${styles.button} ${styles.ghost}`} href="#kits-relacionados">Ver kits relacionados</a>
               </div>
             </div>
             <aside className={styles.heroVisual} aria-label={`Identidad visual ${product.consumerName}`}>
-              <p className={styles.heroNote}>PRESENTACIÓN DOMÉSTICA EN VALIDACIÓN</p>
+              <p className={styles.heroNote}>PRODUCTO DEFINIDO · FORMATO DOMÉSTICO EN VALIDACIÓN</p>
               <HomeGardenStageVisual stage={product.id} size="hero" />
               <p style={{ color: "#d5e2dc", maxWidth: "26rem" }}>
-                Referencia técnica: {product.technicalName}. El arte de línea identifica la familia aprobada; no representa un packshot específico de los formatos domésticos propuestos.
+                Referencia técnica: {product.technicalName}{product.formula ? ` · ${product.formula}` : ""}. El arte de línea identifica la familia aprobada; no representa un packshot específico de los formatos domésticos propuestos.
               </p>
             </aside>
           </div>
@@ -60,7 +76,34 @@ export default async function HomeGardenProductPage({ params }: { params: Promis
         <section className={styles.section}>
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Formatos del handoff B2C</span><h2>Propuestos, todavía no vendidos como SKU.</h2></div>
+              <div><span className={styles.eyebrow}>Qué es este producto</span><h2>La referencia existe antes que la presentación doméstica.</h2></div>
+              <p>Casa & Jardín traduce una referencia Wondergreen ya gobernada a una lectura por etapa. La fórmula, identidad técnica y Product Truth permanecen en Wondergreen; el empaque pequeño, precio, stock, dosificador y condiciones de venta se habilitan únicamente cuando su cierre B2C esté reconciliado.</p>
+            </div>
+            <div className={styles.decisionGrid}>
+              <article className={styles.decisionCard}>
+                <span className={styles.eyebrow}>Nombre Casa & Jardín</span>
+                <h3>{product.consumerName}</h3>
+                <p>{product.prompt}</p>
+              </article>
+              <article className={styles.decisionCard}>
+                <span className={styles.eyebrow}>Referencia técnica</span>
+                <h3>{product.technicalName}</h3>
+                <p>{product.formula ? `Formulación ${product.formula}.` : "Compost / acondicionamiento del sustrato."}</p>
+                <Link href={`/wondergreen/productos/${product.technicalSlug}`}>Abrir Product Truth →</Link>
+              </article>
+              <article className={styles.decisionCard}>
+                <span className={styles.eyebrow}>Estado comercial B2C</span>
+                <h3>Pre-lanzamiento</h3>
+                <p>Sin PVP, checkout, disponibilidad ni promesa de stock hasta cerrar las dependencias pendientes.</p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`}>
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Presentaciones domésticas propuestas</span><h2>Tamaños visibles sin convertirlos todavía en SKUs comprables.</h2></div>
               <p>{product.householdFormatStatus}</p>
             </div>
             <div className={styles.decisionGrid}>
@@ -75,7 +118,53 @@ export default async function HomeGardenProductPage({ params }: { params: Promis
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.soft}`}>
+        <section className={styles.section} id="documentacion">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Documentación relacionada</span><h2>Producto, guía y Product Truth permanecen conectados, pero no se confunden.</h2></div>
+              <p>Los PDFs públicos sirven como material educativo y de acompañamiento. La referencia técnica exacta se consulta en Wondergreen. Los binarios públicos actuales fueron reconstruidos y verificados desde contenido gobernado; no se presentan como copias byte a byte de los masters históricos del handoff.</p>
+            </div>
+            <div className={styles.decisionGrid}>
+              {documents.map((document) => (
+                <article className={styles.decisionCard} key={document.id}>
+                  <span className={styles.eyebrow}>PDF público verificado</span>
+                  <h3>{document.title}</h3>
+                  <p>{document.summary}</p>
+                  <p><small>Master fuente: {document.sourceMaster}</small></p>
+                  <div className={styles.actions}>
+                    <a className={`${styles.button} ${styles.primary}`} href={publicDocumentHref(document)} target="_blank" rel="noreferrer">Abrir PDF ↗</a>
+                    <a className={`${styles.button} ${styles.ghost}`} href={publicDocumentDownloadHref(document)}>Descargar ↓</a>
+                  </div>
+                </article>
+              ))}
+            </div>
+            <div className={styles.actions}>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/guias">Ver biblioteca Casa & Jardín</Link>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.section} ${styles.soft}`} id="kits-relacionados">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Kits relacionados</span><h2>Este producto puede aparecer dentro de rutas de uso distintas.</h2></div>
+              <p>La presencia de una etapa dentro de un kit no significa aplicación simultánea con las demás. Cada planta entra a la secuencia según su etapa y condición.</p>
+            </div>
+            <div className={styles.decisionGrid}>
+              {relatedKits.map((kit) => (
+                <article className={styles.decisionCard} key={kit.id}>
+                  <span className={styles.eyebrow}>Kit de pre-lanzamiento</span>
+                  <h3>{kit.name}</h3>
+                  <p>{kit.audience}</p>
+                  <p><strong>{kit.promise}</strong></p>
+                  <Link href={`/casa-jardin/kits/${kit.id}`}>Ver composición del kit →</Link>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section}>
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>Cómo decidir</span><h2>{product.prompt}</h2></div>
@@ -104,6 +193,19 @@ export default async function HomeGardenProductPage({ params }: { params: Promis
           <div className={`${styles.container} ${styles.releaseGrid}`}>
             <div><span className={styles.eyebrow}>Estado B2C</span><h2>Producto definido. Variante doméstica todavía en cierre.</h2></div>
             <div><ul>{homeGardenRelease.blockedReasons.map((reason) => <li key={reason}>{reason}</li>)}</ul></div>
+          </div>
+        </section>
+
+        <section className={styles.section} aria-labelledby="product-orientation-title">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <div><span className={styles.eyebrow}>Solo si todavía hay duda</span><h2 id="product-orientation-title">¿No sabes si {product.consumerName} corresponde a tu planta?</h2></div>
+              <p>El orientador entra después de conocer el producto. Puede detener la ruta de fertilización si primero corresponde revisar agua, drenaje, raíces, estrés o sanidad; no calcula dosis ni convierte síntomas aislados en diagnóstico.</p>
+            </div>
+            <div className={styles.actions}>
+              <Link className={`${styles.button} ${styles.primary}`} href="/casa-jardin/diagnostico">Usar orientador de etapa y condición</Link>
+              <Link className={`${styles.button} ${styles.ghost}`} href="/casa-jardin/productos">Comparar otros productos</Link>
+            </div>
           </div>
         </section>
       </main>

--- a/src/data/home-garden-public-documents.test.ts
+++ b/src/data/home-garden-public-documents.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  getHomeGardenDocumentsForKit,
+  getHomeGardenDocumentsForStage,
+  getRelatedHomeGardenKitsForStage,
+  homeGardenPublicDocuments,
+  publicDocumentDownloadHref,
+  publicDocumentHref,
+} from "./home-garden-public-documents";
+
+describe("homeGardenPublicDocuments", () => {
+  it("keeps the four verified public guide endpoints same-origin", () => {
+    expect(homeGardenPublicDocuments).toHaveLength(4);
+    for (const document of homeGardenPublicDocuments) {
+      expect(publicDocumentHref(document)).toBe(`/api/public-resources/${document.resourceId}`);
+      expect(publicDocumentDownloadHref(document)).toBe(`/api/public-resources/${document.resourceId}?download=1`);
+      expect(publicDocumentHref(document)).not.toMatch(/^https?:/);
+      expect(document.status).toBe("public-verified-reconstruction");
+    }
+  });
+
+  it("links CRECE to governed guides and only visible kits that contain the stage", () => {
+    expect(getHomeGardenDocumentsForStage("crece").map((document) => document.id)).toEqual([
+      "casa-jardin",
+      "mi-huerta",
+      "etapas",
+      "trasplante",
+    ]);
+    expect(getRelatedHomeGardenKitsForStage("crece").map((kit) => kit.id)).toEqual([
+      "plantas-verdes",
+      "mi-huerta",
+      "casa-completa",
+      "casa-completa-xl",
+    ]);
+    expect(getRelatedHomeGardenKitsForStage("crece").some((kit) => kit.id === "trasplanta-arranca")).toBe(false);
+  });
+
+  it("gives Mi Huerta its specific guide without making every kit inherit it", () => {
+    expect(getHomeGardenDocumentsForKit("mi-huerta").map((document) => document.id)).toEqual([
+      "casa-jardin",
+      "mi-huerta",
+      "etapas",
+    ]);
+    expect(getHomeGardenDocumentsForKit("plantas-verdes").map((document) => document.id)).toEqual([
+      "casa-jardin",
+      "etapas",
+    ]);
+  });
+});

--- a/src/data/home-garden-public-documents.ts
+++ b/src/data/home-garden-public-documents.ts
@@ -1,0 +1,73 @@
+import { visibleHomeGardenKits, type HomeGardenStage } from "./home-garden";
+
+export type HomeGardenPublicDocument = {
+  id: "casa-jardin" | "mi-huerta" | "etapas" | "trasplante";
+  title: string;
+  summary: string;
+  resourceId: string;
+  sourceMaster: string;
+  stages: readonly HomeGardenStage[];
+  status: "public-verified-reconstruction";
+};
+
+export const homeGardenPublicDocuments: readonly HomeGardenPublicDocument[] = [
+  {
+    id: "casa-jardin",
+    title: "Guía Wondergreen Casa & Jardín",
+    summary: "Método de observación, etapas, semáforo de seguridad, aplicación y errores frecuentes.",
+    resourceId: "home-garden-guide-casa-jardin",
+    sourceMaster: "GUIA_WONDERGREEN_CASA_Y_JARDIN_IMAGEGEN_V1.pdf",
+    stages: ["prepara", "crece", "equilibra", "florece", "fructifica"],
+    status: "public-verified-reconstruction",
+  },
+  {
+    id: "mi-huerta",
+    title: "Guía Mi Huerta",
+    summary: "Ruta PREPARA → CRECE → FLORECE → FRUCTIFICA para una huerta doméstica por etapas.",
+    resourceId: "home-garden-guide-mi-huerta",
+    sourceMaster: "Guia_Mi_Huerta_Wondergreen_V1_optimizada.pdf",
+    stages: ["prepara", "crece", "florece", "fructifica"],
+    status: "public-verified-reconstruction",
+  },
+  {
+    id: "etapas",
+    title: "Guía rápida de etapas",
+    summary: "Referencia visual corta para reconocer suelo, crecimiento, equilibrio, floración y fructificación antes de elegir.",
+    resourceId: "home-garden-guide-etapas",
+    sourceMaster: "GUIA_RAPIDA_ETAPAS_WONDERGREEN_IMAGEGEN_V1.pdf",
+    stages: ["prepara", "crece", "equilibra", "florece", "fructifica"],
+    status: "public-verified-reconstruction",
+  },
+  {
+    id: "trasplante",
+    title: "Guía de trasplante",
+    summary: "Drenaje, raíces, sustrato, estabilidad y observación antes de decidir nutrición.",
+    resourceId: "home-garden-guide-trasplante",
+    sourceMaster: "GUIA_TRASPLANTE_WONDERGREEN_IMAGEGEN_V1.pdf",
+    stages: ["prepara", "crece"],
+    status: "public-verified-reconstruction",
+  },
+] as const;
+
+export function publicDocumentHref(document: HomeGardenPublicDocument) {
+  return `/api/public-resources/${document.resourceId}`;
+}
+
+export function publicDocumentDownloadHref(document: HomeGardenPublicDocument) {
+  return `${publicDocumentHref(document)}?download=1`;
+}
+
+export function getHomeGardenDocumentsForStage(stage: HomeGardenStage) {
+  return homeGardenPublicDocuments.filter((document) => document.stages.includes(stage));
+}
+
+export function getRelatedHomeGardenKitsForStage(stage: HomeGardenStage) {
+  return visibleHomeGardenKits.filter((kit) => kit.pathway.includes(stage));
+}
+
+export function getHomeGardenDocumentsForKit(kitId: string) {
+  if (kitId === "mi-huerta") {
+    return homeGardenPublicDocuments.filter((document) => ["mi-huerta", "etapas", "casa-jardin"].includes(document.id));
+  }
+  return homeGardenPublicDocuments.filter((document) => ["casa-jardin", "etapas"].includes(document.id));
+}


### PR DESCRIPTION
## Objetivo
Aplicar a Casa & Jardín la jerarquía comercial acordada: producto y kit primero, documentación y referencia técnica en profundidad, y orientador únicamente como ruta secundaria cuando persiste incertidumbre.

## Cambios
- Las fichas de producto ahora conectan nombre Casa & Jardín, referencia técnica Wondergreen, formulación cuando aplica, formatos domésticos propuestos, estado B2C, documentación y kits relacionados.
- El acceso al orientador sale del hero de producto y pasa al final, después de que el usuario conoce la oferta.
- Las fichas de kit abren cada producto de su composición y conectan las guías relacionadas antes del orientador.
- `/casa-jardin/guias` deja de reconstruir cada guía como extractos HTML y pasa a biblioteca documental: abrir PDF inline y descargar el archivo público.
- Se crea un registro único de relaciones documento ↔ etapa ↔ kit para no duplicar URLs ni asociaciones en componentes.
- Mi Huerta conserva su guía específica; otros kits reciben únicamente los documentos que corresponden.
- Se añade cobertura unitaria y Playwright de profundidad producto/kit/documento.

## Truth / Brand / Safety locks
- Los formatos domésticos propuestos no se convierten en SKUs comerciales reconciliados.
- No se habilitan PVP, checkout, stock, cobertura ni dosis universales.
- `Trasplanta & Arranca` permanece bloqueado y no entra por asociación indirecta.
- La referencia técnica exacta sigue gobernada por Wondergreen Product Truth.
- Los PDFs Casa & Jardín públicos actuales se describen como reconstrucciones verificadas desde contenido gobernado; no se presentan como copias byte a byte de los masters históricos del handoff mientras persistan discrepancias de QR, pesos o texto.
- El orientador puede detener fertilización bajo condiciones de seguridad y nunca sustituye una ficha de producto ni genera prescripción automática.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile