### PR TITLE
feat(solutions): expone catálogo de servicios dentro de cada familia V2.3

### DIFF
--- a/e2e/public-intent-solutions.spec.ts
+++ b/e2e/public-intent-solutions.spec.ts
@@ -7,14 +7,20 @@ async function jsonLdByType(page: import("@playwright/test").Page, type: string)
     .filter((payload) => payload["@type"] === type);
 }
 
-test("solutions hub separates audience routes from problem-specific intent routes", async ({ page }) => {
+test("solutions hub separates audience routes from concrete service routes", async ({ page }) => {
   await page.goto("/soluciones");
 
   await expect(page.getByRole("heading", { name: "Propiedad horizontal / Instituciones", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Plantas / Operadores", exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: /Ver ruta multiunidad/ })).toHaveAttribute("href", "/soluciones/propiedad-horizontal");
   await expect(page.getByRole("link", { name: /Ver ruta de plantas/ })).toHaveAttribute("href", "/soluciones/plantas");
-  await expect(page.getByRole("link", { name: /Plantas y tratamiento/ })).toHaveAttribute("href", "/soluciones/infraestructura-plantas");
+
+  const plantServices = page.getByRole("navigation", { name: "Servicios de Plantas y tratamiento" });
+  await expect(plantServices).toBeVisible();
+  await expect(plantServices.getByRole("link", { name: /Prefactibilidad de plantas y sistemas de tratamiento y valorización/ })).toHaveAttribute("href", "/soluciones/prefactibilidad");
+  await expect(plantServices.getByRole("link", { name: /Factibilidad, APU e ingeniería de detalle/ })).toHaveAttribute("href", "/soluciones/factibilidad-ingenieria");
+  await expect(plantServices.getByRole("link", { name: /Diseño, construcción e implementación de plantas/ })).toHaveAttribute("href", "/soluciones/plantas-nuevas");
+  await expect(plantServices.getByRole("link", { name: /Diagnóstico, rehabilitación y puesta en marcha de infraestructura existente/ })).toHaveAttribute("href", "/soluciones/rehabilitacion");
 });
 
 test("organic waste route moves from real capture to treatment and prefactibility", async ({ page }) => {

--- a/e2e/public-solutions.spec.ts
+++ b/e2e/public-solutions.spec.ts
@@ -19,14 +19,14 @@ async function clickDigitalBridge(page: import("@playwright/test").Page) {
   await page.getByRole("dialog", { name: "Navegación Greenatics" }).getByRole("link", { name: "Ingresar", exact: true }).click();
 }
 
-test("solutions hub leads with services and keeps orientation secondary", async ({ page }) => {
+test("solutions hub exposes concrete services inside every commercial family before orientation", async ({ page }) => {
   await page.goto("/soluciones");
 
   await expect(page.getByRole("heading", { name: /Servicios para convertir necesidades de gestión en resultados concretos./i })).toBeVisible();
   await expect(page.getByRole("img", { name: "Vista aérea documentada del caso Greenatics en Yarumal", exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: "Ver servicios y entregables", exact: true })).toHaveAttribute("href", "#servicios");
 
-  await expect(page.getByRole("heading", { name: "Ocho familias para contratar actividades, entregables y capacidad de ejecución." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Ocho familias. Servicios concretos que puedes abrir y revisar en profundidad." })).toBeVisible();
   for (const family of [
     "Caracterización y línea base",
     "Planeación y programas",
@@ -40,11 +40,36 @@ test("solutions hub leads with services and keeps orientation secondary", async 
     await expect(page.getByRole("heading", { name: family, exact: true })).toBeVisible();
   }
 
-  await expect(page.getByRole("link", { name: /Caracterización y línea base/ })).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
-  await expect(page.getByRole("link", { name: /Gestión jurídica y regulatoria/ })).toHaveAttribute("href", "/soluciones/gestion-juridica-regulatoria");
-  await expect(page.getByRole("link", { name: /Rutas y logística/ })).toHaveAttribute("href", "/soluciones/rutas-selectivas");
-  await expect(page.getByRole("link", { name: /Datos, trazabilidad y OPS/ })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
-  await expect(page.getByRole("link", { name: /Valorización y desarrollo de productos/ })).toHaveAttribute("href", "/soluciones/valorizacion-productos");
+  const baseline = page.getByRole("navigation", { name: "Servicios de Caracterización y línea base" });
+  await expect(baseline.getByRole("link", { name: "Diagnóstico y caracterización de residuos orgánicos" })).toHaveAttribute("href", "/soluciones/diagnostico-caracterizacion");
+
+  const planning = page.getByRole("navigation", { name: "Servicios de Planeación y programas" });
+  await expect(planning.getByRole("link", { name: /PGIRS/ })).toHaveAttribute("href", "/soluciones/pgirs");
+  await expect(planning.getByRole("link", { name: /PMIRS/ })).toHaveAttribute("href", "/soluciones/pmirs");
+
+  const legal = page.getByRole("navigation", { name: "Servicios de Gestión jurídica y regulatoria" });
+  await expect(legal.getByRole("link", { name: /Gestión jurídica y regulatoria para residuos/ })).toHaveAttribute("href", "/soluciones/gestion-juridica-regulatoria");
+
+  const logistics = page.getByRole("navigation", { name: "Servicios de Rutas y logística" });
+  await expect(logistics.getByRole("link", { name: /rutas selectivas y microrrutas/i })).toHaveAttribute("href", "/soluciones/rutas-selectivas");
+  await expect(logistics.getByRole("link", { name: /motocarguero/i })).toHaveAttribute("href", "/soluciones/motocarguero");
+
+  const plants = page.getByRole("navigation", { name: "Servicios de Plantas y tratamiento" });
+  await expect(plants.getByRole("link", { name: /Prefactibilidad de plantas/i })).toHaveAttribute("href", "/soluciones/prefactibilidad");
+  await expect(plants.getByRole("link", { name: /Factibilidad, APU e ingeniería de detalle/i })).toHaveAttribute("href", "/soluciones/factibilidad-ingenieria");
+  await expect(plants.getByRole("link", { name: /Diseño, construcción e implementación de plantas/i })).toHaveAttribute("href", "/soluciones/plantas-nuevas");
+  await expect(plants.getByRole("link", { name: /rehabilitación y puesta en marcha/i })).toHaveAttribute("href", "/soluciones/rehabilitacion");
+
+  const operations = page.getByRole("navigation", { name: "Servicios de Dirección técnica y operación asistida" });
+  await expect(operations.getByRole("link", { name: /Dirección técnica y coordinación de operación/i })).toHaveAttribute("href", "/soluciones/direccion-operacion");
+  await expect(operations.getByRole("link", { name: /Operación integral de plantas/i })).toHaveAttribute("href", "/soluciones/operacion-integral");
+  await expect(operations.getByRole("link", { name: /Gestión, recolección y tratamiento de residuos orgánicos/i })).toHaveAttribute("href", "/soluciones/recoleccion-tratamiento");
+
+  const data = page.getByRole("navigation", { name: "Servicios de Datos, trazabilidad y OPS" });
+  await expect(data.getByRole("link", { name: /Trazabilidad digital, indicadores y GREENATICS OPS/i })).toHaveAttribute("href", "/soluciones/trazabilidad-datos");
+
+  const valorization = page.getByRole("navigation", { name: "Servicios de Valorización y desarrollo de productos" });
+  await expect(valorization.getByRole("link", { name: "Valorización y desarrollo de productos", exact: true })).toHaveAttribute("href", "/soluciones/valorizacion-productos");
 
   for (const audience of [
     "ESP / Prestadores",

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -54,49 +54,72 @@ const serviceFamilies = [
     number: "01",
     title: "Caracterización y línea base",
     copy: "Mediciones, caracterización, mapa de flujos, brechas y criterios de decisión cuando el proyecto necesita información de partida verificable.",
-    href: "/soluciones/diagnostico-caracterizacion",
+    offers: [
+      { label: "Diagnóstico y caracterización de residuos orgánicos", href: "/soluciones/diagnostico-caracterizacion" },
+    ],
   },
   {
     number: "02",
     title: "Planeación y programas",
     copy: "PGIRS, PMIRS, programas internos, matrices, hojas de ruta, responsables, indicadores e implementación según el actor y el alcance.",
-    href: "/soluciones/pmirs",
+    offers: [
+      { label: "PGIRS · formulación, actualización y fortalecimiento operativo", href: "/soluciones/pgirs" },
+      { label: "PMIRS y planes internos de gestión de residuos", href: "/soluciones/pmirs" },
+    ],
   },
   {
     number: "03",
     title: "Gestión jurídica y regulatoria",
     copy: "Obligaciones, competencias, conceptos, contratos, trámites y soporte regulatorio para que la decisión técnica tenga una ruta jurídica clara.",
-    href: "/soluciones/gestion-juridica-regulatoria",
+    offers: [
+      { label: "Gestión jurídica y regulatoria para residuos, aseo y proyectos", href: "/soluciones/gestion-juridica-regulatoria" },
+    ],
   },
   {
     number: "04",
     title: "Rutas y logística",
     copy: "Diseño de rutas y microrrutas, frecuencias, puntos, pilotos, protocolos, datos operativos y criterios de escalamiento.",
-    href: "/soluciones/rutas-selectivas",
+    offers: [
+      { label: "Diseño e implementación de rutas selectivas y microrrutas", href: "/soluciones/rutas-selectivas" },
+      { label: "Pilotos logísticos con motocarguero y toma de datos", href: "/soluciones/motocarguero" },
+    ],
   },
   {
     number: "05",
     title: "Plantas y tratamiento",
     copy: "Prefactibilidad, ingeniería, construcción, rehabilitación, puesta en marcha y optimización según la madurez y el problema real del sistema.",
-    href: "/soluciones/infraestructura-plantas",
+    offers: [
+      { label: "Prefactibilidad de plantas y sistemas de tratamiento y valorización", href: "/soluciones/prefactibilidad" },
+      { label: "Factibilidad, APU e ingeniería de detalle", href: "/soluciones/factibilidad-ingenieria" },
+      { label: "Diseño, construcción e implementación de plantas", href: "/soluciones/plantas-nuevas" },
+      { label: "Diagnóstico, rehabilitación y puesta en marcha de infraestructura existente", href: "/soluciones/rehabilitacion" },
+    ],
   },
   {
     number: "06",
     title: "Dirección técnica y operación asistida",
     copy: "Protocolos, programación, mantenimiento, calidad, personas, inventarios, informes y fortalecimiento sostenido de la operación.",
-    href: "/soluciones/direccion-operacion",
+    offers: [
+      { label: "Dirección técnica y coordinación de operación", href: "/soluciones/direccion-operacion" },
+      { label: "Operación integral de plantas de tratamiento y valorización", href: "/soluciones/operacion-integral" },
+      { label: "Gestión, recolección y tratamiento de residuos orgánicos para generadores", href: "/soluciones/recoleccion-tratamiento" },
+    ],
   },
   {
     number: "07",
     title: "Datos, trazabilidad y OPS",
     copy: "Captura, indicadores, evidencia, lotes, inventarios y seguimiento para convertir la actividad operativa en información útil para decidir.",
-    href: "/soluciones/trazabilidad-datos",
+    offers: [
+      { label: "Trazabilidad digital, indicadores y GREENATICS OPS", href: "/soluciones/trazabilidad-datos" },
+    ],
   },
   {
     number: "08",
     title: "Valorización y desarrollo de productos",
     copy: "Especificaciones, control, documentación, ruta regulatoria, presentación y preparación comercial para convertir una salida en un producto vendible.",
-    href: "/soluciones/valorizacion-productos",
+    offers: [
+      { label: "Valorización y desarrollo de productos", href: "/soluciones/valorizacion-productos" },
+    ],
   },
 ];
 
@@ -158,19 +181,28 @@ export default function SolutionsPage() {
             <div className={styles.sectionHead}>
               <div>
                 <span className={styles.eyebrow}>Qué puedes contratar</span>
-                <h2 id="services-title">Ocho familias para contratar actividades, entregables y capacidad de ejecución.</h2>
+                <h2 id="services-title">Ocho familias. Servicios concretos que puedes abrir y revisar en profundidad.</h2>
               </div>
-              <p>Cada familia conduce a una ruta concreta. La página de detalle explica primero qué recibe el cliente y después qué actividades puede incluir el servicio.</p>
+              <p>La familia ayuda a ubicar la necesidad, pero no es el destino final. Cada servicio abre su alcance, entregables, actividades, límites, evidencia disponible y siguiente paso comercial.</p>
             </div>
 
             <div className={styles.serviceList}>
               {serviceFamilies.map((family) => (
-                <Link className={styles.serviceRow} href={family.href} key={family.number}>
-                  <span className={styles.index}>{family.number}</span>
-                  <h3>{family.title}</h3>
-                  <p>{family.copy}</p>
-                  <span className={styles.arrow} aria-hidden="true">→</span>
-                </Link>
+                <article className={styles.serviceFamily} key={family.number}>
+                  <div className={styles.serviceFamilyIntro}>
+                    <span className={styles.index}>{family.number}</span>
+                    <h3>{family.title}</h3>
+                    <p>{family.copy}</p>
+                  </div>
+                  <nav className={styles.serviceOfferList} aria-label={`Servicios de ${family.title}`}>
+                    {family.offers.map((offer) => (
+                      <Link className={styles.serviceOffer} href={offer.href} key={offer.href}>
+                        <strong>{offer.label}</strong>
+                        <span aria-hidden="true">→</span>
+                      </Link>
+                    ))}
+                  </nav>
+                </article>
               ))}
             </div>
           </div>

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { getPrimaryProjectMedia } from "@/data/public-media";
+import catalog from "./solutions-catalog.module.css";
 import styles from "./solutions-v2.module.css";
 
 export const metadata: Metadata = {
@@ -188,15 +189,15 @@ export default function SolutionsPage() {
 
             <div className={styles.serviceList}>
               {serviceFamilies.map((family) => (
-                <article className={styles.serviceFamily} key={family.number}>
-                  <div className={styles.serviceFamilyIntro}>
+                <article className={catalog.serviceFamily} key={family.number}>
+                  <div className={catalog.serviceFamilyIntro}>
                     <span className={styles.index}>{family.number}</span>
                     <h3>{family.title}</h3>
                     <p>{family.copy}</p>
                   </div>
-                  <nav className={styles.serviceOfferList} aria-label={`Servicios de ${family.title}`}>
+                  <nav className={catalog.serviceOfferList} aria-label={`Servicios de ${family.title}`}>
                     {family.offers.map((offer) => (
-                      <Link className={styles.serviceOffer} href={offer.href} key={offer.href}>
+                      <Link className={catalog.serviceOffer} href={offer.href} key={offer.href}>
                         <strong>{offer.label}</strong>
                         <span aria-hidden="true">→</span>
                       </Link>

--- a/src/app/soluciones/solutions-catalog.module.css
+++ b/src/app/soluciones/solutions-catalog.module.css
@@ -1,0 +1,101 @@
+.serviceFamily {
+  display: grid;
+  gap: 0;
+  padding: 34px 0 30px;
+  border-bottom: 1px solid rgba(24, 36, 31, 0.16);
+}
+
+.serviceFamilyIntro {
+  display: grid;
+  grid-template-columns: 58px minmax(220px, 0.75fr) minmax(320px, 1.25fr);
+  gap: 22px;
+  align-items: start;
+}
+
+.serviceFamilyIntro > span {
+  padding-top: 6px;
+}
+
+.serviceFamilyIntro h3 {
+  margin: 0;
+}
+
+.serviceFamilyIntro p {
+  margin: 0;
+  color: #68736c;
+  line-height: 1.65;
+}
+
+.serviceOfferList {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 24px;
+  margin: 24px 0 0 80px;
+  border-top: 1px solid rgba(24, 36, 31, 0.16);
+}
+
+.serviceOffer {
+  min-height: 62px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: center;
+  padding: 13px 0;
+  border-bottom: 1px solid rgba(24, 36, 31, 0.16);
+  color: #0a7a4b !important;
+}
+
+.serviceOffer strong {
+  font-size: 0.84rem;
+  font-weight: 800;
+  line-height: 1.45;
+}
+
+.serviceOffer > span {
+  font-size: 1.05rem;
+  transition: transform 160ms ease;
+}
+
+.serviceOffer:hover > span {
+  transform: translateX(4px);
+}
+
+.serviceOffer:focus-visible {
+  outline: 3px solid #ddc952;
+  outline-offset: 4px;
+}
+
+@media (max-width: 900px) {
+  .serviceFamilyIntro {
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .serviceFamilyIntro p {
+    grid-column: 2;
+    margin-top: 4px;
+  }
+
+  .serviceOfferList {
+    margin-left: 66px;
+  }
+}
+
+@media (max-width: 700px) {
+  .serviceFamily {
+    padding: 28px 0;
+  }
+
+  .serviceFamilyIntro {
+    grid-template-columns: 34px minmax(0, 1fr);
+    gap: 14px;
+  }
+
+  .serviceOfferList {
+    grid-template-columns: 1fr;
+    margin: 22px 0 0 48px;
+  }
+
+  .serviceOffer {
+    min-height: 58px;
+  }
+}


### PR DESCRIPTION
## Objetivo
Profundizar `/soluciones` para que las ocho familias comerciales no se queden en una enunciación ni conduzcan a una sola ruta representativa. Cada familia expone los servicios reales ya gobernados y permite abrirlos directamente hasta alcance, entregables, actividades, límites, evidencia y contacto contextual.

## Cambios
- Las ocho familias permanecen como estructura comercial, pero cada una muestra sus servicios individuales.
- Planeación abre directamente PGIRS y PMIRS.
- Rutas y logística abre rutas selectivas y piloto con motocarguero.
- Plantas abre prefactibilidad, factibilidad/ingeniería, planta nueva y rehabilitación.
- Operación abre dirección técnica, operación integral y gestión/recolección/tratamiento para generadores.
- Jurídica, datos/OPS, valorización y caracterización mantienen sus destinos profundos propios.
- La familia deja de ser el destino final: el usuario entra directamente al servicio que quiere revisar.
- La jerarquía permanece servicio-first y el orientador inicial continúa únicamente al final para incertidumbre.
- Nueva presentación responsive del catálogo y cobertura Playwright de todas las rutas directas.

## Truth / commercial locks
- No se inventan servicios ni rutas nuevas: el catálogo expone únicamente capacidades ya presentes en Product/Service Truth del repositorio.
- Cada ficha conserva su alcance, entregables y límites regulatorios propios.
- Relacionar servicios bajo una familia no presume paquete, contratación conjunta ni ampliación automática de alcance.
- Diagnóstico/orientación no vuelve a ser la entrada comercial principal.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile