### PR TITLE
feat(programs): prioriza salidas y alcance comercial V2.6

### DIFF
--- a/e2e/public-strategic-program-commercial-depth.spec.ts
+++ b/e2e/public-strategic-program-commercial-depth.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from "@playwright/test";
 
-async function expectSectionBefore(page: import("@playwright/test").Page, first: string, secondText: string) {
-  const second = page.getByRole("heading", { name: secondText, exact: true });
-  const firstBeforeSecond = await page.locator(first).evaluate((node, secondElement) => {
-    return Boolean(node.compareDocumentPosition(secondElement as Node) & Node.DOCUMENT_POSITION_FOLLOWING);
-  }, await second.elementHandle());
+async function expectSectionBefore(page: import("@playwright/test").Page, first: string, secondHeading: string) {
+  const firstBeforeSecond = await page.locator(first).evaluate((node, headingText) => {
+    const heading = [...document.querySelectorAll("h1, h2, h3")].find((candidate) => candidate.textContent?.trim() === headingText);
+    if (!heading) return false;
+    return Boolean(node.compareDocumentPosition(heading) & Node.DOCUMENT_POSITION_FOLLOWING);
+  }, secondHeading);
   expect(firstBeforeSecond).toBe(true);
 }
 
@@ -25,12 +26,12 @@ for (const [slug, name, outputs, relatedHref] of programs) {
 
     await expectSectionBefore(page, "#entregables", "El programa organiza una etapa concreta sin convertirla en una ruta obligatoria para todos.");
 
-    const related = page.getByRole("link", { name: /Ver alcance y entregables/ }).filter({ has: page.locator(`[href="${relatedHref}"]`) });
     await expect(page.locator(`a[href="${relatedHref}"]`).filter({ hasText: "Ver alcance y entregables" }).first()).toBeVisible();
 
     const contact = page.getByRole("link", { name: `Hablar sobre ${name}`, exact: true });
-    await expect(contact).toHaveAttribute("href", new RegExp(`service=${encodeURIComponent(name).replace(/%20/g, "(?:%20|\\+)")}`));
     await expect(contact).toHaveAttribute("href", /source=programa/);
+    const href = await contact.getAttribute("href");
+    expect(new URL(href ?? "", "https://greenatics.com.co").searchParams.get("service")).toBe(name);
   });
 }
 

