### PR TITLE
feat(solutions): conecta servicios con evidencia y contexto V2.2

### DIFF
--- a/e2e/public-editorial-sections.spec.ts
+++ b/e2e/public-editorial-sections.spec.ts
@@ -20,7 +20,12 @@ for (const route of ["/soluciones", "/proyectos"]) {
 
 test("solution and project details keep governed public routes", async ({ page }) => {
   await page.goto("/soluciones/diagnostico-caracterizacion");
-  await expect(page.getByRole("link", { name: "Hablar con Greenatics" })).toHaveAttribute("href", "/contacto");
+  const contactHref = await page.getByRole("link", { name: "Hablar con Greenatics" }).getAttribute("href");
+  expect(contactHref).toBeTruthy();
+  const contact = new URL(contactHref!, "https://greenatics.com.co");
+  expect(contact.pathname).toBe("/contacto");
+  expect(contact.searchParams.get("source")).toBe("solucion");
+  expect(contact.searchParams.get("service")).toBe("Diagnóstico y caracterización de residuos orgánicos");
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute("href", /\/soluciones\/diagnostico-caracterizacion$/);
 
   await page.goto("/proyectos/yarumal");

--- a/e2e/service-commercial-depth.spec.ts
+++ b/e2e/service-commercial-depth.spec.ts
@@ -27,9 +27,7 @@ test("rehabilitation service connects only the governed Tamesis assessment and r
   await expect(evidence.getByRole("link", { name: /Abrir caso documentado/ })).toHaveAttribute("href", "/proyectos/tamesis");
   await expect(main.getByRole("heading", { name: "Yarumal", exact: true })).toHaveCount(0);
 
-  const related = main.getByRole("heading", { name: /El servicio puede conectarse con otras fases/ });
-  await expect(related).toBeVisible();
-  await expect(main.getByRole("link", { name: /Ver servicio/ }).filter({ has: page.locator('[href="/soluciones/factibilidad-ingenieria"]') })).toHaveCount(0);
+  await expect(main.getByRole("heading", { name: /El servicio puede conectarse con otras fases/ })).toBeVisible();
   await expect(main.locator('a[href="/soluciones/factibilidad-ingenieria"]')).toHaveCount(1);
   await expect(main.locator('a[href="/soluciones/plantas-nuevas"]')).toHaveCount(1);
 });

--- a/e2e/service-commercial-depth.spec.ts
+++ b/e2e/service-commercial-depth.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+
+test("trazabilidad service connects governed Yarumal evidence without turning the case into a universal promise", async ({ page }) => {
+  await page.goto("/soluciones/trazabilidad-datos");
+
+  const main = page.getByRole("main");
+  await expect(main.getByRole("heading", { name: "Trazabilidad digital, indicadores y GREENATICS OPS" })).toBeVisible();
+  await expect(main.getByRole("heading", { name: "Qué recibe", exact: true })).toBeVisible();
+  await expect(main.getByRole("heading", { name: "Qué hacemos", exact: true })).toBeVisible();
+  await expect(main.getByRole("heading", { name: /Casos que documentan esta capacidad/ })).toBeVisible();
+
+  const evidence = main.getByRole("article").filter({ has: main.getByRole("heading", { name: "Yarumal", exact: true }) });
+  await expect(evidence).toHaveCount(1);
+  await expect(evidence.getByText("Caso documentado", { exact: true })).toBeVisible();
+  await expect(evidence.getByText(/registros de recepción, lotes, mantenimiento, producto e inventarios/i)).toBeVisible();
+  await expect(evidence.getByRole("link", { name: /Abrir caso documentado/ })).toHaveAttribute("href", "/proyectos/yarumal");
+  await expect(main.getByRole("heading", { name: "Támesis", exact: true })).toHaveCount(0);
+});
+
+test("rehabilitation service connects only the governed Tamesis assessment and related infrastructure routes", async ({ page }) => {
+  await page.goto("/soluciones/rehabilitacion");
+
+  const main = page.getByRole("main");
+  const evidence = main.getByRole("article").filter({ has: main.getByRole("heading", { name: "Támesis", exact: true }) });
+  await expect(evidence).toHaveCount(1);
+  await expect(evidence.getByText("Diagnóstico y rehabilitación documentados", { exact: true })).toBeVisible();
+  await expect(evidence.getByRole("link", { name: /Abrir caso documentado/ })).toHaveAttribute("href", "/proyectos/tamesis");
+  await expect(main.getByRole("heading", { name: "Yarumal", exact: true })).toHaveCount(0);
+
+  const related = main.getByRole("heading", { name: /El servicio puede conectarse con otras fases/ });
+  await expect(related).toBeVisible();
+  await expect(main.getByRole("link", { name: /Ver servicio/ }).filter({ has: page.locator('[href="/soluciones/factibilidad-ingenieria"]') })).toHaveCount(0);
+  await expect(main.locator('a[href="/soluciones/factibilidad-ingenieria"]')).toHaveCount(1);
+  await expect(main.locator('a[href="/soluciones/plantas-nuevas"]')).toHaveCount(1);
+});
+
+test("services without a directly governed case do not fabricate an evidence block", async ({ page }) => {
+  await page.goto("/soluciones/pmirs");
+
+  const main = page.getByRole("main");
+  await expect(main.getByRole("heading", { name: "PMIRS y planes internos de gestión de residuos" })).toBeVisible();
+  await expect(main.getByText("Evidencia pública relacionada", { exact: true })).toHaveCount(0);
+  await expect(main.getByRole("heading", { name: "Yarumal", exact: true })).toHaveCount(0);
+  await expect(main.getByRole("heading", { name: "Támesis", exact: true })).toHaveCount(0);
+});
+
+test("service contact keeps the exact commercial context instead of restarting at diagnosis", async ({ page }) => {
+  await page.goto("/soluciones/trazabilidad-datos");
+
+  const contact = page.getByRole("link", { name: "Solicitar conversación comercial", exact: true });
+  const href = await contact.getAttribute("href");
+  expect(href).toBeTruthy();
+  const target = new URL(href!, "https://greenatics.com.co");
+  expect(target.pathname).toBe("/contacto");
+  expect(target.searchParams.get("source")).toBe("solucion");
+  expect(target.searchParams.get("service")).toBe("Trazabilidad digital, indicadores y GREENATICS OPS");
+  expect(target.searchParams.get("contexto")).toContain("Interés en Trazabilidad digital");
+
+  await contact.click();
+  const inherited = page.getByLabel("Contexto heredado de navegación");
+  await expect(inherited).toContainText("Origen: solucion");
+  await expect(inherited).toContainText("Servicio: Trazabilidad digital, indicadores y GREENATICS OPS");
+  await expect(inherited).toContainText("Interés en Trazabilidad digital");
+});

--- a/e2e/service-commercial-depth.spec.ts
+++ b/e2e/service-commercial-depth.spec.ts
@@ -9,8 +9,9 @@ test("trazabilidad service connects governed Yarumal evidence without turning th
   await expect(main.getByRole("heading", { name: "Qué hacemos", exact: true })).toBeVisible();
   await expect(main.getByRole("heading", { name: /Casos que documentan esta capacidad/ })).toBeVisible();
 
-  const evidence = main.getByRole("article").filter({ has: main.getByRole("heading", { name: "Yarumal", exact: true }) });
+  const evidence = main.getByRole("article").filter({ hasText: "Yarumal" });
   await expect(evidence).toHaveCount(1);
+  await expect(evidence.getByRole("heading", { name: "Yarumal", exact: true })).toBeVisible();
   await expect(evidence.getByText("Caso documentado", { exact: true })).toBeVisible();
   await expect(evidence.getByText(/registros de recepción, lotes, mantenimiento, producto e inventarios/i)).toBeVisible();
   await expect(evidence.getByRole("link", { name: /Abrir caso documentado/ })).toHaveAttribute("href", "/proyectos/yarumal");
@@ -21,8 +22,9 @@ test("rehabilitation service connects only the governed Tamesis assessment and r
   await page.goto("/soluciones/rehabilitacion");
 
   const main = page.getByRole("main");
-  const evidence = main.getByRole("article").filter({ has: main.getByRole("heading", { name: "Támesis", exact: true }) });
+  const evidence = main.getByRole("article").filter({ hasText: "Támesis" });
   await expect(evidence).toHaveCount(1);
+  await expect(evidence.getByRole("heading", { name: "Támesis", exact: true })).toBeVisible();
   await expect(evidence.getByText("Diagnóstico y rehabilitación documentados", { exact: true })).toBeVisible();
   await expect(evidence.getByRole("link", { name: /Abrir caso documentado/ })).toHaveAttribute("href", "/proyectos/tamesis");
   await expect(main.getByRole("heading", { name: "Yarumal", exact: true })).toHaveCount(0);

--- a/src/app/soluciones/[slug]/page.tsx
+++ b/src/app/soluciones/[slug]/page.tsx
@@ -2,9 +2,11 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicProjects } from "@/data/projects-public";
 import { getService, services } from "@/data/services";
 import styles from "../solutions.module.css";
 import refresh from "../solutions-refresh.module.css";
+import depth from "./service-depth.module.css";
 
 type Props = { params: Promise<{ slug: string }> };
 
@@ -28,12 +30,20 @@ export default async function SolutionDetailPage({ params }: Props) {
   const service = getService(slug);
   if (!service) notFound();
 
+  const servicePath = `/soluciones/${service.slug}` as `/soluciones/${string}`;
+  const relatedProjects = publicProjects.filter((project) => project.relatedSolution.href === servicePath);
+  const relatedServices = services
+    .filter((candidate) => candidate.category === service.category && candidate.slug !== service.slug)
+    .slice(0, 3);
+  const contactContext = `Interés en ${service.name}. ${service.summary}`;
+  const contactHref = `/contacto?service=${encodeURIComponent(service.name)}&source=solucion&contexto=${encodeURIComponent(contactContext)}`;
+
   return (
     <div className={`${styles.page} ${refresh.page}`}>
       <BreadcrumbJsonLd items={[
         { name: "Greenatics", path: "/" },
         { name: "Soluciones", path: "/soluciones" },
-        { name: service.name, path: `/soluciones/${service.slug}` as `/${string}` },
+        { name: service.name, path: servicePath },
       ]} />
       <main>
         <section className={styles.detailHero}>
@@ -47,7 +57,7 @@ export default async function SolutionDetailPage({ params }: Props) {
                 <p className={styles.detailLead}>{service.summary}</p>
                 <div className={styles.actions}>
                   <a className={`${styles.button} ${styles.primary}`} href="#entregables">Ver qué recibe el cliente</a>
-                  <Link className={styles.button} href="/contacto">Solicitar conversación comercial</Link>
+                  <Link className={styles.button} href={contactHref}>Solicitar conversación comercial</Link>
                 </div>
               </div>
               <aside className={styles.detailAside}>
@@ -71,6 +81,7 @@ export default async function SolutionDetailPage({ params }: Props) {
                 <div><span className={styles.eyebrow}>Actividades y alcance</span><h2>Qué hacemos</h2><ul>{service.includes.map((item) => <li key={item}>{item}</li>)}</ul></div>
               </article>
             </div>
+
             {service.scopeNote ? (
               <aside className={styles.detailAside}>
                 <span>Alcance y precisión</span>
@@ -78,13 +89,59 @@ export default async function SolutionDetailPage({ params }: Props) {
                 <p>{service.scopeNote}</p>
               </aside>
             ) : null}
+
+            {relatedProjects.length > 0 ? (
+              <section className={depth.depthSection} aria-labelledby="service-evidence-title">
+                <div className={depth.sectionHead}>
+                  <div>
+                    <span>Evidencia pública relacionada</span>
+                    <h2 id="service-evidence-title">Casos que documentan esta capacidad sin convertirlos en una promesa universal.</h2>
+                  </div>
+                  <p>Estos proyectos muestran experiencia y aprendizajes ya publicados. El caso no reemplaza el alcance, diagnóstico o condiciones específicas de un proyecto nuevo.</p>
+                </div>
+                <div className={depth.projectGrid}>
+                  {relatedProjects.map((project) => (
+                    <article className={depth.projectCard} key={project.slug}>
+                      <div className={depth.projectMeta}><span>{project.statusLabel}</span><span>{project.region}</span></div>
+                      <h3>{project.name}</h3>
+                      <p>{project.summary}</p>
+                      <p className={depth.projectContext}>{project.relatedSolution.context}</p>
+                      <Link href={`/proyectos/${project.slug}`}>Abrir caso documentado <span aria-hidden="true">→</span></Link>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
+            {relatedServices.length > 0 ? (
+              <section className={depth.depthSection} aria-labelledby="related-services-title">
+                <div className={depth.sectionHead}>
+                  <div>
+                    <span>Rutas relacionadas · {service.category}</span>
+                    <h2 id="related-services-title">El servicio puede conectarse con otras fases sin obligarte a contratar un paquete único.</h2>
+                  </div>
+                  <p>Cada ruta conserva su propio alcance y entregables. Esta relación sirve para navegar la oferta, no para presumir actividades adicionales dentro del servicio actual.</p>
+                </div>
+                <div className={depth.relatedGrid}>
+                  {relatedServices.map((candidate) => (
+                    <article className={depth.relatedCard} key={candidate.slug}>
+                      <span>{candidate.category}</span>
+                      <h3>{candidate.name}</h3>
+                      <p>{candidate.summary}</p>
+                      <Link href={`/soluciones/${candidate.slug}`}>Ver servicio <span aria-hidden="true">→</span></Link>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
             <div className={styles.detailCta}>
               <div>
                 <span className={styles.eyebrow}>Siguiente paso</span>
                 <h3>{service.cta}</h3>
                 <p>El alcance final depende de la información disponible, las condiciones del proyecto y las responsabilidades acordadas. Cuando falte información crítica, la línea base o el diagnóstico se incorpora como una actividad inicial; no sustituye el servicio contratado.</p>
               </div>
-              <Link className={`${styles.button} ${styles.primary}`} href="/contacto">Hablar con Greenatics</Link>
+              <Link className={`${styles.button} ${styles.primary}`} href={contactHref}>Hablar con Greenatics</Link>
             </div>
           </div>
         </section>

--- a/src/app/soluciones/[slug]/service-depth.module.css
+++ b/src/app/soluciones/[slug]/service-depth.module.css
@@ -1,0 +1,165 @@
+.depthSection {
+  margin-top: 64px;
+  padding-top: 52px;
+  border-top: 1px solid var(--line);
+}
+
+.sectionHead {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(260px, .9fr);
+  gap: 48px;
+  align-items: end;
+  margin-bottom: 30px;
+}
+
+.sectionHead > div > span {
+  display: block;
+  margin-bottom: 10px;
+  color: var(--green);
+  font-size: .7rem;
+  font-weight: 800;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+.sectionHead h2 {
+  margin: 0;
+  max-width: 760px;
+}
+
+.sectionHead p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.projectGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.projectCard {
+  display: flex;
+  min-height: 330px;
+  flex-direction: column;
+  padding: 30px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: #fff;
+}
+
+.projectMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin-bottom: 20px;
+  color: var(--green);
+  font-size: .7rem;
+  font-weight: 800;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+.projectCard h3 {
+  margin: 0;
+}
+
+.projectCard p {
+  margin: 16px 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.projectContext {
+  margin-top: 18px !important;
+  padding-left: 16px;
+  border-left: 3px solid var(--sun);
+  font-size: .82rem;
+}
+
+.projectCard a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 24px;
+  color: var(--green);
+  font-size: .82rem;
+  font-weight: 800;
+}
+
+.relatedGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.relatedCard {
+  display: flex;
+  min-height: 230px;
+  flex-direction: column;
+  padding: 26px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+}
+
+.relatedCard > span {
+  color: var(--green);
+  font-size: .68rem;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.relatedCard h3 {
+  margin: 14px 0 0;
+  font-size: 1.28rem;
+}
+
+.relatedCard p {
+  margin: 14px 0 0;
+  color: var(--muted);
+  font-size: .86rem;
+  line-height: 1.65;
+}
+
+.relatedCard a {
+  margin-top: auto;
+  padding-top: 22px;
+  color: var(--green);
+  font-size: .8rem;
+  font-weight: 800;
+}
+
+@media (max-width: 900px) {
+  .sectionHead,
+  .projectGrid,
+  .relatedGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .sectionHead {
+    gap: 18px;
+  }
+
+  .projectCard,
+  .relatedCard {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 760px) {
+  .depthSection {
+    margin-top: 48px;
+    padding-top: 38px;
+  }
+
+  .projectCard,
+  .relatedCard {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Objetivo
Profundizar las fichas dinámicas de servicio sin volver al diagnóstico como eje: después de entregables y actividades, la web conecta únicamente evidencia pública gobernada, otras fases reales de la misma familia y una conversación comercial que conserva el servicio exacto.

## Cambios
- Las fichas de `/soluciones/[slug]` mantienen `Qué recibe` antes de `Qué hacemos`.
- El CTA comercial lleva a Contacto con `service`, `source=solucion` y contexto heredado; el usuario no reinicia la conversación desde cero.
- La evidencia se deriva inversamente de `projects-public.ts`: solo aparece cuando un caso ya declara explícitamente esa solución relacionada.
- Trazabilidad/OPS conecta con Yarumal.
- Rehabilitación conecta con Támesis.
- Servicios sin caso directamente gobernado no fabrican una sección de evidencia.
- Se añaden hasta tres servicios de la misma familia como navegación de fases relacionadas, con disclaimer explícito de que no amplían el alcance contratado.
- Nueva cobertura Playwright para evidencia, ausencia fail-closed, rutas relacionadas y contexto comercial heredado.

## Truth / commercial locks
- Un caso documenta experiencia; no se presenta como promesa universal ni como estado operativo actual.
- No se crean casos, métricas, documentos ni resultados nuevos.
- La relación entre servicios sirve para navegar la oferta y no presume un paquete o alcance adicional.
- La línea base/diagnóstico sigue siendo una actividad condicionada por falta de información, no el producto central.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile