### PR TITLE
fix(ops): estabiliza hidratación temporal del HOME OPS

### DIFF
--- a/e2e/today-dashboard-hydration.spec.ts
+++ b/e2e/today-dashboard-hydration.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+const hydrationPattern = /hydration|server rendered html|did not match/i;
+
+test("OPS home hydrates deterministically when browser and server clocks differ", async ({ page }) => {
+  const hydrationErrors: string[] = [];
+
+  page.on("console", (message) => {
+    if (message.type() === "error" && hydrationPattern.test(message.text())) {
+      hydrationErrors.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => {
+    if (hydrationPattern.test(error.message)) hydrationErrors.push(error.message);
+  });
+
+  // Freeze only the browser clock far from the server clock. TodayDashboard
+  // currently derives its first client render from new Date(), so any temporal
+  // dependency that is not serialized from the server becomes deterministic.
+  await page.clock.setFixedTime(new Date("2030-01-15T15:00:00.000Z"));
+  await page.goto("/app");
+
+  await expect(page.getByRole("heading", { name: "Operación de hoy" })).toBeVisible();
+  await expect(page.getByRole("region", { name: "Indicadores de hoy" })).toBeVisible();
+  await expect(page.getByText("Horas-hombre", { exact: true })).toBeVisible();
+
+  // React reports hydration mismatches during or immediately after hydration.
+  // Yield once so console/pageerror listeners capture the diagnostic.
+  await page.waitForTimeout(100);
+
+  expect(hydrationErrors, hydrationErrors.join("\n\n")).toEqual([]);
+});

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -11,7 +11,7 @@ export default async function InternalAppHome() {
   return (
     <AppShell>
       <TodayDashboard initialNowIso={initialNowIso} />
-      <MaintenanceHome />
+      <MaintenanceHome initialNowIso={initialNowIso} />
       <CompostHome />
     </AppShell>
   );

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,12 +1,16 @@
+import { connection } from "next/server";
 import { AppShell } from "@/components/app-shell";
 import { TodayDashboard } from "@/components/today-dashboard";
 import { MaintenanceHome } from "@/components/maintenance-home";
 import { CompostHome } from "@/components/compost-home";
 
-export default function InternalAppHome() {
+export default async function InternalAppHome() {
+  await connection();
+  const initialNowIso = new Date().toISOString();
+
   return (
     <AppShell>
-      <TodayDashboard />
+      <TodayDashboard initialNowIso={initialNowIso} />
       <MaintenanceHome />
       <CompostHome />
     </AppShell>

--- a/src/components/maintenance-home.tsx
+++ b/src/components/maintenance-home.tsx
@@ -1,15 +1,24 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { useMaintenanceStore } from "@/components/maintenance-store";
 import { EquipmentStatusPill, MaintenanceStatusPill } from "@/components/equipment-status-pill";
 import { getDowntimeMinutes } from "@/lib/maintenance-domain";
 
-export function MaintenanceHome() {
+export function MaintenanceHome({ initialNowIso }: { initialNowIso: string }) {
   const { equipment, tickets } = useMaintenanceStore();
+  const [nowIso, setNowIso] = useState(initialNowIso);
+
+  useEffect(() => {
+    const update = () => setNowIso(new Date().toISOString());
+    const timer = window.setInterval(update, 60_000);
+    return () => window.clearInterval(timer);
+  }, []);
+
   const activeTickets = tickets.filter((ticket) => ticket.status !== "closed");
   const affected = equipment.filter((asset) => asset.status === "stopped" || asset.status === "maintenance");
   if (!affected.length && !activeTickets.length) return null;
 
-  return <section className="panel plant-panel mt-4"><div className="section-head"><div><p className="eyebrow">Equipos</p><h2>Mantenimiento que requiere atención</h2></div><Link className="button secondary" href="/equipment">Ver equipos</Link></div><div className="grid gap-3 md:grid-cols-2">{affected.map((asset)=>{ const ticket = activeTickets.find((item)=>item.equipmentId===asset.id); return <Link className="rounded-xl border border-[var(--line)] p-4 no-underline" href={`/equipment/${asset.id}`} key={asset.id}><div className="flex items-start justify-between gap-3"><div><strong className="block text-sm">{asset.code} · {asset.name}</strong><span className="mt-1 block text-xs text-[var(--muted)]">{asset.plant} · {asset.area}</span></div><EquipmentStatusPill status={asset.status}/></div>{ticket && <div className="mt-3 border-t border-[var(--line)] pt-3"><div className="flex items-center justify-between gap-2"><strong className="text-xs">{ticket.title}</strong><MaintenanceStatusPill status={ticket.status}/></div><span className="mt-2 block text-[11px] text-[var(--muted)]">{Math.round(getDowntimeMinutes(ticket,new Date().toISOString()))} min fuera de servicio</span></div>}</Link>;})}</div></section>;
+  return <section className="panel plant-panel mt-4"><div className="section-head"><div><p className="eyebrow">Equipos</p><h2>Mantenimiento que requiere atención</h2></div><Link className="button secondary" href="/equipment">Ver equipos</Link></div><div className="grid gap-3 md:grid-cols-2">{affected.map((asset)=>{ const ticket = activeTickets.find((item)=>item.equipmentId===asset.id); return <Link className="rounded-xl border border-[var(--line)] p-4 no-underline" href={`/equipment/${asset.id}`} key={asset.id}><div className="flex items-start justify-between gap-3"><div><strong className="block text-sm">{asset.code} · {asset.name}</strong><span className="mt-1 block text-xs text-[var(--muted)]">{asset.plant} · {asset.area}</span></div><EquipmentStatusPill status={asset.status}/></div>{ticket && <div className="mt-3 border-t border-[var(--line)] pt-3"><div className="flex items-center justify-between gap-2"><strong className="text-xs">{ticket.title}</strong><MaintenanceStatusPill status={ticket.status}/></div><span className="mt-2 block text-[11px] text-[var(--muted)]">{Math.round(getDowntimeMinutes(ticket, nowIso))} min fuera de servicio</span></div>}</Link>;})}</div></section>;
 }

--- a/src/components/today-dashboard.tsx
+++ b/src/components/today-dashboard.tsx
@@ -22,11 +22,11 @@ function timeLabel(iso?: string) {
   return bogotaTime.format(new Date(iso));
 }
 
-export function TodayDashboard() {
+export function TodayDashboard({ initialNowIso }: { initialNowIso: string }) {
   const { activities, incidents, receptions, workers, ready, resetDemo } = useOpsStore();
   const { equipment, tickets } = useMaintenanceStore();
   const { piles, measurements } = useCompostStore();
-  const [nowIso, setNowIso] = useState(() => new Date().toISOString());
+  const [nowIso, setNowIso] = useState(initialNowIso);
 
   useEffect(() => {
     const update = () => setNowIso(new Date().toISOString());


### PR DESCRIPTION
Closes #270.

## Objetivo
Eliminar los hydration mismatches temporales de `/app` sin ocultar warnings y sin alterar la semántica de horas-hombre, downtime ni `buildOperationalAnalytics`.

## RED certificado
Test-only SHA: `5021d9e4f4e22e6b6bbd301b661814348465583e`.
Actions #916:
- quality PASS;
- database/RLS PASS;
- desktop: **268 passed, 1 skipped y únicamente la nueva regresión falló**, incluido retry;
- React reportó `Hydration failed because the server rendered text didn't match the client`;
- primera diferencia observada dentro de `TodayDashboard`: cliente `martes, 15 de enero de 2030` vs servidor `martes, 25 de agosto de 2026`.

## Segunda causa revelada por el primer fix
Actions #918 demostró una segunda fuente temporal durante render:
- `MaintenanceHome` calculaba `getDowntimeMinutes(ticket, new Date().toISOString())` durante SSR y primer render cliente;
- desktop y mobile terminaron con **268 PASS, 1 skip y únicamente la regresión de hidratación FAIL**;
- `CompostHome` y `AppShell` fueron auditados y no contienen otro wall-clock equivalente en el primer render.

## Implementación final
- `src/app/app/page.tsx`: espera `connection()` de `next/server`, genera un único `initialNowIso` request-time y lo comparte con los consumidores temporales del HOME;
- `src/components/today-dashboard.tsx`: inicializa `nowIso` desde ese snapshot serializado y conserva el refresco posterior al mount;
- `src/components/maintenance-home.tsx`: inicializa su reloj desde el mismo snapshot y actualiza downtime solo después del mount;
- no usa `suppressHydrationWarning`;
- no modifica dominio, fórmulas de analytics, stores, RLS, Supabase ni datos.

## Gobierno de render
`await connection()` hace explícita la dependencia request-time antes de `new Date()`. SSR y primera hidratación reciben el mismo timestamp serializado; los relojes vivos empiezan a avanzar únicamente después del mount.

## Regresión
`e2e/today-dashboard-hydration.spec.ts` congela el reloj del browser en 2030 mientras el servidor conserva su tiempo real y exige cero diagnósticos React de hydration mismatch en `/app`. La prueba cubre el árbol HOME completo y por eso detectó también la segunda causa en `MaintenanceHome`.

## Certificación final
Head certificado: `33fdb42074cf492ab360fb407a61721aaf7d8168`.
Actions #920:
- ✅ quality PASS;
- ✅ database/RLS PASS;
- ✅ browser mobile-chromium PASS;
- ✅ browser desktop-chromium PASS;
- ✅ review threads: cero.

Merge protegido:
- ✅ `expected_head_sha=33fdb42074cf492ab360fb407a61721aaf7d8168`;
- ✅ merge commit `2afdfb0eb8260cacbe722f4d00edb60ad411cd39` en `develop`.

Post-merge Actions #921 sobre `develop@2afdfb0eb8260cacbe722f4d00edb60ad411cd39`:
- ✅ quality PASS;
- ✅ database/RLS PASS;
- ✅ browser desktop-chromium PASS;
- ✅ browser mobile-chromium PASS.

## Estado
**CERRADO Y CERTIFICADO 4/4 POST-MERGE.**

## Fuera de alcance
No modifica producto público, contenido, datos, fórmulas de negocio, RLS, Supabase, publicación ni Vercel.