--- a/e2e/public-strategic-program-commercial-depth.spec.ts
+++ b/e2e/public-strategic-program-commercial-depth.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+
+async function expectSectionBefore(page: import("@playwright/test").Page, first: string, secondText: string) {
+  const second = page.getByRole("heading", { name: secondText, exact: true });
+  const firstBeforeSecond = await page.locator(first).evaluate((node, secondElement) => {
+    return Boolean(node.compareDocumentPosition(secondElement as Node) & Node.DOCUMENT_POSITION_FOLLOWING);
+  }, await second.elementHandle());
+  expect(firstBeforeSecond).toBe(true);
+}
+
+const programs = [
+  ["esp-ready", "ESP READY", ["Estado actual", "Brechas", "Prioridades", "Hoja de ruta"], "/soluciones/rutas-selectivas"],
+  ["greenatics-base", "GREENATICS BASE", ["Ficha GREENATICS BASE", "Base consolidada", "Evidencias organizadas", "Insumos para PMIRS y operación"], "/soluciones/pmirs"],
+  ["pmirs-red", "PMIRS RED", ["PMIRS implementables", "Base consolidada", "Indicadores comparables", "Ruta de seguimiento"], "/soluciones/recoleccion-tratamiento"],
+] as const;
+
+for (const [slug, name, outputs, relatedHref] of programs) {
+  test(`${name} exposes governed outputs before method and preserves exact program context`, async ({ page }) => {
+    await page.goto(`/soluciones/programas/${slug}`);
+
+    await expect(page.getByRole("heading", { name, exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Ver qué recibe el cliente", exact: true })).toHaveAttribute("href", "#entregables");
+    await expect(page.getByRole("heading", { name: "Salidas gobernadas del programa." })).toBeVisible();
+    for (const output of outputs) await expect(page.getByText(output, { exact: true })).toBeVisible();
+
+    await expectSectionBefore(page, "#entregables", "El programa organiza una etapa concreta sin convertirla en una ruta obligatoria para todos.");
+
+    const related = page.getByRole("link", { name: /Ver alcance y entregables/ }).filter({ has: page.locator(`[href="${relatedHref}"]`) });
+    await expect(page.locator(`a[href="${relatedHref}"]`).filter({ hasText: "Ver alcance y entregables" }).first()).toBeVisible();
+
+    const contact = page.getByRole("link", { name: `Hablar sobre ${name}`, exact: true });
+    await expect(contact).toHaveAttribute("href", new RegExp(`service=${encodeURIComponent(name).replace(/%20/g, "(?:%20|\\+)")}`));
+    await expect(contact).toHaveAttribute("href", /source=programa/);
+  });
+}
+
+test("program related services remain separate scopes rather than automatic package contents", async ({ page }) => {
+  await page.goto("/soluciones/programas/esp-ready");
+
+  await expect(page.getByRole("heading", { name: "El programa puede conectarse con servicios específicos sin convertirlos en un paquete obligatorio." })).toBeVisible();
+  await expect(page.getByText(/no significa que esté incluido automáticamente dentro del programa/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Ver portafolio de servicios", exact: true })).toHaveAttribute("href", "/soluciones");
+});

--- a/src/app/soluciones/programas/[slug]/page.tsx
+++ b/src/app/soluciones/programas/[slug]/page.tsx
@@ -30,6 +30,8 @@ export default async function StrategicProgramPage({ params }: Props) {
   const program = getStrategicProgram(slug);
   if (!program) notFound();
   const relatedServices = program.relatedServiceSlugs.map((serviceSlug) => getService(serviceSlug)).filter(Boolean);
+  const contactContext = `Interés en el programa ${program.name}. ${program.summary}`;
+  const contactHref = `/contacto?service=${encodeURIComponent(program.name)}&source=programa&contexto=${encodeURIComponent(contactContext)}`;
 
   return (
     <div className={`${styles.page} ${refresh.page}`}>
@@ -48,21 +50,36 @@ export default async function StrategicProgramPage({ params }: Props) {
                 <span className={styles.eyebrow}>{program.audience}</span>
                 <h1>{program.name}</h1>
                 <p className={styles.detailLead}>{program.headline}</p>
+                <div className={styles.actions}>
+                  <a className={`${styles.button} ${styles.primary}`} href="#entregables">Ver qué recibe el cliente</a>
+                  <Link className={styles.button} href={contactHref}>Solicitar conversación comercial</Link>
+                </div>
               </div>
               <aside className={styles.detailAside}>
-                <span>Producto consultivo</span>
-                <strong>{program.slug === "greenatics-base" ? "Empezar ya, pero con método." : "Primero claridad para decidir."}</strong>
+                <span>Programa consultivo</span>
+                <strong>Un alcance propio con salidas definidas y servicios técnicos relacionados.</strong>
                 <p>{program.summary}</p>
               </aside>
             </div>
           </div>
         </section>
 
+        <section className={programStyles.programSection} id="entregables" aria-labelledby="program-outputs-title">
+          <div className={styles.container}>
+            <span className={styles.eyebrow}>Qué recibe el cliente</span>
+            <h2 id="program-outputs-title">Salidas gobernadas del programa.</h2>
+            <div className={programStyles.programOutputs}>
+              {program.outputs.map((item, index) => <div key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>)}
+            </div>
+            <p className={programStyles.programNote}>{program.sourceNote}</p>
+          </div>
+        </section>
+
         <section className={programStyles.detailIntro}>
           <div className={`${styles.container} ${programStyles.detailIntroGrid}`}>
             <div>
-              <span className={styles.eyebrow}>Cómo se usa</span>
-              <h2>Una puerta de entrada que organiza las siguientes decisiones.</h2>
+              <span className={styles.eyebrow}>Qué es y cómo funciona</span>
+              <h2>El programa organiza una etapa concreta sin convertirla en una ruta obligatoria para todos.</h2>
               <p>{program.summary}</p>
             </div>
             <aside className={programStyles.principle}>
@@ -96,21 +113,11 @@ export default async function StrategicProgramPage({ params }: Props) {
 
         <section className={programStyles.programSection}>
           <div className={styles.container}>
-            <span className={styles.eyebrow}>Salida del programa</span>
-            <h2>Resultados que permiten decidir qué activar después.</h2>
-            <div className={programStyles.programOutputs}>
-              {program.outputs.map((item, index) => <div key={item}><span>{String(index + 1).padStart(2, "0")}</span><strong>{item}</strong></div>)}
-            </div>
-            <p className={programStyles.programNote}>{program.sourceNote}</p>
-          </div>
-        </section>
-
-        <section className={programStyles.programSection}>
-          <div className={styles.container}>
-            <span className={styles.eyebrow}>Servicios que pueden activarse después</span>
-            <h2>El programa organiza la decisión; el alcance contractual sigue en las fichas técnicas.</h2>
+            <span className={styles.eyebrow}>Servicios técnicos relacionados</span>
+            <h2>El programa puede conectarse con servicios específicos sin convertirlos en un paquete obligatorio.</h2>
+            <p className={programStyles.programNote}>Cada servicio conserva alcance, actividades, entregables y límites propios. Puede contratarse directamente cuando la necesidad ya está clara; su presencia aquí no significa que esté incluido automáticamente dentro del programa.</p>
             <div className={programStyles.relatedLinks}>
-              {relatedServices.map((service) => service ? <Link href={`/soluciones/${service.slug}`} key={service.slug}><span>{service.name}</span><span>Ver servicio →</span></Link> : null)}
+              {relatedServices.map((service) => service ? <Link href={`/soluciones/${service.slug}`} key={service.slug}><span>{service.name}</span><span>Ver alcance y entregables →</span></Link> : null)}
             </div>
           </div>
         </section>
@@ -118,7 +125,13 @@ export default async function StrategicProgramPage({ params }: Props) {
         <section className={styles.guardrail}>
           <div className={`${styles.container} ${styles.guardrailGrid}`}>
             <div><span className={styles.eyebrow}>Siguiente paso</span><h2>{program.cta}</h2></div>
-            <div><p>La metodología se adapta al estado real del cliente. No presupone que todas las brechas existan ni convierte una capacidad general de Greenatics en obligación contractual automática.</p><Link className={styles.button} href="/contacto">Hablar con Greenatics</Link></div>
+            <div>
+              <p>La metodología se adapta al estado real del cliente. No presupone que todas las brechas existan ni convierte una capacidad general de Greenatics en obligación contractual automática.</p>
+              <div className={styles.actions}>
+                <Link className={`${styles.button} ${styles.primary}`} href={contactHref}>Hablar sobre {program.name}</Link>
+                <Link className={styles.button} href="/soluciones">Ver portafolio de servicios</Link>
+              </div>
+            </div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Objetivo
Profundizar ESP READY, GREENATICS BASE y PMIRS RED como programas consultivos contratables: el usuario debe ver primero qué recibe, después cómo funciona el programa y finalmente qué servicios técnicos relacionados puede revisar o contratar por separado.

## Cambios
- Las tres fichas de programa incorporan CTA de hero `Ver qué recibe el cliente`.
- `Salidas gobernadas del programa` pasa inmediatamente después del hero, antes de metodología y dimensiones.
- La explicación metodológica se reposiciona como `Qué es y cómo funciona`.
- Los servicios relacionados se presentan como alcances separados, no como actividades incluidas automáticamente dentro del programa.
- El contacto conserva el nombre exacto del programa, `source=programa` y el contexto comercial.
- Se mantiene acceso directo al portafolio completo de servicios.
- Nueva regresión Playwright verifica salidas, orden DOM, servicios relacionados y continuidad del programa hacia Contacto.

## Truth / commercial locks
- No se modifican las salidas, dimensiones, exclusiones o servicios gobernados en `strategic-programs.ts`.
- No se promete que todos los servicios relacionados estén incluidos ni que deban contratarse después.
- GREENATICS BASE mantiene separadas línea base técnica, PMIRS, aforo, tarifa, ingeniería y permisos.
- PMIRS RED mantiene su límite de escala: 24 no es mínimo ni promesa universal.
- ESP READY mantiene su naturaleza consultiva y no amplía responsabilidades regulatorias de Greenatics.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile