### PR TITLE
feat(public): hardening de release y publicación V2.7

### DIFF
--- a/.github/workflows/publish-greenatics-web-release-20260825.yml
+++ b/.github/workflows/publish-greenatics-web-release-20260825.yml
@@ -130,44 +130,55 @@ jobs:
           set -u -o pipefail
           base="${APP_BASE_URL%/}"
           failures=0
+          counter=0
 
           check_route() {
             local path="$1"
-            local outfile="/tmp/greenatics-route.html"
+            local marker="$2"
+            counter=$((counter + 1))
+            local outfile="/tmp/greenatics-route-${counter}.body"
             local status
             status="$(curl --silent --show-error --location --retry 3 --retry-delay 2 --max-time 45 -w '%{http_code}' "$base$path" -o "$outfile" || printf '000')"
             local bytes=0
             [ -f "$outfile" ] && bytes="$(wc -c < "$outfile")"
-            echo "$path -> HTTP $status · $bytes bytes"
-            if [ "$status" != "200" ] || [ "$bytes" -lt 500 ]; then
-              echo "::error::$path failed production smoke (HTTP $status, $bytes bytes)."
+            echo "$path -> HTTP $status · $bytes bytes · marker='$marker'"
+
+            if [ "$status" != "200" ]; then
+              echo "::error::$path failed production smoke (HTTP $status)."
               failures=$((failures + 1))
-            else
-              echo "- PASS: $path (HTTP 200, $bytes bytes)" >> "$GITHUB_STEP_SUMMARY"
+              return
             fi
+            if [ "$bytes" -lt 200 ]; then
+              echo "::error::$path returned only $bytes bytes."
+              failures=$((failures + 1))
+              return
+            fi
+            if ! grep -Fq "$marker" "$outfile"; then
+              echo "::error::$path did not contain release marker '$marker'."
+              failures=$((failures + 1))
+              return
+            fi
+
+            echo "- PASS: $path (HTTP 200, $bytes bytes, marker '$marker')" >> "$GITHUB_STEP_SUMMARY"
           }
 
           echo "### Public production smoke" >> "$GITHUB_STEP_SUMMARY"
-          for path in \
-            / \
-            /soluciones \
-            /soluciones/rehabilitacion \
-            /wondergreen \
-            /wondergreen/productos \
-            /wondergreen/lineas \
-            /wondergreen/lineas/2grow \
-            /wondergreen/tecnologia \
-            /wondergreen/cultivos \
-            /casa-jardin \
-            /proyectos \
-            /biblioteca \
-            /nosotros \
-            /contacto \
-            /sitemap.xml \
-            /robots.txt
-          do
-            check_route "$path"
-          done
+          check_route "/" "Transformamos residuos en vida."
+          check_route "/soluciones" "Servicios para convertir necesidades de gestión en resultados concretos."
+          check_route "/soluciones/rehabilitacion" "Diagnóstico, rehabilitación y puesta en marcha de infraestructura existente"
+          check_route "/wondergreen" "Nutrición que trabaja con el suelo."
+          check_route "/wondergreen/productos" "Productos concretos, formulación por formulación."
+          check_route "/wondergreen/lineas" "Una identidad por línea. Una ficha exacta por referencia."
+          check_route "/wondergreen/lineas/2grow" "2Grow"
+          check_route "/wondergreen/tecnologia" "Organomineral. Oclusión. Lenta liberación."
+          check_route "/wondergreen/cultivos" "El cultivo cambia la pregunta."
+          check_route "/casa-jardin" "Nutrición por etapas para tus plantas."
+          check_route "/proyectos" "Proyectos"
+          check_route "/biblioteca" "Biblioteca"
+          check_route "/nosotros" "Diseñamos sistemas que tienen que funcionar en la vida real"
+          check_route "/contacto" "Cuéntanos qué quieres resolver."
+          check_route "/sitemap.xml" "https://greenatics.com.co/wondergreen"
+          check_route "/robots.txt" "Disallow: /app"
 
           if [ "$failures" -ne 0 ]; then
             echo "::error::Production public smoke failed on $failures route(s)."
@@ -183,7 +194,7 @@ jobs:
           echo "Stable public/OPS origin: $OPS_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
           echo "Unique deployment: $UNIQUE_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
           echo "Published develop commit: $DEPLOY_GIT_SHA" >> "$GITHUB_STEP_SUMMARY"
-          echo "Quality, backend, preview, production provenance and public route smoke: PASS." >> "$GITHUB_STEP_SUMMARY"
+          echo "Quality, backend, preview, production provenance and semantic public route smoke: PASS." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Mark release success
         if: ${{ success() }}

