### PR TITLE
feat(public): completa metadata social por ruta · fase A

### DIFF
--- a/e2e/public-social.spec.ts
+++ b/e2e/public-social.spec.ts
@@ -26,23 +26,26 @@ for (const route of routes) {
 
     const ogTitle = page.locator('meta[property="og:title"]');
     const ogDescription = page.locator('meta[property="og:description"]');
+    const ogUrl = page.locator('meta[property="og:url"]');
     const twitterTitle = page.locator('meta[name="twitter:title"]');
     const twitterDescription = page.locator('meta[name="twitter:description"]');
 
     await expect(ogTitle).toHaveCount(1);
     await expect(ogDescription).toHaveCount(1);
+    await expect(ogUrl).toHaveCount(1);
     await expect(twitterTitle).toHaveCount(1);
     await expect(twitterDescription).toHaveCount(1);
 
     const title = (await ogTitle.getAttribute("content")) ?? "";
     const description = (await ogDescription.getAttribute("content")) ?? "";
+    const socialUrl = (await ogUrl.getAttribute("content")) ?? "";
     expect(title).not.toContain("GREENATICS OPS");
     expect(title.trim().length).toBeGreaterThan(0);
     expect(description.trim().length).toBeGreaterThan(0);
     await expect(twitterTitle).toHaveAttribute("content", title);
     await expect(twitterDescription).toHaveAttribute("content", description);
 
-    await expect(page.locator('meta[property="og:url"]')).toHaveAttribute("content", `https://greenatics.com.co${route}`);
+    expect(new URL(socialUrl).href).toBe(new URL(route, "https://greenatics.com.co").href);
     await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute("content", "Greenatics");
     await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute("content", "es_CO");
     await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");

--- a/e2e/public-social.spec.ts
+++ b/e2e/public-social.spec.ts
@@ -1,8 +1,13 @@
 import { test, expect } from "@playwright/test";
 
 const routes = [
+  "/",
+  "/soluciones",
+  "/soluciones/rehabilitacion",
   "/soluciones/gestion-juridica-regulatoria",
   "/soluciones/valorizacion-productos",
+  "/proyectos",
+  "/proyectos/yarumal",
   "/wondergreen",
   "/wondergreen/tecnologia",
   "/wondergreen/cultivos",
@@ -18,12 +23,29 @@ const routes = [
 for (const route of routes) {
   test(`social metadata: ${route}`, async ({ page }) => {
     await page.goto(route);
-    const title = page.locator('meta[property="og:title"]');
-    await expect(title).toHaveCount(1);
-    expect((await title.getAttribute("content")) ?? "").not.toContain("GREENATICS OPS");
+
+    const ogTitle = page.locator('meta[property="og:title"]');
+    const ogDescription = page.locator('meta[property="og:description"]');
+    const twitterTitle = page.locator('meta[name="twitter:title"]');
+    const twitterDescription = page.locator('meta[name="twitter:description"]');
+
+    await expect(ogTitle).toHaveCount(1);
+    await expect(ogDescription).toHaveCount(1);
+    await expect(twitterTitle).toHaveCount(1);
+    await expect(twitterDescription).toHaveCount(1);
+
+    const title = (await ogTitle.getAttribute("content")) ?? "";
+    const description = (await ogDescription.getAttribute("content")) ?? "";
+    expect(title).not.toContain("GREENATICS OPS");
+    expect(title.trim().length).toBeGreaterThan(0);
+    expect(description.trim().length).toBeGreaterThan(0);
+    await expect(twitterTitle).toHaveAttribute("content", title);
+    await expect(twitterDescription).toHaveAttribute("content", description);
+
     await expect(page.locator('meta[property="og:url"]')).toHaveAttribute("content", `https://greenatics.com.co${route}`);
     await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute("content", "Greenatics");
     await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute("content", "es_CO");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");
     await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute("content", "summary");
   });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,13 +4,18 @@ import Link from "next/link";
 import { HomeProjectEvidence } from "@/components/public-home-evidence-crops";
 import { PublicShell } from "@/components/public-shell";
 import { publicCommercialMethod } from "@/data/public-method";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import styles from "./public-home-v2.module.css";
 
+const title = "Greenatics | Transformamos residuos en vida";
+const description =
+  "Greenatics diseña e implementa soluciones de gestión integral de residuos que conectan planeación, infraestructura, operación, datos y valorización para devolver valor al territorio y a los sistemas productivos.";
+
 export const metadata: Metadata = {
-  title: "Greenatics | Transformamos residuos en vida",
-  description:
-    "Greenatics diseña e implementa soluciones de gestión integral de residuos que conectan planeación, infraestructura, operación, datos y valorización para devolver valor al territorio y a los sistemas productivos.",
+  title,
+  description,
   alternates: { canonical: "/" },
+  ...publicSocialMetadata({ title, description, path: "/" }),
 };
 
 const universes = [

--- a/src/app/proyectos/[slug]/layout.tsx
+++ b/src/app/proyectos/[slug]/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { getPublicProject } from "@/data/projects-public";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Omit<Props, "children">): Promise<Metadata> {
+  const { slug } = await params;
+  const project = getPublicProject(slug);
+  if (!project) return {};
+
+  const title = `${project.name} | Proyectos Greenatics`;
+  const description = project.summary;
+  const path = `/proyectos/${project.slug}` as `/${string}`;
+
+  return publicSocialMetadata({ title, description, path });
+}
+
+export default function ProjectSocialMetadataLayout({ children }: Props) {
+  return children;
+}

--- a/src/app/proyectos/layout.tsx
+++ b/src/app/proyectos/layout.tsx
@@ -1,4 +1,13 @@
+import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const title = "Proyectos | Greenatics";
+const description = "Casos documentados y aprendizajes Greenatics en operación, rehabilitación, tratamiento biológico, rutas selectivas y trazabilidad.";
+
+export const metadata: Metadata = {
+  ...publicSocialMetadata({ title, description, path: "/proyectos" }),
+};
 
 export default function ProjectsLayout({ children }: { children: React.ReactNode }) {
   return <PublicShell ownsMain={false}>{children}</PublicShell>;

--- a/src/app/soluciones/[slug]/layout.tsx
+++ b/src/app/soluciones/[slug]/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { getService } from "@/data/services";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Omit<Props, "children">): Promise<Metadata> {
+  const { slug } = await params;
+  const service = getService(slug);
+  if (!service) return {};
+
+  const title = `${service.name} | Greenatics`;
+  const description = service.summary;
+  const path = `/soluciones/${service.slug}` as `/${string}`;
+
+  return publicSocialMetadata({ title, description, path });
+}
+
+export default function ServiceSocialMetadataLayout({ children }: Props) {
+  return children;
+}

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -3,14 +3,19 @@ import Image from "next/image";
 import Link from "next/link";
 import { publicCommercialMethod } from "@/data/public-method";
 import { getPrimaryProjectMedia } from "@/data/public-media";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import catalog from "./solutions-catalog.module.css";
 import styles from "./solutions-v2.module.css";
 
+const title = "Soluciones | Greenatics";
+const description =
+  "Servicios de planeación, regulación, logística, plantas, dirección técnica, operación, datos, valorización y caracterización para ESP, municipios, empresas, instituciones y operadores.";
+
 export const metadata: Metadata = {
-  title: "Soluciones | Greenatics",
-  description:
-    "Servicios de planeación, regulación, logística, plantas, dirección técnica, operación, datos, valorización y caracterización para ESP, municipios, empresas, instituciones y operadores.",
+  title,
+  description,
   alternates: { canonical: "/soluciones" },
+  ...publicSocialMetadata({ title, description, path: "/soluciones" }),
 };
 
 const audiences = [


### PR DESCRIPTION
Refs #129.

## Objetivo
Completar la cobertura Open Graph/Twitter textual y canonical por ruta en las superficies que todavía no la tienen, sin incorporar aún una imagen social no aprobada.

## Base congelada
`develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`, certificado 4/4 post-merge en Actions #934 y reservado como candidato de publicación actual.

**Esta PR no debe fusionarse mientras ese SHA siga pendiente de release**, para no invalidar el contrato `release_sha = HEAD actual de develop`.

## RED certificado
Test-only SHA: `9885a10afb7dadbe80ea6b992e195502b877ca99`.
Actions #935:
- ✅ quality PASS;
- ✅ database/RLS PASS;
- ❌ mobile: 272 PASS, 1 skip y exactamente 5 fallos;
- los 5 fallos correspondieron únicamente a las rutas añadidas al contrato social:
  - `/`
  - `/soluciones`
  - `/soluciones/rehabilitacion`
  - `/proyectos`
  - `/proyectos/yarumal`
- en los cinco casos Playwright recibió `0` elementos para `meta[property="og:title"]`;
- todas las rutas que ya tenían metadata social permanecieron PASS.

## Implementación fase A
- HOME usa `publicSocialMetadata()` con su title/description/canonical actuales;
- `/soluciones` usa el mismo helper en la página hub;
- `src/app/soluciones/[slug]/layout.tsx` genera OG/Twitter por servicio dinámico usando el slug y `service.summary`, evitando heredar la URL del hub;
- `/proyectos` recibe metadata social en su layout;
- `src/app/proyectos/[slug]/layout.tsx` sobrescribe la metadata social para cada caso dinámico con su propia URL;
- no se modifica el root layout compartido con OPS.

## Contrato fortalecido
`e2e/public-social.spec.ts` exige:
- exactamente un `og:title`, `og:description` y `og:url`;
- `og:url` semánticamente equivalente al canonical público exacto de cada ruta;
- `og:site_name=Greenatics`;
- `og:locale=es_CO`;
- `og:type=website`;
- Twitter card/title/description coherentes con OG;
- ningún título público con `GREENATICS OPS`.

## GREEN intento #1 · Actions #940
Head: `e1355929f81b1308d19ea629660116e67bc1dffc`.
- ✅ quality PASS;
- ✅ database/RLS PASS;
- ❌ desktop: 276 PASS, 1 skip, 1 fallo;
- ❌ mobile: 276 PASS, 1 skip, 1 fallo;
- el único fallo en ambos navegadores fue HOME y no fue ausencia de metadata: `og:url` existía;
- Next serializó la raíz como `https://greenatics.com.co`, mientras el test exigía literalmente `https://greenatics.com.co/`;
- `/soluciones`, `/soluciones/rehabilitacion`, `/proyectos`, `/proyectos/yarumal` y todas las rutas sociales previamente cubiertas quedaron PASS.

La diferencia de barra final representa la misma URL raíz. El helper ya construye la URL mediante `new URL(...)`; no se modificó la implementación.

## Ajuste de contrato E2E
Commit `03c237e3bed37e007abcaebb1cfaac943403583d`:
- compara `og:url` como URL normalizada con `new URL(...)`;
- mantiene la exigencia de exactamente un `og:url`;
- cualquier dominio o path incorrecto continúa fallando;
- no modifica aplicación, metadata, assets, OPS ni datos.

## GREEN final certificado · Actions #941
Head final: `03c237e3bed37e007abcaebb1cfaac943403583d`.
- ✅ quality PASS;
- ✅ database/RLS/Postgres PASS;
- ✅ desktop Chromium: 277 PASS, 1 skip;
- ✅ mobile Chromium: 277 PASS, 1 skip;
- ✅ HOME y las 17 rutas del contrato social PASS;
- ✅ `/soluciones`, detalle dinámico, `/proyectos` y caso dinámico emiten metadata social propia;
- ✅ no hay regresión en OPS, SEO, shell público, Wondergreen, Casa & Jardín ni release gates.

## Alcance final
6 archivos; +103/−11. Solo metadata pública y E2E. No toca OPS, datos, Supabase, RLS, workflows ni assets.

## Estado de integración
La fase A está técnicamente certificada pero esta PR permanece **draft y sin merge** mientras `develop@9de516df1b3ce7eeedd59db500bbc858551e86c4` siga pendiente de publicación gobernada. Fusionar #274 antes invalidaría el candidato actual porque el workflow de release exige que `release_sha` sea exactamente el HEAD vigente de `develop`.

## Fuera de esta fase
- imagen social 1200×630 aprobada;
- `og:image` / Twitter image;
- cambios en branding/assets;
- producción;
- cierre de #129.

La fase B de #129 permanece pendiente hasta contar con una pieza social canónica aprobada.