### PR TITLE
feat(public): cierra jerarquía comercial y continuidad de contacto V2.4

### DIFF
--- a/e2e/public-commercial-continuity.spec.ts
+++ b/e2e/public-commercial-continuity.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+test("legal solution keeps exact service context into Contact", async ({ page }) => {
+  await page.goto("/soluciones/gestion-juridica-regulatoria");
+
+  const contact = page.getByRole("link", { name: "Plantear el caso", exact: true });
+  await expect(contact).toHaveAttribute("href", /\/contacto\?service=/);
+  await contact.click();
+
+  const inherited = page.getByLabel("Contexto heredado de navegación");
+  await expect(inherited.locator("span").filter({ hasText: "Origen:" })).toContainText("solucion");
+  await expect(inherited.locator("span").filter({ hasText: "Servicio:" })).toContainText("Gestión jurídica y regulatoria para residuos, aseo y proyectos");
+  await expect(page.getByLabel("Servicio recibido de la navegación")).toContainText("Gestión jurídica y regulatoria para residuos, aseo y proyectos");
+});
+
+test("valorization solution keeps exact service context into Contact", async ({ page }) => {
+  await page.goto("/soluciones/valorizacion-productos");
+
+  const contact = page.getByRole("link", { name: "Evaluar un producto", exact: true });
+  await expect(contact).toHaveAttribute("href", /\/contacto\?service=/);
+  await contact.click();
+
+  const inherited = page.getByLabel("Contexto heredado de navegación");
+  await expect(inherited.locator("span").filter({ hasText: "Origen:" })).toContainText("solucion");
+  await expect(inherited.locator("span").filter({ hasText: "Servicio:" })).toContainText("Valorización y desarrollo de productos");
+  await expect(page.getByLabel("Servicio recibido de la navegación")).toContainText("Valorización y desarrollo de productos");
+});
+
+test("public company and contact surfaces no longer make technical diagnosis the primary next step", async ({ page }) => {
+  for (const route of ["/nosotros", "/contacto"] as const) {
+    await page.goto(route);
+    await expect(page.getByRole("link", { name: "Explorar servicios", exact: true })).toHaveAttribute("href", "/soluciones");
+    await expect(page.getByRole("link", { name: "Usar orientador inicial", exact: true })).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
+    await expect(page.getByRole("link", { name: "Empezar por diagnóstico", exact: true })).toHaveCount(0);
+  }
+});

--- a/e2e/public-company-contact.spec.ts
+++ b/e2e/public-company-contact.spec.ts
@@ -1,17 +1,20 @@
 import { test, expect } from "@playwright/test";
 
