### PR TITLE
feat(audiences): prioriza servicios directos por contexto V2.5

### DIFF
--- a/e2e/public-audience-commercial-depth.spec.ts
+++ b/e2e/public-audience-commercial-depth.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+
+async function expectSectionBefore(page: import("@playwright/test").Page, first: string, second: string) {
+  const firstBeforeSecond = await page.locator(first).evaluate((node, secondSelector) => {
+    const secondNode = document.querySelector(secondSelector as string);
+    if (!secondNode) return false;
+    return Boolean(node.compareDocumentPosition(secondNode) & Node.DOCUMENT_POSITION_FOLLOWING);
+  }, second);
+  expect(firstBeforeSecond).toBe(true);
+}
+
+test("audience landing exposes direct services before the uncertainty router", async ({ page }) => {
+  await page.goto("/soluciones/esp");
+
+  await expect(page.getByRole("link", { name: "Ver servicios para este contexto →", exact: true })).toHaveAttribute("href", "#servicios");
+  await expect(page.getByRole("link", { name: "No sé cuál revisar →", exact: true })).toHaveAttribute("href", "#decisiones");
+  await expect(page.getByRole("link", { name: "Encontrar punto de entrada →", exact: true })).toHaveCount(0);
+
+  await expect(page.getByRole("heading", { name: "Servicios que puedes abrir directamente." })).toBeVisible();
+  await expectSectionBefore(page, "#servicios", "#decisiones");
+
+  const routesCard = page.getByRole("article").filter({
+    has: page.getByRole("heading", { name: "Diseño e implementación de rutas selectivas y microrrutas", exact: true }),
+  });
+  await expect(routesCard).toHaveCount(1);
+  await expect(routesCard.getByText("Entregables típicos", { exact: true })).toBeVisible();
+  await expect(routesCard.getByText("diseño de ruta", { exact: true })).toBeVisible();
+  await expect(routesCard.getByRole("link", { name: /Ver alcance y entregables/ })).toHaveAttribute("href", "/soluciones/rutas-selectivas");
+
+  const contact = page.getByRole("link", { name: "Hablar con Greenatics →", exact: true });
+  await expect(contact).toHaveAttribute("href", /audience=esp/);
+  await expect(contact).toHaveAttribute("href", /source=soluciones-esp/);
+  await expect(contact).toHaveAttribute("href", /contexto=ESP/);
+});
+
+test("all five audience routes expose governed service cards without forcing orientation first", async ({ page }) => {
+  const cases = [
+    ["/soluciones/esp", "Dirección técnica y coordinación de operación", "/soluciones/direccion-operacion"],
+    ["/soluciones/municipios", "PGIRS · formulación, actualización y fortalecimiento operativo", "/soluciones/pgirs"],
+    ["/soluciones/empresas", "PMIRS y planes internos de gestión de residuos", "/soluciones/pmirs"],
+    ["/soluciones/propiedad-horizontal", "PMIRS y planes internos de gestión de residuos", "/soluciones/pmirs"],
+    ["/soluciones/plantas", "Operación integral de plantas de tratamiento y valorización", "/soluciones/operacion-integral"],
+  ] as const;
+
+  for (const [route, serviceName, href] of cases) {
+    await page.goto(route);
+    await expect(page.getByRole("heading", { name: "Servicios que puedes abrir directamente." })).toBeVisible();
+    const card = page.getByRole("article").filter({
+      has: page.getByRole("heading", { name: serviceName, exact: true }),
+    });
+    await expect(card, `${route} should expose ${serviceName}`).toHaveCount(1);
+    await expect(card.getByRole("link", { name: /Ver alcance y entregables/ })).toHaveAttribute("href", href);
+    await expectSectionBefore(page, "#servicios", "#decisiones");
+  }
+});
+
+test("intent routes inherit the same direct-service hierarchy", async ({ page }) => {
+  const cases = [
+    ["/soluciones/residuos-organicos", "Gestión, recolección y tratamiento de residuos orgánicos para generadores", "/soluciones/recoleccion-tratamiento"],
+    ["/soluciones/infraestructura-plantas", "Prefactibilidad de plantas y sistemas de tratamiento y valorización", "/soluciones/prefactibilidad"],
+    ["/soluciones/propiedad-horizontal-redes", "PMIRS y planes internos de gestión de residuos", "/soluciones/pmirs"],
+  ] as const;
+
+  for (const [route, serviceName, href] of cases) {
+    await page.goto(route);
+    const card = page.getByRole("article").filter({
+      has: page.getByRole("heading", { name: serviceName, exact: true }),
+    });
+    await expect(card).toHaveCount(1);
+    await expect(card.getByRole("link", { name: /Ver alcance y entregables/ })).toHaveAttribute("href", href);
+    await expect(page.getByRole("heading", { name: "Usa la situación actual como orientación." })).toBeVisible();
+    await expectSectionBefore(page, "#servicios", "#decisiones");
+  }
+});

