### PR TITLE
feat(release): gobernanza manual y repetible de producción

### DIFF
--- a/.github/workflows/publish-greenatics-web.yml
+++ b/.github/workflows/publish-greenatics-web.yml
@@ -1,0 +1,254 @@
+name: publish-greenatics-web
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: "SHA completo de develop que se quiere publicar"
+        required: true
+        type: string
+      confirm_production:
+        description: "Escribe PUBLISH-GREENATICS para habilitar producción"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: greenatics-hosted-pilot-production
+  cancel-in-progress: false
+
+jobs:
+  publish-and-certify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      PILOT_PREVIEW_MODE: full-ops
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      DEPLOY_GIT_REF: develop
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.PILOT_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PILOT_SUPABASE_PUBLISHABLE_KEY }}
+      SUPABASE_SECRET_KEY: ${{ secrets.PILOT_SUPABASE_SECRET_KEY }}
+
+    steps:
+      - name: Checkout requested release SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Validate explicit production request
+        env:
+          REQUESTED_SHA: ${{ inputs.release_sha }}
+          CONFIRM_PRODUCTION: ${{ inputs.confirm_production }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$CONFIRM_PRODUCTION" != "PUBLISH-GREENATICS" ]; then
+            echo "::error::confirm_production must equal PUBLISH-GREENATICS."
+            exit 1
+          fi
+          if ! [[ "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::release_sha must be a full lowercase 40-character Git SHA."
+            exit 1
+          fi
+          checked_out="$(git rev-parse HEAD)"
+          if [ "$checked_out" != "$REQUESTED_SHA" ]; then
+            echo "::error::Checked out SHA $checked_out does not match requested SHA $REQUESTED_SHA."
+            exit 1
+          fi
+          git fetch origin develop --prune
+          develop_head="$(git rev-parse origin/develop)"
+          if [ "$develop_head" != "$REQUESTED_SHA" ]; then
+            echo "::error::Requested SHA is no longer the current develop head ($develop_head). Start a new release from the current develop head."
+            exit 1
+          fi
+          echo "DEPLOY_GIT_SHA=$REQUESTED_SHA" >> "$GITHUB_ENV"
+          echo "GREENATICS manual web release from develop@$REQUESTED_SHA" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Mark release pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$DEPLOY_GIT_SHA" \
+            -d "{\"state\":\"pending\",\"context\":\"greenatics/web-release\",\"description\":\"Publicando SHA confirmado en greenatics-ops\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null
+
+      - name: Require deployment secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            VERCEL_TOKEN \
+            VERCEL_ORG_ID \
+            NEXT_PUBLIC_SUPABASE_URL \
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
+            SUPABASE_SECRET_KEY
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is not configured for GREENATICS production release."
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Canonical quality gate
+        run: |
+          npm run typecheck
+          npm run lint
+          npm test
+          npm run build
+
+      - name: Certify hosted backend
+        run: npm run pilot:backend-preflight -- --plants TAM,YAR
+
+      - name: Deploy full OPS preview
+        id: preview
+        run: npm run pilot:vercel-preview
+
+      - name: Certify protected preview
+        env:
+          DEPLOYMENT_URL: ${{ steps.preview.outputs.deployment_url }}
+          VERCEL_PROJECT_ID: ${{ steps.preview.outputs.project_id }}
+        run: npm run pilot:vercel-preflight
+
+      - name: Deploy stable full OPS production
+        id: production
+        run: node scripts/vercel-ops-production-deploy.mjs
+
+      - name: Certify stable OPS origin and provenance
+        env:
+          APP_BASE_URL: ${{ steps.production.outputs.deployment_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run pilot:preflight -- \
+            --base-url "$APP_BASE_URL" \
+            --mode full-ops \
+            --expected-branch "$DEPLOY_GIT_REF" \
+            --expected-commit "$DEPLOY_GIT_SHA"
+
+      - name: Certify critical public routes in production
+        env:
+          APP_BASE_URL: ${{ steps.production.outputs.deployment_url }}
+        shell: bash
+        run: |
+          set -u -o pipefail
+          base="${APP_BASE_URL%/}"
+          failures=0
+          counter=0
+
+          check_route() {
+            local path="$1"
+            local marker="$2"
+            counter=$((counter + 1))
+            local outfile="/tmp/greenatics-route-${counter}.body"
+            local status
+            status="$(curl --silent --show-error --location --retry 3 --retry-delay 2 --max-time 45 -w '%{http_code}' "$base$path" -o "$outfile" || printf '000')"
+            local bytes=0
+            [ -f "$outfile" ] && bytes="$(wc -c < "$outfile")"
+            echo "$path -> HTTP $status · $bytes bytes · marker='$marker'"
+
+            if [ "$status" != "200" ]; then
+              echo "::error::$path failed production smoke (HTTP $status)."
+              failures=$((failures + 1))
+              return
+            fi
+            if [ "$bytes" -lt 200 ]; then
+              echo "::error::$path returned only $bytes bytes."
+              failures=$((failures + 1))
+              return
+            fi
+            if ! grep -Fq "$marker" "$outfile"; then
+              echo "::error::$path did not contain release marker '$marker'."
+              failures=$((failures + 1))
+              return
+            fi
+
+            echo "- PASS: $path (HTTP 200, $bytes bytes, marker '$marker')" >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          echo "### Public production smoke" >> "$GITHUB_STEP_SUMMARY"
+          check_route "/" "Transformamos residuos en vida."
+          check_route "/soluciones" "Servicios para convertir necesidades de gestión en resultados concretos."
+          check_route "/soluciones/rehabilitacion" "Diagnóstico, rehabilitación y puesta en marcha de infraestructura existente"
+          check_route "/wondergreen" "Nutrición que trabaja con el suelo."
+          check_route "/wondergreen/productos" "Productos concretos, formulación por formulación."
+          check_route "/wondergreen/lineas" "Una identidad por línea. Una ficha exacta por referencia."
+          check_route "/wondergreen/lineas/2grow" "2Grow"
+          check_route "/wondergreen/tecnologia" "Organomineral. Oclusión. Lenta liberación."
+          check_route "/wondergreen/cultivos" "El cultivo cambia la pregunta."
+          check_route "/casa-jardin" "Nutrición por etapas para tus plantas."
+          check_route "/proyectos" "Proyectos"
+          check_route "/biblioteca" "Biblioteca"
+          check_route "/nosotros" "Diseñamos sistemas que tienen que funcionar en la vida real"
+          check_route "/contacto" "Cuéntanos qué quieres resolver."
+          check_route "/sitemap.xml" "https://greenatics.com.co/wondergreen"
+          check_route "/robots.txt" "Disallow: /app"
+
+          if [ "$failures" -ne 0 ]; then
+            echo "::error::Production public smoke failed on $failures route(s)."
+            exit 1
+          fi
+
+      - name: Release summary
+        env:
+          OPS_ORIGIN: ${{ steps.production.outputs.deployment_url }}
+          UNIQUE_ORIGIN: ${{ steps.production.outputs.unique_deployment_url }}
+        shell: bash
+        run: |
+          echo "Stable public/OPS origin: $OPS_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
+          echo "Unique deployment: $UNIQUE_ORIGIN" >> "$GITHUB_STEP_SUMMARY"
+          echo "Published develop commit: $DEPLOY_GIT_SHA" >> "$GITHUB_STEP_SUMMARY"
+          echo "Manual confirmation, quality, backend, preview, production provenance and semantic public route smoke: PASS." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark release success
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$DEPLOY_GIT_SHA" \
+            -d "{\"state\":\"success\",\"context\":\"greenatics/web-release\",\"description\":\"greenatics-ops publicado y certificado\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null
+
+      - name: Mark release failure
+        if: ${{ failure() && env.DEPLOY_GIT_SHA != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$DEPLOY_GIT_SHA" \
+            -d "{\"state\":\"failure\",\"context\":\"greenatics/web-release\",\"description\":\"falló la certificación/publicación web\",\"target_url\":\"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            >/dev/null

--- a/scripts/publish-greenatics-web-workflow.test.mjs
+++ b/scripts/publish-greenatics-web-workflow.test.mjs
@@ -7,8 +7,8 @@ describe("GREENATICS manual production release workflow", () => {
   it("is manual-only and requires an explicit production confirmation", () => {
     expect(workflow).toContain("workflow_dispatch:");
     expect(workflow).not.toMatch(/^\s*push:\s*$/m);
-    expect(workflow).toContain('confirm_production:');
-    expect(workflow).toContain('PUBLISH-GREENATICS');
+    expect(workflow).toContain("confirm_production:");
+    expect(workflow).toContain("PUBLISH-GREENATICS");
   });
 
   it("publishes only the exact current develop head", () => {
@@ -32,7 +32,7 @@ describe("GREENATICS manual production release workflow", () => {
       '--expected-commit "$DEPLOY_GIT_SHA"',
       'check_route "/" "Transformamos residuos en vida."',
       'check_route "/robots.txt" "Disallow: /app"',
-      'context\\\":\\\"greenatics/web-release',
+      "greenatics/web-release",
     ]) {
       expect(workflow).toContain(marker);
     }

--- a/scripts/publish-greenatics-web-workflow.test.mjs
+++ b/scripts/publish-greenatics-web-workflow.test.mjs
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(".github/workflows/publish-greenatics-web.yml", "utf8");
+
+describe("GREENATICS manual production release workflow", () => {
+  it("is manual-only and requires an explicit production confirmation", () => {
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).not.toMatch(/^\s*push:\s*$/m);
+    expect(workflow).toContain('confirm_production:');
+    expect(workflow).toContain('PUBLISH-GREENATICS');
+  });
+
+  it("publishes only the exact current develop head", () => {
+    expect(workflow).toContain('ref: ${{ inputs.release_sha }}');
+    expect(workflow).toContain('^\[0-9a-f\]{40}$');
+    expect(workflow).toContain('develop_head="$(git rev-parse origin/develop)"');
+    expect(workflow).toContain('if [ "$develop_head" != "$REQUESTED_SHA" ]');
+    expect(workflow).toContain('DEPLOY_GIT_SHA=$REQUESTED_SHA');
+  });
+
+  it("keeps quality, hosted backend, preview, production provenance and semantic smoke as release gates", () => {
+    for (const marker of [
+      "npm run typecheck",
+      "npm run lint",
+      "npm test",
+      "npm run build",
+      "npm run pilot:backend-preflight -- --plants TAM,YAR",
+      "npm run pilot:vercel-preview",
+      "npm run pilot:vercel-preflight",
+      "node scripts/vercel-ops-production-deploy.mjs",
+      '--expected-commit "$DEPLOY_GIT_SHA"',
+      'check_route "/" "Transformamos residuos en vida."',
+      'check_route "/robots.txt" "Disallow: /app"',
+      'context\\\":\\\"greenatics/web-release',
+    ]) {
+      expect(workflow).toContain(marker);
+    }
+  });
+});


### PR DESCRIPTION
## Objetivo
Convertir la publicación V2.7, que nació como workflow fechado one-shot, en un mecanismo reusable y fail-closed para futuros releases.

## Cambios
- añade `.github/workflows/publish-greenatics-web.yml`;
- solo se ejecuta mediante `workflow_dispatch`;
- exige SHA completo de 40 caracteres;
- exige confirmación literal `PUBLISH-GREENATICS`;
- verifica que el SHA solicitado siga siendo exactamente el HEAD actual de `develop` antes de tocar producción;
- repite typecheck, lint, unit y build;
- certifica backend hospedado TAM/YAR;
- crea/certifica preview full-ops;
- publica producción estable;
- verifica branch/SHA por provenance;
- repite smoke semántico de 16 rutas;
- conserva `greenatics/web-release` como status del commit;
- añade test de contrato para impedir que el workflow derive hacia auto-deploy o pierda gates.

## Seguridad de release
El workflow fechado `publish-greenatics-web-release-20260825.yml` se conserva como evidencia histórica e inerte. No se modifica ni se elimina en esta PR.

## No hace
- no publica producción al hacer merge;
- no cambia aplicación, contenidos, base de datos ni UX;
- no resuelve todavía el Issue #263 de hydration intermitente;
- no habilita rollback arbitrario: solo permite publicar el HEAD actual de `develop`.

## Gate requerido
- quality
- database/RLS
- Playwright desktop
- Playwright mobile