--- a/.github/workflows/publish-greenatics-web-release-20260825.yml
+++ b/.github/workflows/publish-greenatics-web-release-20260825.yml
@@ -1,0 +1,218 @@
+name: publish-greenatics-web-release-20260825
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - .github/workflows/publish-greenatics-web-release-20260825.yml
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: greenatics-hosted-pilot-production
+  cancel-in-progress: false
+
+jobs:
+  publish-and-certify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      PILOT_PREVIEW_MODE: full-ops
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      DEPLOY_GIT_REF: develop
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+      SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+
+    steps:
+      - name: Checkout canonical develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Resolve exact release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          test "${#sha}" -eq 40
+          echo "DEPLOY_GIT_SHA=$sha" >> "$GITHUB_ENV"
+          echo "GREENATICS web release from develop@${sha:0:12}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark release pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$DEPLOY_GIT_SHA" \
+            -d "{\"state\":\"pending\",\"context\":\"greenatics/web-release\",\"description\":\"Publicando develop en greenatics-ops\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null
+
+      - name: Require deployment secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            VERCEL_TOKEN \
+            VERCEL_ORG_ID \
+            NEXT_PUBLIC_SUPABASE_URL \
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
+            SUPABASE_SECRET_KEY
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is not configured for GREENATICS production release."
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Canonical quality gate
+        run: |
+          npm run typecheck
+          npm run lint
+          npm test
+          npm run build
+
+      - name: Certify hosted backend
+        run: npm run pilot:backend-preflight -- --plants TAM,YAR
+
+      - name: Deploy full OPS preview
+        id: preview
+        run: npm run pilot:vercel-preview
+
+      - name: Certify protected preview
+        env:
+          DEPLOYMENT_URL: ${{ steps.preview.outputs.deployment_url }}
+          VERCEL_PROJECT_ID: ${{ steps.preview.outputs.project_id }}
+        run: npm run pilot:vercel-preflight
+
+      - name: Deploy stable full OPS production
+        id: production
+        run: node scripts/vercel-ops-production-deploy.mjs
+
+      - name: Certify stable OPS origin and provenance
+        env:
+          APP_BASE_URL: ${{ steps.production.outputs.deployment_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run pilot:preflight -- \
+            --base-url "$APP_BASE_URL" \
+            --mode full-ops \
+            --expected-branch "$DEPLOY_GIT_REF" \
+            --expected-commit "$DEPLOY_GIT_SHA"
+
+      - name: Certify critical public routes in production
+        env:
+          APP_BASE_URL: ${{ steps.production.outputs.deployment_url }}
+        shell: bash
+        run: |
+          set -u -o pipefail
+          base="${APP_BASE_URL%/}"
+          failures=0
+
+          check_route() {
+            local path="$1"
+            local outfile="/tmp/greenatics-route.html"
+            local status
+            status="$(curl --silent --show-error --location --retry 3 --retry-delay 2 --max-time 45 -w '%{http_code}' "$base$path" -o "$outfile" || printf '000')"
+            local bytes=0
+            [ -f "$outfile" ] && bytes="$(wc -c < "$outfile")"
+            echo "$path -> HTTP $status · $bytes bytes"
+            if [ "$status" != "200" ] || [ "$bytes" -lt 500 ]; then
+              echo "::error::$path failed production smoke (HTTP $status, $bytes bytes)."
+              failures=$((failures + 1))
+            else
+              echo "- PASS: $path (HTTP 200, $bytes bytes)" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+
+          echo "### Public production smoke" >> "$GITHUB_STEP_SUMMARY"
+          for path in \
+            / \
+            /soluciones \
+            /soluciones/rehabilitacion \
+            /wondergreen \
+            /wondergreen/productos \
+            /wondergreen/lineas \
+            /wondergreen/lineas/2grow \
+            /wondergreen/tecnologia \
+            /wondergreen/cultivos \
+            /casa-jardin \
+            /proyectos \
+            /biblioteca \
+            /nosotros \
+            /contacto \
+            /sitemap.xml \
+            /robots.txt
+          do
+            check_route "$path"
+          done
+
+          if [ "$failures" -ne 0 ]; then
+            echo "::error::Production public smoke failed on $failures route(s)."
+            exit 1
+          fi
+
+      - name: Release summary
+        env:
+          OPS_ORIGIN: ${{ steps.production.outputs.deployment_url }}
+          UNIQUE_ORIGIN: ${{ steps.production.outputs.unique_deployment_url }}
+        shell: bash
+        run: |
+          echo "Stable public/OPS origin: $OPS_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
+          echo "Unique deployment: $UNIQUE_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published develop commit: $DEPLOY_GIT_SHA" >> "$GITHUB_STEP_SUMMARY"
+          echo "Quality, backend, preview, production provenance and public route smoke: PASS." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark release success
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$DEPLOY_GIT_SHA" \
+            -d "{\"state\":\"success\",\"context\":\"greenatics/web-release\",\"description\":\"greenatics-ops publicado y certificado\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null
+
+      - name: Mark release failure
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$DEPLOY_GIT_SHA" \
+            -d "{\"state\":\"failure\",\"context\":\"greenatics/web-release\",\"description\":\"falló la certificación/publicación web\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null

--- a/docs/releases/PUBLIC_WEB_RELEASE_2026-08-25.md
+++ b/docs/releases/PUBLIC_WEB_RELEASE_2026-08-25.md
@@ -1,0 +1,38 @@
+# GREENATICS Public Web Release · 2026-08-25
+
+## Objetivo
+Cerrar el ciclo de profundización comercial de la web pública y publicar el `develop` certificado en el origen estable de GREENATICS OPS/Vercel.
+
+## Alcance de este release
+- Conserva la arquitectura pública y los Truth Locks ya aprobados.
+- Traduce estados internos de Wondergreen a lenguaje público sin cambiar `truthStatus` ni Product Truth.
+- Mantiene la separación línea → referencia → formulación → presentación → documentación.
+- Preserva el producto o servicio exacto al pasar a Contacto.
+- Oculta metadata técnica de navegación que no aporta valor al visitante.
+- Añade un gate E2E de rutas públicas críticas, conversión, sitemap y frontera OPS.
+- Añade un workflow de publicación que certifica preview, producción, provenance y smoke HTTP.
+
+## No cambia
+- H1 de HOME: `Transformamos residuos en vida.`
+- Estados técnicos/regulatorios internos.
+- Formulaciones, presentaciones, dosis, claims, precios o disponibilidad no documentados.
+- Casa & Jardín continúa en pre-lanzamiento y `noindex,follow`.
+- Canonical público continúa apuntando a `https://greenatics.com.co`.
+- `main` no participa en este release: la fuente canónica es `develop`.
+
+## Gate antes de merge
+- `quality`
+- `database`
+- Playwright desktop
+- Playwright mobile
+
+## Gate después de merge
+El workflow `publish-greenatics-web-release-20260825`:
+1. toma el SHA exacto de `develop`;
+2. repite typecheck, lint, unit y build;
+3. certifica backend hospedado;
+4. despliega y certifica Preview full-ops;
+5. publica producción estable;
+6. certifica branch/SHA con `pilot:preflight`;
+7. prueba rutas públicas críticas, sitemap y robots;
+8. marca `greenatics/web-release` en el commit publicado.

--- a/e2e/public-commercial-continuity.spec.ts
+++ b/e2e/public-commercial-continuity.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test("legal solution keeps exact service context into Contact", async ({ page }) => {
+test("legal solution keeps exact service context into Contact without exposing source metadata", async ({ page }) => {
   await page.goto("/soluciones/gestion-juridica-regulatoria");
 
   const contact = page.getByRole("link", { name: "Plantear el caso", exact: true });
@@ -8,12 +8,12 @@ test("legal solution keeps exact service context into Contact", async ({ page })
   await contact.click();
 
   const inherited = page.getByLabel("Contexto heredado de navegación");
-  await expect(inherited.locator("span").filter({ hasText: "Origen:" })).toContainText("solucion");
   await expect(inherited.locator("span").filter({ hasText: "Servicio:" })).toContainText("Gestión jurídica y regulatoria para residuos, aseo y proyectos");
   await expect(page.getByLabel("Servicio recibido de la navegación")).toContainText("Gestión jurídica y regulatoria para residuos, aseo y proyectos");
+  await expect(page.getByText(/Origen:/)).toHaveCount(0);
 });
 
-test("valorization solution keeps exact service context into Contact", async ({ page }) => {
+test("valorization solution keeps exact service context into Contact without exposing source metadata", async ({ page }) => {
   await page.goto("/soluciones/valorizacion-productos");
 
   const contact = page.getByRole("link", { name: "Evaluar un producto", exact: true });
@@ -21,9 +21,9 @@ test("valorization solution keeps exact service context into Contact", async ({ 
   await contact.click();
 
   const inherited = page.getByLabel("Contexto heredado de navegación");
-  await expect(inherited.locator("span").filter({ hasText: "Origen:" })).toContainText("solucion");
   await expect(inherited.locator("span").filter({ hasText: "Servicio:" })).toContainText("Valorización y desarrollo de productos");
   await expect(page.getByLabel("Servicio recibido de la navegación")).toContainText("Valorización y desarrollo de productos");
+  await expect(page.getByText(/Origen:/)).toHaveCount(0);
 });
 
 test("public company and contact surfaces no longer make technical diagnosis the primary next step", async ({ page }) => {

--- a/e2e/public-company-contact.spec.ts
+++ b/e2e/public-company-contact.spec.ts
@@ -23,18 +23,18 @@ test("contact page starts with context without forcing diagnosis or a service na
   await expect(page.getByLabel("¿Qué necesitas resolver primero?")).toBeVisible();
   await expect(page.getByText(/Este paso no envía información a Greenatics/i)).toBeVisible();
   await expect(page.getByRole("link", { name: /Preparar conversación/i }).first()).toHaveAttribute("href", /\/contacto\?audience=/);
-  await expect(page.getByRole("heading", { name: "El servicio primero. La orientación solo cuando todavía hace falta." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Si ya sabes qué necesitas, podemos empezar por ahí." })).toBeVisible();
   await expect(page.getByRole("link", { name: "Explorar servicios", exact: true })).toHaveAttribute("href", "/soluciones");
   await expect(page.getByRole("link", { name: "Usar orientador inicial", exact: true })).toHaveAttribute("href", "/soluciones/diagnostico-inicial");
   await expect(page.getByRole("link", { name: "Empezar por diagnóstico", exact: true })).toHaveCount(0);
 });
 
-test("contact page inherits audience and need context without inventing a recommendation", async ({ page }) => {
+test("contact page inherits audience and need context without exposing internal source metadata", async ({ page }) => {
   await page.goto("/contacto?audience=planta&need=planta&source=soluciones");
 
   await expect(page.getByRole("heading", { name: /Cuéntanos sobre la planta que quieres recuperar o mejorar/i })).toBeVisible();
-  const inherited = page.getByLabel("Contexto heredado de navegación");
-  await expect(inherited.locator("span").filter({ hasText: "Origen:" })).toContainText("soluciones");
+  await expect(page.getByLabel("Contexto heredado de navegación")).toHaveCount(0);
+  await expect(page.getByText(/Origen:/)).toHaveCount(0);
   await expect(page.getByLabel("¿Desde qué contexto nos escribes?")).toHaveValue("planta");
   await expect(page.getByLabel("¿Qué necesitas resolver primero?")).toHaveValue("planta");
 
@@ -54,6 +54,7 @@ test("contact page preserves an exact service from a commercial solution route",
 
   const inherited = page.getByLabel("Contexto heredado de navegación");
   await expect(inherited.locator("span").filter({ hasText: "Servicio:" })).toContainText(service);
+  await expect(page.getByText(/Origen:/)).toHaveCount(0);
   await expect(page.getByLabel("Servicio recibido de la navegación")).toContainText(service);
 
   await page.getByLabel("¿Desde qué contexto nos escribes?").selectOption("planta");
@@ -72,6 +73,7 @@ test("contact page preserves an exact Wondergreen product context", async ({ pag
   await expect(page.getByRole("heading", { name: /2Grow Sólido/i })).toBeVisible();
   const inherited = page.getByLabel("Contexto heredado de navegación");
   await expect(inherited.locator("span").filter({ hasText: "Producto:" })).toContainText("2Grow Sólido");
+  await expect(page.getByText("Estado comercial confirmado").first()).toBeVisible();
   await expect(page.getByRole("link", { name: /Volver a la ficha/i })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
 });
 

--- a/e2e/public-release-gate.spec.ts
+++ b/e2e/public-release-gate.spec.ts
@@ -35,7 +35,7 @@ test("release gate: known service reaches contact with the exact commercial cont
 
   const inherited = page.getByLabel("Contexto heredado de navegación");
   await expect(inherited.getByText(/Servicio:/)).toBeVisible();
-  await expect(inherited).toContainText("Rehabilitación");
+  await expect(inherited).toContainText(/Diagnóstico, rehabilitación y puesta en marcha de infraestructura existente/i);
   await expect(page.getByText(/Origen:/)).toHaveCount(0);
   await expect(page.getByRole("link", { name: "Agendar reunión", exact: true }).first()).toHaveAttribute("href", /^https:\/\/outlook\.office\.com\//);
 });

--- a/e2e/public-release-gate.spec.ts
+++ b/e2e/public-release-gate.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+
+const criticalRoutes = [
+  ["/", "Transformamos residuos en vida."],
+  ["/soluciones", "Servicios para convertir necesidades de gestión en resultados concretos."],
+  ["/wondergreen", "Nutrición que trabaja con el suelo."],
+  ["/wondergreen/productos", "Productos concretos, formulación por formulación."],
+  ["/wondergreen/lineas", "Una identidad por línea. Una ficha exacta por referencia."],
+  ["/wondergreen/tecnologia", "Organomineral. Oclusión. Lenta liberación."],
+  ["/wondergreen/cultivos", "El cultivo cambia la pregunta."],
+  ["/casa-jardin", "Nutrición por etapas para tus plantas."],
+  ["/proyectos", "Proyectos"],
+  ["/biblioteca", "Biblioteca"],
+  ["/nosotros", "Diseñamos sistemas que tienen que funcionar en la vida real"],
+  ["/contacto", "Cuéntanos qué quieres resolver."],
+] as const;
+
+test("release gate: critical public routes render useful HTML without server errors", async ({ request }) => {
+  for (const [path, marker] of criticalRoutes) {
+    const response = await request.get(path);
+    expect(response.status(), `${path} should return HTTP 200`).toBe(200);
+    const html = await response.text();
+    expect(html.length, `${path} should return substantial HTML`).toBeGreaterThan(1000);
+    expect(html, `${path} should contain its release marker`).toContain(marker);
+    expect(html, `${path} should not expose a server error`).not.toMatch(/Internal Server Error|Application error|This page could not be found/i);
+  }
+});
+
+test("release gate: known service reaches contact with the exact commercial context", async ({ page }) => {
+  await page.goto("/soluciones/rehabilitacion");
+  const consult = page.getByRole("link", { name: "Solicitar conversación comercial" });
+  await expect(consult).toHaveAttribute("href", /service=/);
+  await expect(consult).toHaveAttribute("href", /source=solucion/);
+  await consult.click();
+
+  const inherited = page.getByLabel("Contexto heredado de navegación");
+  await expect(inherited.getByText(/Servicio:/)).toBeVisible();
+  await expect(inherited).toContainText("Rehabilitación");
+  await expect(page.getByText(/Origen:/)).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Agendar reunión", exact: true }).first()).toHaveAttribute("href", /^https:\/\/outlook\.office\.com\//);
+});
+
+test("release gate: Wondergreen line reaches an exact reference and preserves line context into contact", async ({ page }) => {
+  await page.goto("/wondergreen/lineas/2grow");
+  await expect(page.getByText("Estado comercial confirmado").first()).toBeVisible();
+  await page.getByRole("link", { name: /2Grow Sólido/ }).click();
+  await expect(page).toHaveURL(/\/wondergreen\/productos\/2grow-solido-15-3-3$/);
+  await expect(page.getByText("Estado comercial confirmado").first()).toBeVisible();
+
+  await page.goto("/wondergreen/lineas/2grow");
+  await page.getByRole("link", { name: "Consultar línea" }).click();
+  await expect(page).toHaveURL(/\/contacto\?.*source=wondergreen-linea/);
+  await expect(page.getByRole("heading", { name: /Cuéntanos sobre tu cultivo o tu interés en Wondergreen/i })).toBeVisible();
+  await expect(page.getByLabel("Contexto heredado de navegación")).toContainText("Interés en la línea Wondergreen 2Grow");
+});
+
+test("release gate: sitemap and robots remain aligned with public versus OPS boundaries", async ({ request }) => {
+  const sitemap = await request.get("/sitemap.xml");
+  expect(sitemap.ok()).toBe(true);
+  const sitemapText = await sitemap.text();
+  for (const path of ["/soluciones", "/wondergreen", "/wondergreen/productos", "/wondergreen/lineas", "/wondergreen/tecnologia", "/proyectos", "/biblioteca", "/contacto"]) {
+    expect(sitemapText).toContain(`https://greenatics.com.co${path}`);
+  }
+  expect(sitemapText).not.toContain("https://greenatics.com.co/app");
+  expect(sitemapText).not.toContain("https://greenatics.com.co/login");
+
+  const robots = await request.get("/robots.txt");
+  expect(robots.ok()).toBe(true);
+  const robotsText = await robots.text();
+  expect(robotsText).toContain("Disallow: /app");
+  expect(robotsText).toContain("Sitemap: https://greenatics.com.co/sitemap.xml");
+});

--- a/e2e/service-commercial-depth.spec.ts
+++ b/e2e/service-commercial-depth.spec.ts
@@ -44,7 +44,7 @@ test("services without a directly governed case do not fabricate an evidence blo
   await expect(main.getByRole("heading", { name: "Támesis", exact: true })).toHaveCount(0);
 });
 
-test("service contact keeps the exact commercial context instead of restarting at diagnosis", async ({ page }) => {
+test("service contact keeps the exact commercial context without exposing internal source metadata", async ({ page }) => {
   await page.goto("/soluciones/trazabilidad-datos");
 
   const contact = page.getByRole("link", { name: "Solicitar conversación comercial", exact: true });
@@ -58,7 +58,7 @@ test("service contact keeps the exact commercial context instead of restarting a
 
   await contact.click();
   const inherited = page.getByLabel("Contexto heredado de navegación");
-  await expect(inherited).toContainText("Origen: solucion");
   await expect(inherited).toContainText("Servicio: Trazabilidad digital, indicadores y GREENATICS OPS");
   await expect(inherited).toContainText("Interés en Trazabilidad digital");
+  await expect(page.getByText(/Origen:/)).toHaveCount(0);
 });

--- a/e2e/wondergreen-lines.spec.ts
+++ b/e2e/wondergreen-lines.spec.ts
@@ -23,13 +23,13 @@ test("Wondergreen exposes visual line families before requiring an exact formula
   await expect(page.getByText(/no trasladamos automáticamente una formulación, tecnología/i)).toBeVisible();
 });
 
-test("2Grow line separates family identity from exact solid and liquid Product Truth", async ({ page }) => {
+test("2Grow line separates family identity from exact solid and liquid product truth", async ({ page }) => {
   await page.goto("/wondergreen/lineas/2grow");
 
   await expect(page.getByRole("heading", { name: "2Grow", exact: true })).toBeVisible();
   await expect(page.getByRole("img", { name: "Identidad visual aprobada de la línea Wondergreen 2Grow" })).toBeVisible();
   await expect(page.getByText("3 referencias documentadas", { exact: true })).toBeVisible();
-  await expect(page.getByText("2 comerciales reconciliadas", { exact: true })).toBeVisible();
+  await expect(page.getByText("2 con estado comercial confirmado", { exact: true })).toBeVisible();
 
   await expect(page.getByRole("link", { name: /2Grow Sólido/ })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
   const liquid100 = page.getByRole("link").filter({ hasText: "2Grow Líquido" }).filter({ hasText: "100-20-20" });
@@ -47,13 +47,18 @@ test("2Grow line separates family identity from exact solid and liquid Product T
 
   await expect(page.getByRole("link", { name: "Profundizar en tecnología" })).toHaveAttribute("href", "/wondergreen/tecnologia");
   await expect(page.getByText(/no significa compartir automáticamente una característica tecnológica/i)).toBeVisible();
+
+  const consult = page.getByRole("link", { name: "Consultar línea" });
+  await expect(consult).toHaveAttribute("href", /audience=wondergreen/);
+  await expect(consult).toHaveAttribute("href", /source=wondergreen-linea/);
+  await expect(consult).toHaveAttribute("href", /contexto=/);
 });
 
 test("product catalog exposes line exploration while keeping exact products primary", async ({ page }) => {
   await page.goto("/wondergreen/productos");
   await expect(page.getByRole("link", { name: "Explorar líneas de producto →" })).toHaveAttribute("href", "/wondergreen/lineas");
   await expect(page.getByRole("link", { name: "Líneas Wondergreen" })).toHaveAttribute("href", "/wondergreen/lineas");
-  await expect(page.getByRole("heading", { name: "Empieza por los productos comercialmente reconciliados." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Empieza por las referencias con estado comercial confirmado." })).toBeVisible();
 });
 
 test("line routes have canonical metadata and are included in sitemap", async ({ page, request }) => {

--- a/e2e/wondergreen-product-depth.spec.ts
+++ b/e2e/wondergreen-product-depth.spec.ts
@@ -35,5 +35,5 @@ test("Wondergreen product page exposes presentations plus open and download PDF 
   await expect(main.getByRole("link", { name: /Descargar catálogo PDF/ })).toHaveAttribute("href", "/api/public-resources/wondergreen-product-master?download=1");
   await expect(main.getByRole("link", { name: /Descargar guía PDF/ }).first()).toHaveAttribute("href", /\?download=1$/);
   await expect(main.getByRole("heading", { name: "Ficha técnica específica" })).toBeVisible();
-  await expect(main.getByText("Pendiente de vincular master público", { exact: true })).toBeVisible();
+  await expect(main.getByText("Pendiente de vincular documento público", { exact: true })).toBeVisible();
 });

--- a/e2e/wondergreen-product-depth.spec.ts
+++ b/e2e/wondergreen-product-depth.spec.ts
@@ -4,7 +4,7 @@ test("Wondergreen catalog starts with commercial products and keeps orientation 
   await page.goto("/wondergreen/productos");
 
   await expect(page.getByRole("heading", { name: "Productos concretos, formulación por formulación." })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Comerciales reconciliadas" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByRole("button", { name: "Estado comercial confirmado" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByRole("link", { name: /Encontrar mi programa/ })).toHaveAttribute("href", "/wondergreen/finder");
 
   const growCard = page.getByRole("link", { name: /2Grow Sólido/ }).first();

--- a/e2e/wondergreen-products.spec.ts
+++ b/e2e/wondergreen-products.spec.ts
@@ -4,7 +4,7 @@ test("Wondergreen product catalog exposes governed references with commercial pr
   await page.goto("/wondergreen/productos");
 
   await expect(page.getByRole("heading", { name: "Productos concretos, formulación por formulación." })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Comerciales reconciliadas" })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByRole("button", { name: "Estado comercial confirmado" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByText("8 referencias", { exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: /2Grow Sólido/ }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: /Extracto de Neem/ })).toHaveCount(0);
@@ -30,8 +30,8 @@ test("catalog browser filters by search, commercial truth and format without cha
   await expect(page.getByRole("link", { name: /Extracto de Neem/ }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: /2Grow Sólido/ })).toHaveCount(0);
 
-  await page.getByRole("button", { name: "Volver a comerciales" }).click();
-  await expect(page.getByRole("button", { name: "Comerciales reconciliadas" })).toHaveAttribute("aria-pressed", "true");
+  await page.getByRole("button", { name: "Volver a referencias confirmadas" }).click();
+  await expect(page.getByRole("button", { name: "Estado comercial confirmado" })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByRole("link", { name: /2Grow Sólido/ }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: /Extracto de Neem/ })).toHaveCount(0);
 

--- a/e2e/wondergreen-products.spec.ts
+++ b/e2e/wondergreen-products.spec.ts
@@ -40,13 +40,13 @@ test("catalog browser filters by search, commercial truth and format without cha
   await expect(page.getByRole("link", { name: /2Grow Sólido/ })).toHaveCount(0);
 });
 
-test("commercial product page shows reconciled state and approved line artwork without inventing a packshot", async ({ page }) => {
+test("commercial product page shows public commercial state and approved line artwork without inventing a packshot", async ({ page }) => {
   await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
 
   await expect(page.locator('div[data-tone="grow"]').first()).toBeVisible();
   await expect(page.getByRole("heading", { name: /2Grow Sólido/ })).toBeVisible();
-  await expect(page.getByText("Referencia comercial reconciliada").first()).toBeVisible();
-  await expect(page.getByText("Reconciliada", { exact: true })).toBeVisible();
+  await expect(page.getByText("Estado comercial confirmado").first()).toBeVisible();
+  await expect(page.getByText("Confirmada", { exact: true })).toBeVisible();
   await expect(page.getByRole("img", { name: "Identidad visual aprobada de la línea Wondergreen 2Grow" })).toBeVisible();
   await expect(page.getByText(/No se presenta como packshot específico/)).toBeVisible();
   await expect(page.getByRole("link", { name: "Manual de uso Wondergreen" })).toHaveAttribute("href", "/biblioteca/manual-uso-wondergreen");
@@ -56,12 +56,13 @@ test("product consultation preserves the exact governed reference into contact",
   await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
 
   const consult = page.getByRole("link", { name: "Consultar esta referencia" });
-  await expect(consult).toHaveAttribute("href", "/contacto?producto=2grow-solido-15-3-3#wondergreen");
+  await expect(consult).toHaveAttribute("href", "/contacto?producto=2grow-solido-15-3-3&source=wondergreen-producto");
   await consult.click();
 
   await expect(page.getByRole("heading", { name: "Cuéntanos el contexto de 2Grow Sólido." })).toBeVisible();
   await expect(page.getByRole("heading", { name: "2Grow Sólido · 15-3-3" })).toBeVisible();
-  await expect(page.getByText("Referencia comercial reconciliada").first()).toBeVisible();
+  await expect(page.getByText("Estado comercial confirmado").first()).toBeVisible();
+  await expect(page.getByText(/Origen:/)).toHaveCount(0);
   await expect(page.getByRole("link", { name: /Volver a la ficha/ })).toHaveAttribute("href", "/wondergreen/productos/2grow-solido-15-3-3");
   await expect(page.getByRole("link", { name: "Agendar reunión", exact: true }).first()).toHaveAttribute("href", /^https:\/\/outlook\.office\.com\//);
 });
@@ -78,7 +79,7 @@ test("technical bioinput page does not pretend to be commercially available", as
 
   await expect(page.locator('div[data-tone="botanical"]').first()).toBeVisible();
   await expect(page.getByRole("heading", { name: /Extracto de Neem/ })).toBeVisible();
-  await expect(page.getByText(/Portafolio técnico · ficha\/registro por reconciliar/).first()).toBeVisible();
+  await expect(page.getByText("Portafolio técnico · condición comercial por confirmar").first()).toBeVisible();
   await expect(page.getByText("Requiere confirmación", { exact: true })).toBeVisible();
   await expect(page.getByText("Consultar", { exact: true })).toBeVisible();
 });

--- a/src/app/contacto/page.tsx
+++ b/src/app/contacto/page.tsx
@@ -89,12 +89,18 @@ function normalizeInheritedContext(value: string | undefined) {
   return value?.trim().slice(0, 480) || undefined;
 }
 
+function publicProductStatus(status: string) {
+  if (status === "commercial-reconciled") return "Estado comercial confirmado";
+  if (status === "technical-portfolio") return "Portafolio técnico · condición comercial por confirmar";
+  if (status === "development") return "En desarrollo · no disponible comercialmente";
+  return "Estado por confirmar";
+}
+
 export default async function ContactPage({ searchParams }: { searchParams: Promise<ContactSearchParams> }) {
   const query = await searchParams;
   const audience = normalizeAudience(firstParam(query.audience));
   const need = firstParam(query.need) ?? "";
   const service = firstParam(query.service)?.trim().slice(0, 180) || undefined;
-  const source = firstParam(query.source);
   const crop = firstParam(query.cultivo);
   const inheritedContext = normalizeInheritedContext(firstParam(query.contexto));
   const productSlug = firstParam(query.producto);
@@ -115,9 +121,8 @@ export default async function ContactPage({ searchParams }: { searchParams: Prom
               <span className={styles.eyebrow}>Contacto Greenatics · conversación con contexto</span>
               <h1>{title}</h1>
               <p className={styles.lead}>{lead}</p>
-              {(source || service || product || crop || inheritedContext) ? (
+              {(service || product || crop || inheritedContext) ? (
                 <div className={styles.contextLine} aria-label="Contexto heredado de navegación">
-                  {source ? <span><strong>Origen:</strong> {source}</span> : null}
                   {service ? <span><strong>Servicio:</strong> {service}</span> : null}
                   {product ? <span><strong>Producto:</strong> {product.name}{product.formula ? ` ${product.formula}` : ""}</span> : null}
                   {crop ? <span><strong>Cultivo:</strong> {crop}</span> : null}
@@ -138,7 +143,7 @@ export default async function ContactPage({ searchParams }: { searchParams: Prom
           <section className={`${styles.section} ${styles.soft}`} aria-label="Contexto de la consulta Wondergreen">
             <div className={`${styles.container} ${styles.productContext}`}>
               <div><span className={styles.eyebrow}>Referencia identificada</span><h2>{product.name}{product.formula ? ` · ${product.formula}` : ""}</h2><p>Conservamos la referencia para no reiniciar la conversación desde cero. Disponibilidad, versión, dosis y recomendación final siguen dependiendo del contexto real del cultivo o del canal comercial.</p></div>
-              <div className={styles.productMeta}><strong>{product.publicStatus}</strong><span>{product.stage}</span><Link href={`/wondergreen/productos/${product.slug}`}>Volver a la ficha →</Link></div>
+              <div className={styles.productMeta}><strong>{publicProductStatus(product.truthStatus)}</strong><span>{product.stage}</span><Link href={`/wondergreen/productos/${product.slug}`}>Volver a la ficha →</Link></div>
             </div>
           </section>
         ) : null}
@@ -196,8 +201,8 @@ export default async function ContactPage({ searchParams }: { searchParams: Prom
 
         <section className={styles.closing}>
           <div className={`${styles.container} ${styles.closingGrid}`}>
-            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>El servicio primero. La orientación solo cuando todavía hace falta.</h2></div>
-            <div><p>Si ya reconoces lo que necesitas, vuelve al catálogo y abre directamente el servicio, producto o solución correspondiente. Si todavía existe incertidumbre, el orientador inicial puede ayudarte a ubicar una ruta sin sustituir una evaluación técnica ni convertirla en una prescripción.</p><div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/soluciones">Explorar servicios</Link><Link className={`${styles.button} ${styles.ghost}`} href="/soluciones/diagnostico-inicial">Usar orientador inicial</Link></div></div>
+            <div><span className={styles.eyebrow}>Siguiente paso</span><h2>Si ya sabes qué necesitas, podemos empezar por ahí.</h2></div>
+            <div><p>Explora directamente el servicio, producto o solución que te interesa. Si todavía necesitas ubicar la ruta adecuada, el orientador inicial puede ayudarte a ordenar la situación antes de conversar con el equipo.</p><div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href="/soluciones">Explorar servicios</Link><Link className={`${styles.button} ${styles.ghost}`} href="/soluciones/diagnostico-inicial">Usar orientador inicial</Link></div></div>
           </div>
         </section>
       </main>

--- a/src/app/wondergreen/lineas/[slug]/page.tsx
+++ b/src/app/wondergreen/lineas/[slug]/page.tsx
@@ -46,6 +46,7 @@ export default async function WondergreenLinePage({ params }: Props) {
   const guides = uniqueGuides(line);
   const catalog = references[0] ? getWondergreenProductDocuments(references[0]).catalog : null;
   const commercialCount = references.filter((reference) => reference.truthStatus === "commercial-reconciled").length;
+  const lineContactContext = `Interés en la línea Wondergreen ${line.family}. Quiero revisar referencias, presentaciones y disponibilidad aplicables a mi caso.`;
 
   return (
     <div className={styles.page}>
@@ -65,11 +66,11 @@ export default async function WondergreenLinePage({ params }: Props) {
               <p className={styles.lead}>{line.headline} {line.description}</p>
               <div className={styles.lineMeta}>
                 <span>{references.length} referencias documentadas</span>
-                <span>{commercialCount} comerciales reconciliadas</span>
+                <span>{commercialCount} con estado comercial confirmado</span>
               </div>
               <div className={styles.actions}>
                 <a className={`${styles.button} ${styles.primary}`} href="#referencias">Ver referencias</a>
-                <Link className={styles.button} href="/wondergreen/productos">Ver Product Master</Link>
+                <Link className={styles.button} href="/wondergreen/productos">Ver catálogo completo</Link>
               </div>
             </div>
             {artwork ? (
@@ -84,14 +85,14 @@ export default async function WondergreenLinePage({ params }: Props) {
         <section className={`${styles.section} ${styles.white}`}>
           <div className={styles.container}>
             <div className={styles.sectionHead}>
-              <div><span className={styles.eyebrow}>Cómo leer la línea</span><h2>La identidad es común. La verdad técnica sigue siendo individual.</h2></div>
-              <p>Una misma familia puede contener sólidos y líquidos, formulaciones distintas y estados comerciales diferentes. Por eso esta página organiza la línea, pero cada referencia conserva su propia ficha pública.</p>
+              <div><span className={styles.eyebrow}>Cómo leer la línea</span><h2>La identidad es común. La información técnica sigue siendo individual.</h2></div>
+              <p>Una misma familia puede contener sólidos y líquidos, formulaciones distintas y estados comerciales diferentes. Esta página organiza la línea; cada referencia conserva su propia ficha con formulación, presentaciones y documentación.</p>
             </div>
             <div className={styles.truthPanel}>
               <div className={styles.truthRow}><span>Familia</span><strong>{line.family}</strong></div>
-              <div className={styles.truthRow}><span>Referencias en Product Master</span><strong>{references.length}</strong></div>
-              <div className={styles.truthRow}><span>Estado comercial</span><strong>{commercialCount} reconciliadas · {references.length - commercialCount} por confirmar o técnicas</strong></div>
-              <div className={styles.truthRow}><span>Regla de lectura</span><strong>Fórmula, formato, presentación y documentación se confirman en la referencia exacta.</strong></div>
+              <div className={styles.truthRow}><span>Referencias documentadas</span><strong>{references.length}</strong></div>
+              <div className={styles.truthRow}><span>Estado comercial</span><strong>{commercialCount} confirmadas · {references.length - commercialCount} técnicas o en validación</strong></div>
+              <div className={styles.truthRow}><span>Antes de elegir</span><strong>Confirma fórmula, formato, presentación, estado y documentación en la referencia exacta.</strong></div>
             </div>
           </div>
         </section>
@@ -100,7 +101,7 @@ export default async function WondergreenLinePage({ params }: Props) {
           <div className={styles.container}>
             <div className={styles.sectionHead}>
               <div><span className={styles.eyebrow}>Referencias de {line.family}</span><h2>Abre el producto exacto que quieres revisar.</h2></div>
-              <p>Las referencias comerciales aparecen junto a las técnicas o pendientes de reconciliación, pero nunca comparten estado por asociación de familia.</p>
+              <p>Las referencias con estado comercial confirmado aparecen junto a referencias técnicas o todavía en validación. Cada una conserva su propio estado y no hereda condiciones por pertenecer a la misma familia.</p>
             </div>
             <div className={styles.referenceGrid}>
               {references.map((reference) => (
@@ -147,7 +148,7 @@ export default async function WondergreenLinePage({ params }: Props) {
         <section className={styles.closing}>
           <div className={`${styles.container} ${styles.closingInner}`}>
             <div><span className={styles.eyebrow}>Siguiente paso</span><h2>Elige una referencia exacta o conversa sobre la línea {line.family}.</h2></div>
-            <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href={`/contacto?linea=${encodeURIComponent(line.slug)}&source=wondergreen-linea#wondergreen`}>Consultar línea</Link><Link className={styles.button} href="/wondergreen/productos">Ver productos</Link></div>
+            <div className={styles.actions}><Link className={`${styles.button} ${styles.primary}`} href={`/contacto?audience=wondergreen&source=wondergreen-linea&contexto=${encodeURIComponent(lineContactContext)}`}>Consultar línea</Link><Link className={styles.button} href="/wondergreen/productos">Ver productos</Link></div>
           </div>
         </section>
       </main>

--- a/src/app/wondergreen/lineas/[slug]/page.tsx
+++ b/src/app/wondergreen/lineas/[slug]/page.tsx
@@ -18,6 +18,13 @@ function formatLabel(format: string) {
   return format === "solid" ? "Sólido" : format === "liquid" ? "Líquido" : format;
 }
 
+function publicStatusLabel(status: string) {
+  if (status === "commercial-reconciled") return "Estado comercial confirmado";
+  if (status === "technical-portfolio") return "Portafolio técnico · condición comercial por confirmar";
+  if (status === "development") return "En desarrollo · no disponible comercialmente";
+  return "Estado por confirmar";
+}
+
 function uniqueGuides(line: NonNullable<ReturnType<typeof getWondergreenProductLine>>) {
   const byId = new Map<string, ReturnType<typeof getWondergreenProductDocuments>["guides"][number]>();
   for (const reference of getWondergreenLineReferences(line)) {
@@ -106,7 +113,7 @@ export default async function WondergreenLinePage({ params }: Props) {
             <div className={styles.referenceGrid}>
               {references.map((reference) => (
                 <Link className={styles.referenceCard} href={`/wondergreen/productos/${reference.slug}`} key={reference.slug}>
-                  <div className={styles.referenceTop}><span>{reference.publicStatus}</span><small>{formatLabel(reference.format)}</small></div>
+                  <div className={styles.referenceTop}><span>{publicStatusLabel(reference.truthStatus)}</span><small>{formatLabel(reference.format)}</small></div>
                   <h3>{reference.name}</h3>
                   {reference.formula ? <strong className={styles.formula}>{reference.formula}</strong> : null}
                   <p>{reference.role}</p>

--- a/src/app/wondergreen/productos/[slug]/page.tsx
+++ b/src/app/wondergreen/productos/[slug]/page.tsx
@@ -42,6 +42,13 @@ function formatLabel(format: string) {
   return labels[format] ?? format;
 }
 
+function publicStatusLabel(status: string) {
+  if (status === "commercial-reconciled") return "Estado comercial confirmado";
+  if (status === "technical-portfolio") return "Portafolio técnico · condición comercial por confirmar";
+  if (status === "development") return "En desarrollo · no disponible comercialmente";
+  return "Estado por confirmar";
+}
+
 function forceDownloadHref(href: string) {
   return `${href}${href.includes("?") ? "&" : "?"}download=1`;
 }
@@ -55,7 +62,8 @@ export default async function WondergreenProductPage({ params }: { params: Promi
   const artwork = getWondergreenProductArtwork(reference);
   const documents = getWondergreenProductDocuments(reference);
   const isCommercial = reference.truthStatus === "commercial-reconciled";
-  const contactHref = `/contacto?producto=${encodeURIComponent(reference.slug)}#wondergreen`;
+  const publicStatus = publicStatusLabel(reference.truthStatus);
+  const contactHref = `/contacto?producto=${encodeURIComponent(reference.slug)}&source=wondergreen-producto`;
   const visualTone = getWondergreenVisualTone(reference);
 
   return (
@@ -71,7 +79,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
               <div className={styles.heroMeta}>
                 <span>{formatLabel(reference.format)}</span>
                 <span>{reference.stage}</span>
-                <span>{reference.publicStatus}</span>
+                <span>{publicStatus}</span>
               </div>
               <div className={styles.actions}>
                 <Link className={`${styles.button} ${styles.primary}`} href={contactHref}>Consultar esta referencia</Link>
@@ -95,18 +103,18 @@ export default async function WondergreenProductPage({ params }: { params: Promi
                 />
                 <div className={depth.visualCaption}>
                   <strong>{artwork.label}</strong>
-                  <span>Activo aprobado de línea. No se presenta como packshot específico si ese master todavía no está vinculado.</span>
+                  <span>Activo aprobado de línea. No se presenta como packshot específico si ese recurso todavía no está vinculado.</span>
                 </div>
               </aside>
             ) : (
               <aside className={styles.identityPlate} aria-label={`Identidad técnica de ${reference.name}`}>
                 <div className={styles.plateTop}>
-                  <span>Product Master público</span>
-                  <small>{reference.publicStatus}</small>
+                  <span>Información pública de referencia</span>
+                  <small>{publicStatus}</small>
                 </div>
                 <div className={styles.familyMark}>{reference.family}</div>
                 {reference.formula ? <strong className={styles.formula}>{reference.formula}</strong> : <strong className={styles.formula}>{formatLabel(reference.format)}</strong>}
-                <p>La web mantiene una representación editorial hasta que exista un master visual específico aprobado para esta referencia.</p>
+                <p>La web mantiene una representación editorial hasta que exista un recurso visual específico aprobado para esta referencia.</p>
               </aside>
             )}
           </div>
@@ -119,12 +127,12 @@ export default async function WondergreenProductPage({ params }: { params: Promi
               <h2>La referencia, su formulación y su condición comercial en un solo lugar.</h2>
             </div>
             <div className={styles.truthPanel}>
-              <div className={styles.statusRow}><span>Estado público</span><strong>{reference.publicStatus}</strong></div>
+              <div className={styles.statusRow}><span>Estado público</span><strong>{publicStatus}</strong></div>
               <div className={styles.statusRow}><span>Familia</span><strong>{reference.family}</strong></div>
               {reference.formula ? <div className={styles.statusRow}><span>Formulación declarada</span><strong>{reference.formula}</strong></div> : null}
               <div className={styles.statusRow}><span>Formato</span><strong>{formatLabel(reference.format)}</strong></div>
               <div className={styles.statusRow}><span>Momento / función</span><strong>{reference.stage}</strong></div>
-              <div className={styles.statusRow}><span>Condición comercial</span><strong>{isCommercial ? "Reconciliada" : "Requiere confirmación"}</strong></div>
+              <div className={styles.statusRow}><span>Condición comercial</span><strong>{isCommercial ? "Confirmada" : "Requiere confirmación"}</strong></div>
             </div>
           </div>
         </section>
@@ -134,7 +142,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Presentaciones</span>
               <h2>Tamaños documentados, separados de inventario y disponibilidad.</h2>
-              <p>La existencia de una presentación en Product Truth no equivale automáticamente a inventario disponible. La cotización confirma versión, despacho y condición comercial.</p>
+              <p>Que una presentación esté documentada no equivale automáticamente a inventario disponible. La cotización confirma versión, despacho y condición comercial.</p>
             </div>
             <div className={styles.commercialGrid}>
               <article className={styles.infoCard}>
@@ -142,8 +150,8 @@ export default async function WondergreenProductPage({ params }: { params: Promi
                 <div className={styles.tags}>{reference.presentations?.map((item) => <strong key={item}>{item}</strong>) ?? <strong>Por confirmar</strong>}</div>
               </article>
               <article className={styles.infoCard}>
-                <span>Precio público reconciliado</span>
-                {reference.priceCop ? <><strong className={styles.price}>{money(reference.priceCop)}</strong><small>Base indicada en las notas de la referencia.</small></> : <><strong className={styles.price}>Consultar</strong><small>No se publica precio hasta reconciliar condición comercial.</small></>}
+                <span>Precio público</span>
+                {reference.priceCop ? <><strong className={styles.price}>{money(reference.priceCop)}</strong><small>Base indicada en las notas de la referencia.</small></> : <><strong className={styles.price}>Consultar</strong><small>No se publica precio hasta confirmar la condición comercial.</small></>}
               </article>
             </div>
           </div>
@@ -154,7 +162,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
             <div className={styles.sectionHeading}>
               <span className={styles.eyebrow}>Documentación oficial</span>
               <h2>Abre o descarga los documentos aprobados, no una reconstrucción de ellos.</h2>
-              <p>La página web organiza la referencia y sus relaciones. Los PDF publicados conservan el diseño y contenido del master editorial aprobado, con acciones separadas para lectura y descarga.</p>
+              <p>La página web organiza la referencia y sus relaciones. Los PDF publicados conservan el diseño y contenido del documento editorial aprobado, con acciones separadas para lectura y descarga.</p>
             </div>
             <div className={depth.documentGrid}>
               {documents.catalog?.downloadHref ? (
@@ -189,7 +197,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
               ))}
 
               <article className={`${depth.documentCard} ${depth.pendingDocument}`}>
-                <div><span>Master individual</span><h3>{documents.technicalSheet.label}</h3><p>{documents.technicalSheet.note}</p><strong>Pendiente de vincular master público</strong></div>
+                <div><span>Documento individual</span><h3>{documents.technicalSheet.label}</h3><p>{documents.technicalSheet.note}</p><strong>Pendiente de vincular documento público</strong></div>
               </article>
             </div>
           </div>
@@ -215,7 +223,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
               <div className={styles.sectionHeading}>
                 <span className={styles.eyebrow}>Cultivos relacionados</span>
                 <h2>Esta familia aparece dentro de programas por etapa.</h2>
-                <p>Cada programa abre también su guía PDF editorial cuando existe un master público aprobado.</p>
+                <p>Cada programa abre también su guía PDF editorial cuando existe un documento público aprobado.</p>
               </div>
               <div className={styles.cropGrid}>
                 {crops.map((crop) => <Link key={crop.slug} href={`/wondergreen/cultivos/${crop.slug}`}><span>Programa</span><h3>{crop.name}</h3><p>{crop.headline}</p><strong>Explorar cultivo →</strong></Link>)}

--- a/src/app/wondergreen/productos/page.tsx
+++ b/src/app/wondergreen/productos/page.tsx
@@ -10,6 +10,8 @@ export const metadata: Metadata = {
 };
 
 export default function WondergreenProductsPage() {
+  const contactContext = "Quiero revisar una referencia, presentación o condición comercial de Wondergreen.";
+
   return (
     <div className={styles.page}>
       <main>
@@ -18,7 +20,7 @@ export default function WondergreenProductsPage() {
             <div>
               <span className={styles.eyebrow}>Wondergreen · Productos</span>
               <h1>Productos concretos, formulación por formulación.</h1>
-              <p className={styles.lead}>Empieza por las referencias comercialmente reconciliadas y abre cada producto para revisar formulación, presentaciones, condición comercial, cultivos relacionados y documentos oficiales. Las referencias técnicas o en desarrollo permanecen separadas y explícitamente identificadas.</p>
+              <p className={styles.lead}>Empieza por las referencias con estado comercial confirmado y abre cada producto para revisar formulación, presentaciones, condición comercial, cultivos relacionados y documentos oficiales. Las referencias técnicas o en desarrollo permanecen separadas y explícitamente identificadas.</p>
             </div>
             <aside className={styles.router}>
               <strong>¿Quieres entender primero la familia?</strong>
@@ -33,7 +35,7 @@ export default function WondergreenProductsPage() {
 
         <section className={styles.knowledge}>
           <div className={`${styles.container} ${styles.knowledgeGrid}`}>
-            <div><span className={styles.eyebrow}>Producto + documentación</span><h2>Profundiza hasta el documento oficial.</h2><p>La web explica y conecta. Los PDF aprobados conservan su diseño, contenido y condición de master público.</p></div>
+            <div><span className={styles.eyebrow}>Producto + documentación</span><h2>Profundiza hasta el documento oficial.</h2><p>La web explica y conecta. Los PDF aprobados conservan su diseño, contenido y condición de documento público de referencia.</p></div>
             <div className={styles.knowledgeLinks}>
               <Link href="/wondergreen/lineas"><strong>Líneas Wondergreen</strong><span>→</span></Link>
               <Link href="/biblioteca"><strong>Biblioteca técnica</strong><span>→</span></Link>
@@ -45,7 +47,7 @@ export default function WondergreenProductsPage() {
         </section>
 
         <section className={styles.closing}>
-          <div className={`${styles.container} ${styles.closingInner}`}><div><span className={styles.eyebrow}>Wondergreen</span><h2>¿Quieres confirmar una referencia, presentación o condición comercial?</h2></div><Link className={styles.button} href="/contacto?necesidad=producto-wondergreen#wondergreen">Hablar con Greenatics</Link></div>
+          <div className={`${styles.container} ${styles.closingInner}`}><div><span className={styles.eyebrow}>Wondergreen</span><h2>¿Quieres confirmar una referencia, presentación o condición comercial?</h2></div><Link className={styles.button} href={`/contacto?audience=wondergreen&source=wondergreen-productos&contexto=${encodeURIComponent(contactContext)}`}>Hablar con Greenatics</Link></div>
         </section>
       </main>
     </div>

--- a/src/app/wondergreen/productos/product-catalog-browser.tsx
+++ b/src/app/wondergreen/productos/product-catalog-browser.tsx
@@ -28,7 +28,7 @@ const groups = [
 ] as const;
 
 const statusOptions: { value: StatusFilter; label: string }[] = [
-  { value: "commercial-reconciled", label: "Comerciales reconciliadas" },
+  { value: "commercial-reconciled", label: "Estado comercial confirmado" },
   { value: "all", label: "Todo el portafolio" },
   { value: "technical-portfolio", label: "Portafolio técnico" },
   { value: "development", label: "Desarrollo" },
@@ -95,7 +95,7 @@ export function ProductCatalogBrowser() {
           <div className={styles.browserHeading}>
             <div>
               <span className={styles.eyebrow}>Portafolio Wondergreen</span>
-              <h2>Empieza por los productos comercialmente reconciliados.</h2>
+              <h2>Empieza por las referencias con estado comercial confirmado.</h2>
               <span className={depth.commercialNote}>Después puedes abrir el portafolio técnico y las referencias en desarrollo sin mezclarlas con disponibilidad comercial.</span>
             </div>
             <p>Busca por nombre, familia, formulación, etapa o función. Cada referencia abre una página propia con presentaciones, documentación pública vinculada y condición comercial.</p>
@@ -147,8 +147,8 @@ export function ProductCatalogBrowser() {
 
           <div className={styles.resultBar} aria-live="polite">
             <strong>{filtered.length} {filtered.length === 1 ? "referencia" : "referencias"}</strong>
-            <span>de {wondergreenReferences.length} en el Product Master público</span>
-            {(query || status !== "commercial-reconciled" || format !== "all") ? <button type="button" onClick={clearFilters}>Volver a comerciales</button> : null}
+            <span>de {wondergreenReferences.length} referencias documentadas</span>
+            {(query || status !== "commercial-reconciled" || format !== "all") ? <button type="button" onClick={clearFilters}>Volver a referencias confirmadas</button> : null}
           </div>
         </div>
       </section>
@@ -190,9 +190,9 @@ export function ProductCatalogBrowser() {
           <div className={styles.container}>
             <span className={styles.eyebrow}>Sin coincidencias</span>
             <h2>No encontramos una referencia con esos filtros.</h2>
-            <p>Esto no significa que debas escoger otro producto automáticamente. Vuelve al portafolio comercial o entra por cultivo para revisar el contexto agronómico.</p>
+            <p>Esto no significa que debas escoger otro producto automáticamente. Vuelve a las referencias con estado comercial confirmado o entra por cultivo para revisar el contexto agronómico.</p>
             <div className={styles.emptyActions}>
-              <button type="button" onClick={clearFilters}>Ver referencias comerciales</button>
+              <button type="button" onClick={clearFilters}>Ver referencias confirmadas</button>
               <Link href="/wondergreen/cultivos">Buscar por cultivo →</Link>
             </div>
           </div>

--- a/src/app/wondergreen/productos/product-catalog-browser.tsx
+++ b/src/app/wondergreen/productos/product-catalog-browser.tsx
@@ -46,6 +46,13 @@ function normalize(value: string) {
   return value.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().trim();
 }
 
+function publicStatusLabel(status: WondergreenTruthStatus) {
+  if (status === "commercial-reconciled") return "Estado comercial confirmado";
+  if (status === "technical-portfolio") return "Portafolio técnico · condición comercial por confirmar";
+  if (status === "development") return "En desarrollo · no disponible comercialmente";
+  return "Estado por confirmar";
+}
+
 function matchesFormat(reference: WondergreenReference, filter: FormatFilter) {
   if (filter === "all") return true;
   if (filter === "bioinput") return reference.line === "bioinput";
@@ -166,7 +173,7 @@ export function ProductCatalogBrowser() {
                 const artwork = getWondergreenProductArtwork(item);
                 return (
                   <Link className={styles.productCard} data-tone={tone} href={`/wondergreen/productos/${item.slug}`} key={item.slug}>
-                    <div className={styles.cardTop}><span>{item.publicStatus}</span><small>{item.format}</small></div>
+                    <div className={styles.cardTop}><span>{publicStatusLabel(item.truthStatus)}</span><small>{item.format}</small></div>
                     {artwork ? (
                       <>
                         <Image className={depth.cardArtwork} src={artwork.href} alt={artwork.alt} width={720} height={450} sizes="(max-width: 640px) 92vw, (max-width: 900px) 45vw, 30vw" unoptimized />


### PR DESCRIPTION
## Objetivo
Cerrar el ciclo actual de profundización de la web pública con una capa de release: lenguaje comercial comprensible, continuidad real hacia Contacto, gate integral de rutas críticas y publicación certificada del SHA exacto de `develop` en el proyecto Vercel `greenatics-ops`.

## Cambios de experiencia pública
- Wondergreen deja de exponer en catálogo/líneas/fichas jerga de control interno como `comercialmente reconciliada` o `Product Master` cuando no aporta valor al visitante.
- Los estados internos (`truthStatus`) no cambian; solo se traducen en UI a `Estado comercial confirmado`, `Portafolio técnico · condición comercial por confirmar` o `En desarrollo · no disponible comercialmente`.
- Las líneas Wondergreen conservan familia ≠ formulación ≠ presentación y ahora llevan a Contacto preservando explícitamente el contexto de línea.
- El catálogo Wondergreen conserva el contexto comercial al pasar a Contacto.
- Las fichas individuales preservan la referencia exacta y muestran condición comercial en lenguaje público.
- Contacto deja de mostrar metadata técnica de navegación (`Origen:`) y mantiene servicio/producto/contexto útil para la conversación.
- El cierre de Contacto pasa de explicar una regla interna de UX a una invitación orientada al cliente.

## Release gate
- Nuevo `e2e/public-release-gate.spec.ts` para rutas públicas críticas, servicio → contacto, línea → referencia → contacto, sitemap y frontera OPS.
- Nuevo documento `docs/releases/PUBLIC_WEB_RELEASE_2026-08-25.md` con alcance, locks y procedimiento.

## Publicación Vercel
Nuevo workflow `publish-greenatics-web-release-20260825.yml`, activado una vez al fusionarse este archivo en `develop`:
1. resuelve SHA exacto de `develop`;
2. repite typecheck, lint, unit y build;
3. certifica backend hospedado;
4. despliega y certifica Preview full-ops;
5. despliega producción estable mediante el script canónico;
6. verifica branch/SHA con `pilot:preflight`;
7. hace smoke HTTP de Home, Soluciones, servicio profundo, Wondergreen, catálogo, líneas, tecnología, cultivos, Casa & Jardín, Proyectos, Biblioteca, Nosotros, Contacto, sitemap y robots;
8. publica el status `greenatics/web-release` en el commit desplegado.

## Locks preservados
- HOME mantiene `Transformamos residuos en vida.`
- No se crean productos, SKUs, packshots, dosis, frecuencias, claims, precios o disponibilidad nuevos.
- `lenta liberación` conserva su alcance documentado.
- Casa & Jardín sigue en pre-lanzamiento y `noindex,follow`.
- Canonical sigue en `https://greenatics.com.co`.
- `main` no participa en este release; la fuente canónica continúa siendo `develop`.

## Gates antes de merge
- quality
- database
- Playwright desktop
- Playwright mobile