--- a/src/app/soluciones/audience-service-catalog.module.css
+++ b/src/app/soluciones/audience-service-catalog.module.css
@@ -1,0 +1,147 @@
+.catalog {
+  padding: 112px 0;
+  background: #fff;
+  border-bottom: 1px solid var(--line);
+}
+
+.catalogGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.serviceCard {
+  min-height: 430px;
+  display: flex;
+  flex-direction: column;
+  padding: 34px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+}
+
+.serviceMeta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.serviceMeta span,
+.deliverables > span {
+  color: var(--green);
+  font-size: .68rem;
+  font-weight: 800;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.serviceMeta small {
+  color: var(--muted);
+  font-size: .68rem;
+  font-weight: 700;
+  text-align: right;
+}
+
+.serviceCard h3 {
+  max-width: 620px;
+  margin: 22px 0 0;
+}
+
+.serviceCard > p {
+  margin: 16px 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.deliverables {
+  margin-top: 26px;
+  padding-top: 20px;
+  border-top: 1px solid var(--line);
+}
+
+.deliverables ul {
+  display: grid;
+  gap: 9px;
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.deliverables li {
+  position: relative;
+  padding-left: 17px;
+  color: var(--ink);
+  font-size: .82rem;
+  line-height: 1.5;
+}
+
+.deliverables li::before {
+  content: "";
+  position: absolute;
+  top: .6em;
+  left: 0;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--sun);
+}
+
+.serviceLink {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-top: auto;
+  padding-top: 24px;
+  border-top: 1px solid var(--line);
+  color: var(--green);
+  font-size: .82rem;
+  font-weight: 800;
+}
+
+.catalogNote {
+  max-width: 880px;
+  margin: 24px 0 0;
+  color: var(--muted);
+  font-size: .78rem;
+  line-height: 1.6;
+}
+
+.orientation {
+  border-top: 1px solid var(--line);
+}
+
+@media (max-width: 900px) {
+  .catalogGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .serviceCard {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 760px) {
+  .catalog {
+    padding: 78px 0;
+  }
+
+  .serviceCard {
+    padding: 28px 24px;
+  }
+
+  .serviceMeta {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .serviceMeta small {
+    text-align: left;
+  }
+}

--- a/src/components/audience-solution-landing.tsx
+++ b/src/components/audience-solution-landing.tsx
@@ -9,8 +9,40 @@ import styles from "@/app/soluciones/solutions.module.css";
 import refresh from "@/app/soluciones/solutions-refresh.module.css";
 import programStyles from "@/app/soluciones/strategic-programs.module.css";
 import moduleStyles from "@/app/soluciones/commercial-modules.module.css";
+import catalogStyles from "@/app/soluciones/audience-service-catalog.module.css";
 
 type GuidedSolutionLanding = AudienceLanding | IntentLanding;
+
+const contactAudienceBySlug: Partial<Record<GuidedSolutionLanding["slug"], string>> = {
+  esp: "esp",
+  municipios: "municipio",
+  empresas: "empresa",
+  "propiedad-horizontal": "ph",
+  plantas: "planta",
+};
+
+function uniqueServiceSlugs(landing: GuidedSolutionLanding) {
+  const decisionSlugs = landing.decisions.flatMap((decision) => {
+    if (!decision.href.startsWith("/soluciones/") || decision.href.startsWith("/soluciones/programas/")) return [];
+    const slug = decision.href.replace("/soluciones/", "");
+    return getService(slug) ? [slug] : [];
+  });
+
+  return [...new Set([
+    ...decisionSlugs,
+    ...landing.stages.flatMap((stage) => stage.serviceSlugs),
+  ])];
+}
+
+function contactHref(landing: GuidedSolutionLanding) {
+  const params = new URLSearchParams({
+    source: `soluciones-${landing.slug}`,
+    contexto: landing.audience,
+  });
+  const audience = contactAudienceBySlug[landing.slug];
+  if (audience) params.set("audience", audience);
+  return `/contacto?${params.toString()}`;
+}
 
 export function AudienceSolutionLanding({ landing }: { landing: GuidedSolutionLanding }) {
   const programs = landing.programSlugs
@@ -19,6 +51,10 @@ export function AudienceSolutionLanding({ landing }: { landing: GuidedSolutionLa
   const modules = landing.moduleIds
     .map((id) => commercialModules.find((commercialModule) => commercialModule.id === id))
     .filter(Boolean);
+  const audienceServices = uniqueServiceSlugs(landing)
+    .map((slug) => getService(slug))
+    .filter(Boolean);
+  const conversationHref = contactHref(landing);
 
   return (
     <div className={`${styles.page} ${refresh.page}`}>
@@ -36,10 +72,10 @@ export function AudienceSolutionLanding({ landing }: { landing: GuidedSolutionLa
               <h1>{landing.title}</h1>
               <p className={styles.lead}>{landing.lead}</p>
               <div className={styles.heroLinks}>
-                <a href="#decisiones">Encontrar punto de entrada →</a>
+                <a href="#servicios">Ver servicios para este contexto →</a>
                 {programs.length > 0 ? <a href="#programas">Ver programas aplicables →</a> : null}
-                <a href="#etapas">Ver ruta por etapas →</a>
-                <Link href="/contacto">Hablar con Greenatics →</Link>
+                <a href="#decisiones">No sé cuál revisar →</a>
+                <Link href={conversationHref}>Hablar con Greenatics →</Link>
               </div>
             </div>
             <aside className={styles.heroProof}>
@@ -50,34 +86,37 @@ export function AudienceSolutionLanding({ landing }: { landing: GuidedSolutionLa
           </div>
         </section>
 
-        <section className={styles.path} aria-label={`Ruta Greenatics para ${landing.audience}`}>
-          <div className={`${styles.container} ${styles.pathGrid} ${refresh.businessPath}`}>
-            {landing.path.map((item, index) => (
-              <div key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>
-            ))}
-          </div>
-        </section>
-
-        <section className={styles.journeys} id="decisiones">
+        <section className={catalogStyles.catalog} id="servicios" aria-labelledby={`${landing.slug}-services-title`}>
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <span className={styles.eyebrow}>Empieza por la situación actual</span>
-              <h2>No necesitas conocer el nombre del servicio.</h2>
-              <p>Ubica primero la decisión que tienes abierta. Cada entrada conduce a un programa o servicio ya gobernado; esta página no crea un catálogo paralelo.</p>
+              <div>
+                <span className={styles.eyebrow}>Oferta para {landing.audience}</span>
+                <h2 id={`${landing.slug}-services-title`}>Servicios que puedes abrir directamente.</h2>
+              </div>
+              <p>Si ya sabes qué necesitas, no tienes que pasar por un orientador. Cada ficha explica alcance, entregables, actividades, límites y evidencia disponible antes de preparar una conversación comercial.</p>
             </div>
-            <div className={styles.journeyGrid}>
-              {landing.decisions.map((decision, index) => (
-                <article className={styles.journeyCard} key={decision.situation}>
-                  <span className={styles.journeyNumber}>{String(index + 1).padStart(2, "0")}</span>
-                  <small>Si estás aquí</small>
-                  <h3>{decision.situation}</h3>
-                  <p>{decision.copy}</p>
-                  <div className={styles.journeyLinks}>
-                    <Link href={decision.href}>{decision.startWith} →</Link>
+            <div className={catalogStyles.catalogGrid}>
+              {audienceServices.map((service) => service ? (
+                <article className={catalogStyles.serviceCard} key={service.slug}>
+                  <div className={catalogStyles.serviceMeta}>
+                    <span>{service.category}</span>
+                    <small>{service.audience}</small>
                   </div>
+                  <h3>{service.name}</h3>
+                  <p>{service.summary}</p>
+                  <div className={catalogStyles.deliverables}>
+                    <span>Entregables típicos</span>
+                    <ul>
+                      {service.deliverables.slice(0, 2).map((deliverable) => <li key={deliverable}>{deliverable}</li>)}
+                    </ul>
+                  </div>
+                  <Link className={catalogStyles.serviceLink} href={`/soluciones/${service.slug}`}>
+                    Ver alcance y entregables <span aria-hidden="true">→</span>
+                  </Link>
                 </article>
-              ))}
+              ) : null)}
             </div>
+            <p className={catalogStyles.catalogNote}>La relación con este contexto facilita la navegación; no presume contratación conjunta ni amplía automáticamente el alcance de ninguna ficha.</p>
           </div>
         </section>
 
@@ -85,9 +124,9 @@ export function AudienceSolutionLanding({ landing }: { landing: GuidedSolutionLa
           <section className={programStyles.programs} id="programas">
             <div className={styles.container}>
               <div className={styles.sectionHead}>
-                <span className={`${styles.eyebrow} ${programStyles.eyebrow}`}>Programas de entrada más relevantes</span>
-                <h2>Programas para ordenar el inicio antes de desplegar servicios.</h2>
-                <p>Los programas empaquetan una primera etapa de trabajo. El alcance contractual y los servicios técnicos relacionados permanecen gobernados por sus fichas específicas.</p>
+                <span className={`${styles.eyebrow} ${programStyles.eyebrow}`}>Programas aplicables</span>
+                <h2>Programas empaquetados para situaciones recurrentes.</h2>
+                <p>Cuando un programa coincide con la necesidad puede funcionar como alcance comercial propio. Los servicios técnicos que lo soportan conservan de todos modos sus fichas, límites y entregables específicos.</p>
               </div>
               <div className={programStyles.programGrid}>
                 {programs.map((program) => program ? (
@@ -104,6 +143,37 @@ export function AudienceSolutionLanding({ landing }: { landing: GuidedSolutionLa
             </div>
           </section>
         ) : null}
+
+        <section className={styles.path} aria-label={`Ruta Greenatics para ${landing.audience}`}>
+          <div className={`${styles.container} ${styles.pathGrid} ${refresh.businessPath}`}>
+            {landing.path.map((item, index) => (
+              <div key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>
+            ))}
+          </div>
+        </section>
+
+        <section className={`${styles.journeys} ${catalogStyles.orientation}`} id="decisiones">
+          <div className={styles.container}>
+            <div className={styles.sectionHead}>
+              <span className={styles.eyebrow}>Si todavía no sabes cuál servicio revisar</span>
+              <h2>Usa la situación actual como orientación.</h2>
+              <p>Esta capa es secundaria: sirve para ubicar una ficha o un programa cuando el nombre de la solución todavía no está claro. No sustituye el servicio ni crea una prescripción automática.</p>
+            </div>
+            <div className={styles.journeyGrid}>
+              {landing.decisions.map((decision, index) => (
+                <article className={styles.journeyCard} key={decision.situation}>
+                  <span className={styles.journeyNumber}>{String(index + 1).padStart(2, "0")}</span>
+                  <small>Si estás aquí</small>
+                  <h3>{decision.situation}</h3>
+                  <p>{decision.copy}</p>
+                  <div className={styles.journeyLinks}>
+                    <Link href={decision.href}>{decision.startWith} →</Link>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
 
         <section className={moduleStyles.modules} id="modulos">
           <div className={styles.container}>
@@ -174,7 +244,7 @@ export function AudienceSolutionLanding({ landing }: { landing: GuidedSolutionLa
             <div>
               <p>{landing.ctaCopy}</p>
               <div className={styles.heroLinks}>
-                <Link href="/contacto">Preparar conversación →</Link>
+                <Link href={conversationHref}>Preparar conversación →</Link>
                 <Link href="/soluciones">Volver al portafolio completo →</Link>
               </div>
             </div>


### PR DESCRIPTION
## Objetivo
Aplicar la jerarquía comercial service-first a las rutas por audiencia e intención: el usuario que ya sabe qué necesita debe poder abrir servicios, entregables y alcance directamente; la orientación por situación queda como capa secundaria cuando persiste incertidumbre.

## Cambios
- Las rutas de ESP, municipios, empresas, propiedad horizontal y plantas abren con un catálogo de servicios gobernados para ese contexto.
- Las rutas de intención (`residuos-organicos`, `infraestructura-plantas`, `propiedad-horizontal-redes`) heredan la misma jerarquía.
- Cada tarjeta muestra categoría, audiencia, resumen, entregables típicos y acceso directo a la ficha profunda del servicio.
- Los programas aplicables aparecen como ofertas comerciales propias antes del orientador, sin absorber los límites de las fichas técnicas relacionadas.
- El antiguo bloque `No necesitas conocer el nombre del servicio` se reposiciona después de la oferta y pasa a `Usa la situación actual como orientación`.
- El hero prioriza `Ver servicios para este contexto`; `No sé cuál revisar` queda secundario.
- Contacto conserva audiencia, origen y contexto desde estas rutas.
- Nueva regresión Playwright verifica orden DOM, servicios directos, entregables y continuidad contextual.

## Truth / commercial locks
- No se inventan servicios, programas, entregables, métricas ni claims.
- La asociación servicio ↔ contexto facilita navegación; no presume paquete, contratación conjunta ni ampliación automática de alcance.
- Diagnóstico, caracterización y rehabilitación conservan sus nombres cuando son servicios o actividades reales; solo se elimina su uso como puerta obligatoria.
- El orientador continúa disponible, pero no sustituye una ficha de servicio ni genera una prescripción automática.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile