### PR TITLE
fix(ops): limpiar warning de maestros operacionales V2.7.1

### DIFF
--- a/src/lib/supabase/operational-master-repository.ts
+++ b/src/lib/supabase/operational-master-repository.ts
@@ -2,7 +2,6 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { type ActivityTemplate, type CollectionRoute, type EquipmentMasterOption, type EquipmentProcessAssignment, type MaterialSource, type MaterialSourceKind, type MaterialTypeMaster, type MeasurementUnit, type OperationalMasterSnapshot, type OperationalProcess, type OperationalTool, type SimpleMasterKind } from "@/lib/operational-master-data";
 import { createClient } from "@/lib/supabase/client";
 
-type UnitRow = { code:string; name:string; symbol:string; category:MeasurementUnit["category"]; active:boolean };
 type SimpleRow = { id:string; plant_id:string; code:string; name:string; active:boolean };
 type TemplateRow = SimpleRow & { process_id:string; default_unit_code?:string|null; requires_quantity:boolean; requires_lot:boolean; requires_equipment:boolean; allows_unplanned:boolean };
 type SourceRow = SimpleRow & { source_kind:MaterialSourceKind };


### PR DESCRIPTION
## Alcance
Hotfix técnico posterior al release V2.7.

- elimina el tipo `UnitRow` no utilizado en `operational-master-repository.ts`;
- no cambia lógica de negocio, persistencia, UX pública ni contratos de datos;
- mantiene intacto el SHA V2.7 ya publicado hasta que esta PR pase los gates.

## Gate requerido
- quality
- database/RLS
- Playwright desktop
- Playwright mobile

## Fuera de alcance
El hydration mismatch observado una vez en `EquipmentDetail` no se modifica aquí porque no se reprodujo en la corrida final publicada. Se documentará por separado con criterio explícito de reproducción antes de introducir un cambio temporal/SSR en mantenimiento.