-test("company page explains Greenatics through capability, method and evidence", async ({ page }) => {
+test("company page explains Greenatics through capability, commercial method and evidence", async ({ page }) => {
   await page.goto("/nosotros");
 
   await expect(page.getByRole("heading", { name: /Diseñamos sistemas que tienen que funcionar en la vida real/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: /La capacidad está en conectar disciplinas/i })).toBeVisible();
-  await expect(page.getByRole("heading", { name: /Diagnóstico primero\. Después una ruta que pueda ejecutarse/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Primero el resultado que necesitas\. Después definimos la ruta para alcanzarlo/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: /Un caso sirve cuando deja aprendizaje transferible/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Si ya sabes qué necesitas, entra directo al servicio/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Explorar servicios", exact: true })).toHaveAttribute("href", "/soluciones");
+  await expect(page.getByRole("link", { name: "Usar orientador inicial", exact: true })).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
   await expect(page.getByRole("link", { name: /Wondergreen/i }).last()).toHaveAttribute("href", "/wondergreen");
   await expect(page.getByRole("link", { name: /Recursos/i }).last()).toHaveAttribute("href", "/recursos");
 });
 
-test("contact page starts with context instead of forcing a service name", async ({ page }) => {
+test("contact page starts with context without forcing diagnosis or a service name", async ({ page }) => {
   await page.goto("/contacto");
 
   await expect(page.getByRole("heading", { name: "Cuéntanos qué quieres resolver." })).toBeVisible();
@@ -20,6 +23,10 @@ test("contact page starts with context instead of forcing a service name", async
   await expect(page.getByLabel("¿Qué necesitas resolver primero?")).toBeVisible();
   await expect(page.getByText(/Este paso no envía información a Greenatics/i)).toBeVisible();
   await expect(page.getByRole("link", { name: /Preparar conversación/i }).first()).toHaveAttribute("href", /\/contacto\?audience=/);
+  await expect(page.getByRole("heading", { name: "El servicio primero. La orientación solo cuando todavía hace falta." })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Explorar servicios", exact: true })).toHaveAttribute("href", "/soluciones");
+  await expect(page.getByRole("link", { name: "Usar orientador inicial", exact: true })).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
+  await expect(page.getByRole("link", { name: "Empezar por diagnóstico", exact: true })).toHaveCount(0);
 });
 
 test("contact page inherits audience and need context without inventing a recommendation", async ({ page }) => {
@@ -39,6 +46,23 @@ test("contact page inherits audience and need context without inventing a recomm
   await expect(page.getByLabel("Resumen preparado para la conversación")).toContainText("Planta / Operador");
   await expect(page.getByLabel("Resumen preparado para la conversación")).toContainText("Antioquia");
   await expect(page.getByText("Nada se ha enviado todavía.", { exact: false })).toBeVisible();
+});
+
+test("contact page preserves an exact service from a commercial solution route", async ({ page }) => {
+  const service = "Dirección técnica y coordinación de operación";
+  await page.goto(`/contacto?service=${encodeURIComponent(service)}&source=solucion&contexto=${encodeURIComponent("Interés en fortalecer la operación de una planta.")}`);
+
+  const inherited = page.getByLabel("Contexto heredado de navegación");
+  await expect(inherited.locator("span").filter({ hasText: "Servicio:" })).toContainText(service);
+  await expect(page.getByLabel("Servicio recibido de la navegación")).toContainText(service);
+
+  await page.getByLabel("¿Desde qué contexto nos escribes?").selectOption("planta");
+  await page.getByLabel("¿Qué necesitas resolver primero?").selectOption("operacion");
+  await page.getByRole("button", { name: "Preparar contexto" }).click();
+
+  const summary = page.getByLabel("Resumen preparado para la conversación");
+  await expect(summary).toContainText(`Servicio de interés: ${service}`);
+  await expect(summary).toContainText("Interés en fortalecer la operación de una planta.");
 });
 
 test("contact page preserves an exact Wondergreen product context", async ({ page }) => {

--- a/src/app/contacto/contact-context-builder.tsx
+++ b/src/app/contacto/contact-context-builder.tsx
@@ -7,6 +7,7 @@ type ContactContextBuilderProps = {
   bookingUrl: string;
   initialAudience?: string;
   initialNeed?: string;
+  initialService?: string;
   initialProduct?: string;
   initialCrop?: string;
   initialContext?: string;
@@ -42,7 +43,7 @@ function optionLabel(options: readonly (readonly [string, string])[], value: str
   return options.find(([id]) => id === value)?.[1] ?? value;
 }
 
-export function ContactContextBuilder({ bookingUrl, initialAudience = "", initialNeed = "", initialProduct, initialCrop, initialContext }: ContactContextBuilderProps) {
+export function ContactContextBuilder({ bookingUrl, initialAudience = "", initialNeed = "", initialService, initialProduct, initialCrop, initialContext }: ContactContextBuilderProps) {
   const [audience, setAudience] = useState(initialAudience);
   const [need, setNeed] = useState(initialNeed);
   const [location, setLocation] = useState("");
@@ -54,6 +55,7 @@ export function ContactContextBuilder({ bookingUrl, initialAudience = "", initia
     const lines = [
       `Contexto: ${optionLabel(audiences, audience) || "Por definir"}`,
       `Necesidad: ${optionLabel(needs, need) || "Por definir"}`,
+      initialService ? `Servicio de interés: ${initialService}` : "",
       initialContext ? `Contexto heredado: ${initialContext}` : "",
       location ? `Ubicación: ${location}` : "",
       initialProduct ? `Referencia Wondergreen: ${initialProduct}` : "",
@@ -61,7 +63,7 @@ export function ContactContextBuilder({ bookingUrl, initialAudience = "", initia
       details ? `Situación: ${details}` : "",
     ].filter(Boolean);
     return lines.join("\n");
-  }, [audience, need, location, details, initialContext, initialProduct, initialCrop]);
+  }, [audience, need, location, details, initialService, initialContext, initialProduct, initialCrop]);
 
   async function copySummary() {
     try {
@@ -97,6 +99,7 @@ export function ContactContextBuilder({ bookingUrl, initialAudience = "", initia
         </div>
       </div>
 
+      {initialService ? <p className={styles.formHelp} aria-label="Servicio recibido de la navegación"><strong>Servicio de interés:</strong> {initialService}</p> : null}
       {initialContext ? <p className={styles.formHelp} aria-label="Contexto recibido de la navegación"><strong>Contexto recibido de la navegación:</strong> {initialContext}</p> : null}
       <p className={styles.formHelp}>Este paso no envía información a Greenatics ni la guarda en un servidor. Solo organiza el contexto en tu navegador para que llegues mejor preparado a la conversación.</p>
       <div className={styles.actions}><button className={`${styles.button} ${styles.primary}`} type="submit">Preparar contexto</button><a className={`${styles.button} ${styles.ghost}`} href={bookingUrl} target="_blank" rel="noreferrer">Agendar sin preparar</a></div>

--- a/src/app/contacto/page.tsx
+++ b/src/app/contacto/page.tsx
@@ -24,28 +24,28 @@ const audienceContent: Record<string, { title: string; lead: string; builder: st
   },
   empresa: {
     title: "Cuéntanos cómo gestionas hoy tus residuos.",
-    lead: "Podemos revisar línea base, PMIRS, múltiples sedes, orgánicos, gestores, logística, indicadores, tratamiento o trazabilidad sin obligarte a llegar con una solución predeterminada.",
+    lead: "Podemos trabajar línea base, PMIRS, múltiples sedes, orgánicos, gestores, logística, indicadores, tratamiento o trazabilidad. Si ya sabes cuál servicio necesitas, conservamos ese contexto desde el primer contacto.",
     builder: "empresa",
   },
   ph: {
     title: "Cuéntanos cuántas unidades o sedes quieres organizar.",
-    lead: "La conversación puede partir de diagnóstico, PMIRS por unidad, estandarización, información comparable y una lógica de red para seguimiento y decisiones.",
+    lead: "La conversación puede partir de PMIRS por unidad, caracterización, estandarización, información comparable y una lógica de red para seguimiento y decisiones.",
     builder: "ph",
   },
   planta: {
     title: "Cuéntanos sobre la planta que quieres recuperar o mejorar.",
-    lead: "Si la infraestructura existe, el primer paso es entender su estado técnico, suministro, proceso, personas, mantenimiento, datos y destino antes de decidir inversión o intervención.",
+    lead: "Podemos entrar por rehabilitación, dirección técnica, operación, prefactibilidad o ingeniería según el estado de la infraestructura y la decisión que ya tengas abierta.",
     builder: "planta",
   },
   wondergreen: {
     title: "Cuéntanos sobre tu cultivo o tu interés en Wondergreen.",
-    lead: "Cultivo, etapa, problema, análisis, referencia y canal comercial cambian la conversación. Podemos empezar por contexto técnico o por distribución.",
+    lead: "Cultivo, etapa, problema, análisis, referencia y canal comercial cambian la conversación. Podemos empezar por una referencia concreta, soporte técnico o distribución.",
     builder: "wondergreen",
   },
 };
 
 const preparation = [
-  ["Organizaciones", "Residuos y gestión", ["Ubicación y tipo de organización", "Qué ocurre hoy", "Datos o diagnósticos disponibles", "Principal decisión pendiente"]],
+  ["Organizaciones", "Residuos y gestión", ["Ubicación y tipo de organización", "Qué ocurre hoy", "Datos o evaluaciones disponibles", "Principal decisión pendiente"]],
   ["Plantas / proyectos", "Infraestructura y operación", ["Estado actual de la planta", "Corriente y suministro", "Restricción principal", "Documentos, planos o datos existentes"]],
   ["Agro / Wondergreen", "Cultivo y nutrición", ["Cultivo y etapa", "Área o número de plantas", "Objetivo o problema observado", "Análisis disponibles y manejo reciente"]],
 ] as const;
@@ -53,9 +53,9 @@ const preparation = [
 const routes = [
   ["01", "ESP / Prestador", "Preparación, rutas, aprovechamiento, infraestructura, operación y datos.", "/contacto?audience=esp", "Preparar conversación"],
   ["02", "Municipio", "PGIRS, proyectos, activos, prefactibilidad y decisiones territoriales.", "/contacto?audience=municipio", "Preparar conversación"],
-  ["03", "Empresa", "Diagnóstico, PMIRS, logística, tratamiento y trazabilidad.", "/contacto?audience=empresa", "Preparar conversación"],
-  ["04", "Propiedad horizontal / Institución", "Diagnóstico por unidad, PMIRS y lógica de red.", "/contacto?audience=ph", "Preparar conversación"],
-  ["05", "Planta / Operador", "Estado técnico, rehabilitación, optimización y dirección.", "/contacto?audience=planta", "Preparar conversación"],
+  ["03", "Empresa", "Línea base, PMIRS, logística, tratamiento y trazabilidad.", "/contacto?audience=empresa", "Preparar conversación"],
+  ["04", "Propiedad horizontal / Institución", "Caracterización, PMIRS por unidad, estandarización y lógica de red.", "/contacto?audience=ph", "Preparar conversación"],
+  ["05", "Planta / Operador", "Rehabilitación, optimización, dirección, operación e ingeniería.", "/contacto?audience=planta", "Preparar conversación"],
   ["06", "Wondergreen", "Cultivo, producto, soporte técnico o distribución.", "/contacto?audience=wondergreen", "Preparar conversación"],
 ] as const;
 
@@ -93,7 +93,7 @@ export default async function ContactPage({ searchParams }: { searchParams: Prom
   const query = await searchParams;
   const audience = normalizeAudience(firstParam(query.audience));
   const need = firstParam(query.need) ?? "";
-  const service = firstParam(query.service);
+  const service = firstParam(query.service)?.trim().slice(0, 180) || undefined;
   const source = firstParam(query.source);
   const crop = firstParam(query.cultivo);
   const inheritedContext = normalizeInheritedContext(firstParam(query.contexto));
@@ -101,7 +101,9 @@ export default async function ContactPage({ searchParams }: { searchParams: Prom
   const product = productSlug ? getWondergreenReference(productSlug) : undefined;
   const contextual = audienceContent[audience];
   const title = contextual?.title ?? (product ? `Cuéntanos el contexto de ${product.name}.` : "Cuéntanos qué quieres resolver.");
-  const lead = contextual?.lead ?? "No necesitas conocer el nombre de nuestro servicio. Empieza por la situación actual, la decisión que necesitas tomar y la información que ya existe.";
+  const lead = contextual?.lead ?? (service
+    ? `Ya conservamos el servicio que estabas revisando: ${service}. Completa solo el contexto que ayude a preparar una conversación útil.`
+    : "Si ya sabes qué servicio necesitas, puedes llegar directamente con esa referencia. Si no, empieza por la situación actual, la decisión que necesitas tomar y la información que ya existe.");
 
   return (
     <div className={styles.page}>
@@ -146,13 +148,14 @@ export default async function ContactPage({ searchParams }: { searchParams: Prom
             <div className={styles.builderIntro}>
               <span className={styles.eyebrow}>Prepara tu caso</span>
               <h2 id="builder-title">Cuatro datos pueden llevar la conversación mucho más rápido al problema real.</h2>
-              <p>Este paso sirve para ordenar el contexto antes de hablar con el equipo. No sustituye un diagnóstico y no intenta recomendar automáticamente un servicio.</p>
+              <p>Este paso sirve para ordenar el contexto antes de hablar con el equipo. No sustituye una evaluación técnica, no cambia el servicio que ya elegiste y no intenta recomendar automáticamente otro.</p>
               <div className={styles.builderNote}><strong>Privacidad práctica.</strong> Evita incluir secretos industriales, datos personales sensibles o documentación confidencial en este primer resumen. Podemos definir después el canal adecuado para compartir información técnica.</div>
             </div>
             <ContactContextBuilder
               bookingUrl={publicSite.bookingUrl}
               initialAudience={contextual?.builder ?? audience}
               initialNeed={need}
+              initialService={service}
               initialProduct={product ? `${product.name}${product.formula ? ` ${product.formula}` : ""}` : undefined}
               initialCrop={crop}
               initialContext={inheritedContext}
@@ -186,15 +189,15 @@ export default async function ContactPage({ searchParams }: { searchParams: Prom
 
         <section className={`${styles.section} ${styles.soft}`}>
           <div className={`${styles.container} ${styles.officeGrid}`}>
-            <div><span className={styles.eyebrow}>Dónde estamos</span><h2>Medellín, Colombia.</h2><p className={styles.lead}>La sede pública es un punto de referencia corporativo. Los proyectos, diagnósticos y operaciones pueden desarrollarse en otros territorios según su alcance.</p></div>
+            <div><span className={styles.eyebrow}>Dónde estamos</span><h2>Medellín, Colombia.</h2><p className={styles.lead}>La sede pública es un punto de referencia corporativo. Los proyectos, evaluaciones y operaciones pueden desarrollarse en otros territorios según su alcance.</p></div>
             <aside className={styles.officeCard}><strong>{publicSite.office.line1}</strong><span>{publicSite.office.line2}</span><span>{publicSite.office.city}</span></aside>
           </div>
         </section>
 
         <section className={styles.closing}>
           <div className={`${styles.container} ${styles.closingGrid}`}>
-            <div><span className={styles.eyebrow}>Si todavía no sabes qué pedir</span><h2>Elige el problema antes que la solución.</h2></div>
-            <div><p>La ruta más segura es empezar por el contexto y dejar que el diagnóstico defina qué servicio, herramienta o intervención tiene sentido después.</p><div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/soluciones/diagnostico-caracterizacion">Empezar por diagnóstico</Link><Link className={`${styles.button} ${styles.ghost}`} href="/soluciones">Explorar soluciones</Link></div></div>
+            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>El servicio primero. La orientación solo cuando todavía hace falta.</h2></div>
+            <div><p>Si ya reconoces lo que necesitas, vuelve al catálogo y abre directamente el servicio, producto o solución correspondiente. Si todavía existe incertidumbre, el orientador inicial puede ayudarte a ubicar una ruta sin sustituir una evaluación técnica ni convertirla en una prescripción.</p><div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/soluciones">Explorar servicios</Link><Link className={`${styles.button} ${styles.ghost}`} href="/soluciones/diagnostico-inicial">Usar orientador inicial</Link></div></div>
           </div>
         </section>
       </main>

--- a/src/app/nosotros/page.tsx
+++ b/src/app/nosotros/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 };
 
 const capabilities = [
-  ["Gestión y planeación", "Diagnóstico, caracterización, PMIRS, PGIRS, separación, rutas y decisiones antes de comprometer infraestructura."],
+  ["Gestión y planeación", "Caracterización, PMIRS, PGIRS, separación, rutas y estructuración de decisiones antes de comprometer infraestructura."],
   ["Ingeniería y plantas", "Prefactibilidad, rehabilitación, optimización, compostaje, digestión anaerobia y puesta en marcha según el contexto."],
   ["Dirección y operación", "Protocolos, personas, mantenimiento, calidad, inventarios, coordinación y mejora continua sin asumir que Greenatics debe operar todo directamente."],
   ["Valorización y agro", "Wondergreen conecta suelo, nutrición organomineral, líquidos, compost, bioinsumos, conocimiento y desarrollo de destinos para materiales aprovechados."],
@@ -19,24 +19,24 @@ const capabilities = [
 ] as const;
 
 const method = [
-  ["01", "Diagnosticar", "Entender generación, operación, restricciones, infraestructura, datos y decisión pendiente."],
-  ["02", "Definir ruta", "Separar lo urgente, lo necesario y lo que todavía requiere validación antes de invertir."],
-  ["03", "Implementar", "Traducir el diagnóstico en actividades, protocolos, ingeniería, logística o herramientas concretas."],
+  ["01", "Entender", "Leer el resultado que se necesita, la situación actual, la información disponible, las restricciones y las responsabilidades involucradas."],
+  ["02", "Definir el alcance", "Traducir la necesidad en actividades, entregables, responsables, exclusiones y criterios de cierre antes de ejecutar."],
+  ["03", "Implementar", "Ejecutar programas, protocolos, ingeniería, logística, operación o herramientas concretas según el alcance contratado."],
   ["04", "Acompañar", "Dirigir, medir y corregir sin confundir seguimiento técnico con una obligación de operar todos los activos."],
   ["05", "Mejorar y valorizar", "Usar la evidencia para optimizar el sistema y encontrar mejores destinos para los recursos recuperados."],
 ] as const;
 
 const principles = [
-  ["Entender antes de dimensionar", "Una tecnología correcta para la corriente equivocada sigue siendo una mala solución. La línea base gobierna la siguiente decisión."],
+  ["Entender antes de dimensionar", "Una tecnología correcta para la corriente equivocada sigue siendo una mala solución. La información de partida gobierna la siguiente decisión cuando realmente hace falta medir o comprobar."],
   ["Diseñar pensando en operar", "Una planta necesita suministro, personas, procedimientos, mantenimiento, control y salida de producto; no solo equipos."],
   ["Separar evidencia de promesa", "Una foto, una capacidad nominal o una característica técnica no se convierten automáticamente en un resultado vigente o universal."],
   ["Medir para mejorar", "Recepciones, impropios, lotes, proceso, mantenimiento, producto e inventario deben producir información útil para decidir."],
 ] as const;
 
 const ecosystem = [
-  ["Soluciones", "/soluciones", "Diagnóstico, planeación, regulación, rutas, plantas, operación, datos y valorización."],
+  ["Soluciones", "/soluciones", "Planeación, regulación, caracterización, rutas, plantas, operación, datos y valorización."],
   ["Wondergreen", "/wondergreen", "Suelo, nutrición, biología, productos, cultivos y acompañamiento técnico."],
-  ["Casa & Jardín", "/casa-jardin", "Una entrada doméstica por observación, seguridad y etapa, todavía sin ecommerce activo."],
+  ["Casa & Jardín", "/casa-jardin", "Una entrada doméstica por producto, kit, etapa y seguridad, todavía sin ecommerce activo."],
   ["Recursos", "/recursos", "Biblioteca técnica, proyectos documentados e impacto publicado con gobierno."],
   ["GREENATICS OPS", "/app", "La capa digital donde una operación activa puede registrar y convertir actividad en evidencia."],
 ] as const;
@@ -85,8 +85,8 @@ export default function AboutPage() {
         <section className={`${styles.section} ${styles.dark}`} id="como-trabajamos" aria-labelledby="method-title">
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Cómo trabajamos</span><h2 id="method-title">Diagnóstico primero. Después una ruta que pueda ejecutarse.</h2></div>
-              <p>No vendemos una tecnología como respuesta universal. La secuencia permite separar lo que sabemos, lo que falta comprobar y lo que realmente conviene hacer después.</p>
+              <div><span className={styles.eyebrow}>Cómo trabajamos</span><h2 id="method-title">Primero el resultado que necesitas. Después definimos la ruta para alcanzarlo.</h2></div>
+              <p>No vendemos una tecnología ni un diagnóstico como respuesta universal. Si el problema y la información ya están claros, podemos entrar directamente al servicio; cuando faltan datos críticos, la línea base se incorpora como una actividad del alcance.</p>
             </div>
             <div className={styles.method}>
               {method.map(([number, title, copy]) => <article key={number}><span>{number}</span><h3>{title}</h3><p>{copy}</p></article>)}
@@ -98,7 +98,7 @@ export default function AboutPage() {
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>Criterio de trabajo</span><h2 id="principles-title">La ingeniería, la operación y la comunicación necesitan el mismo estándar de verdad.</h2></div>
-              <p>Estos principios gobiernan tanto un diagnóstico como una propuesta, una planta, un producto o una cifra pública.</p>
+              <p>Estos principios gobiernan una caracterización, una propuesta, una planta, un producto, una operación o una cifra pública.</p>
             </div>
             <div className={styles.principles}>
               {principles.map(([title, copy], index) => <article className={styles.principle} key={title}><span>{String(index + 1).padStart(2, "0")}</span><div><h3>{title}</h3><p>{copy}</p></div></article>)}
@@ -133,8 +133,8 @@ export default function AboutPage() {
 
         <section className={styles.closing}>
           <div className={`${styles.container} ${styles.closingGrid}`}>
-            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>Si el problema es complejo, empecemos por ordenarlo.</h2></div>
-            <div><p>Cuéntanos qué decisión necesitas tomar y qué información ya existe. Podemos empezar por diagnóstico, una ruta técnica o una conversación exploratoria.</p><div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/contacto?source=nosotros">Hablar con nosotros</Link><Link className={`${styles.button} ${styles.ghost}`} href="/soluciones/diagnostico-caracterizacion">Empezar por diagnóstico</Link></div></div>
+            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>Si ya sabes qué necesitas, entra directo al servicio.</h2></div>
+            <div><p>Explora el alcance y los entregables de cada solución. Si todavía no está claro cuál corresponde, el orientador inicial puede ayudarte a ubicar una ruta sin sustituir la evaluación técnica ni el alcance comercial.</p><div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/soluciones">Explorar servicios</Link><Link className={`${styles.button} ${styles.ghost}`} href="/soluciones/diagnostico-inicial">Usar orientador inicial</Link></div></div>
           </div>
         </section>
       </main>

--- a/src/app/soluciones/gestion-juridica-regulatoria/page.tsx
+++ b/src/app/soluciones/gestion-juridica-regulatoria/page.tsx
@@ -7,6 +7,9 @@ import refresh from "../solutions-refresh.module.css";
 
 const title = "Gestión jurídica y regulatoria | Greenatics";
 const description = "Asesoría jurídica y regulatoria para estructurar responsabilidades, instrumentos, contratos, trámites y decisiones asociadas a residuos, aseo y proyectos de aprovechamiento.";
+const serviceName = "Gestión jurídica y regulatoria para residuos, aseo y proyectos";
+const contactContext = "Interés en estructurar una necesidad jurídica o regulatoria dentro de un proyecto de residuos, aseo, aprovechamiento u operación.";
+const contactHref = `/contacto?service=${encodeURIComponent(serviceName)}&source=solucion&contexto=${encodeURIComponent(contactContext)}`;
 
 export const metadata: Metadata = {
   title,
@@ -52,7 +55,7 @@ export default function RegulatoryLegalSolutionPage() {
                 <p className={styles.detailLead}>Estructuramos actividades, responsabilidades y documentos frente al marco aplicable al alcance, para que la decisión técnica tenga una ruta jurídica clara y ejecutable.</p>
                 <div className={styles.actions}>
                   <a className={`${styles.button} ${styles.primary}`} href="#entregables">Ver entregables</a>
-                  <Link className={styles.button} href="/contacto">Plantear el caso</Link>
+                  <Link className={styles.button} href={contactHref}>Plantear el caso</Link>
                 </div>
               </div>
               <aside className={styles.detailAside}>
@@ -85,7 +88,7 @@ export default function RegulatoryLegalSolutionPage() {
 
             <div className={styles.detailCta}>
               <div><span className={styles.eyebrow}>Siguiente paso</span><h3>Definir el problema jurídico y el resultado que necesita el proyecto.</h3><p>Si el asunto ya está identificado, podemos estructurar directamente el alcance. Si todavía existen vacíos de información, la revisión documental inicial se incorpora como actividad de trabajo y no como sustituto del servicio.</p></div>
-              <Link className={`${styles.button} ${styles.primary}`} href="/contacto">Hablar con Greenatics</Link>
+              <Link className={`${styles.button} ${styles.primary}`} href={contactHref}>Hablar con Greenatics</Link>
             </div>
           </div>
         </section>

--- a/src/app/soluciones/valorizacion-productos/page.tsx
+++ b/src/app/soluciones/valorizacion-productos/page.tsx
@@ -7,6 +7,9 @@ import refresh from "../solutions-refresh.module.css";
 
 const title = "Valorización y desarrollo de productos | Greenatics";
 const description = "Ruta técnica, documental y comercial para convertir salidas del tratamiento en productos con especificaciones, control, documentación y condiciones de comercialización definidas.";
+const serviceName = "Valorización y desarrollo de productos";
+const contactContext = "Interés en convertir una salida del tratamiento, formulación o material existente en un producto técnicamente documentado y comercialmente preparado.";
+const contactHref = `/contacto?service=${encodeURIComponent(serviceName)}&source=solucion&contexto=${encodeURIComponent(contactContext)}`;
 
 export const metadata: Metadata = {
   title,
@@ -55,7 +58,7 @@ export default function ValorizationProductSolutionPage() {
                 <p className={styles.detailLead}>Acompañamos la ruta desde la caracterización y especificación hasta la documentación, controles, presentación y preparación regulatoria o comercial que correspondan al producto.</p>
                 <div className={styles.actions}>
                   <a className={`${styles.button} ${styles.primary}`} href="#entregables">Ver entregables</a>
-                  <Link className={styles.button} href="/contacto">Evaluar un producto</Link>
+                  <Link className={styles.button} href={contactHref}>Evaluar un producto</Link>
                 </div>
               </div>
               <aside className={styles.detailAside}>
@@ -88,7 +91,7 @@ export default function ValorizationProductSolutionPage() {
 
             <div className={styles.detailCta}>
               <div><span className={styles.eyebrow}>Siguiente paso</span><h3>Definir qué material existe hoy y qué condición comercial se quiere alcanzar.</h3><p>La ruta puede iniciar en una caracterización, una formulación ya desarrollada, un producto en trámite o una referencia comercial existente. El alcance se diseña desde ese punto real, no desde una etapa obligatoria de diagnóstico.</p></div>
-              <Link className={`${styles.button} ${styles.primary}`} href="/contacto">Hablar con Greenatics</Link>
+              <Link className={`${styles.button} ${styles.primary}`} href={contactHref}>Hablar con Greenatics</Link>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Objetivo
Cerrar restos de la narrativa diagnosis-first fuera de Soluciones y preservar el servicio exacto cuando el usuario pasa de una ficha comercial a Contacto. La oferta sigue primero; la orientación queda únicamente para incertidumbre.

## Cambios
- `/nosotros` adopta el método `Entender → Definir el alcance → Implementar → Acompañar → Mejorar y valorizar`.
- Se elimina `Diagnóstico primero` como principio corporativo y el cierre dirige primero al catálogo de servicios.
- `/contacto` elimina `Empezar por diagnóstico` como CTA y prioriza `Explorar servicios`; el orientador inicial queda secundario.
- Contacto conserva explícitamente `service` dentro del resumen preparado, además del contexto heredado.
- Rutas rápidas de Contacto usan línea base, PMIRS, rehabilitación y oferta concreta en vez de lenguaje diagnosis-first.
- Gestión jurídica/regulatoria y valorización/desarrollo de productos ya no pierden contexto al ir a Contacto: envían servicio, origen y contexto comercial.
- Nueva regresión Playwright para continuidad de servicio y ausencia de CTA diagnosis-first en Nosotros/Contacto.

## Truth / UX locks
- No se elimina la capacidad de diagnóstico ni caracterización; se reposiciona como actividad o servicio específico cuando corresponde.
- El orientador `/soluciones/diagnostico-inicial` sigue disponible, pero no sustituye una evaluación técnica ni prescribe alcance.
- No se añaden servicios, claims, métricas, permisos, certificaciones ni resultados nuevos.
- El contexto preparado continúa siendo local al navegador y no simula un CRM ni un envío al servidor.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile