### PR TITLE
feat(public): structured data semántica de servicios y Wondergreen V2.10

### DIFF
--- a/e2e/public-structured-data.spec.ts
+++ b/e2e/public-structured-data.spec.ts
@@ -61,7 +61,7 @@ test("technical Wondergreen reference stays non-transactional in Product structu
   expect(product).toBeTruthy();
   expect(product?.name).toBe("2Grow Líquido · referencia nitrogenada");
   expect(product?.url).toBe("https://greenatics.com.co/wondergreen/productos/2grow-liquido-200-0-0");
-  expect(propertyValue(product, "Estado público")).toBe("Portafolio técnico · disponibilidad por confirmar");
+  expect(propertyValue(product, "Estado público")).toBe("Portafolio técnico · condición comercial por confirmar");
   expect(product?.offers).toBeUndefined();
   expect(product?.aggregateRating).toBeUndefined();
   expect(product?.review).toBeUndefined();

--- a/e2e/public-structured-data.spec.ts
+++ b/e2e/public-structured-data.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+
+async function jsonLdByType(page: import("@playwright/test").Page, type: string) {
+  const payloads = await page.locator('script[type="application/ld+json"]').allTextContents();
+  return payloads
+    .map((payload) => JSON.parse(payload) as Record<string, unknown>)
+    .find((payload) => payload["@type"] === type);
+}
+
+function propertyValue(entity: Record<string, unknown> | undefined, name: string) {
+  const properties = Array.isArray(entity?.additionalProperty)
+    ? entity.additionalProperty as Record<string, unknown>[]
+    : [];
+  return properties.find((property) => property.name === name)?.value;
+}
+
+test("service detail emits exact non-transactional Service structured data", async ({ page }) => {
+  await page.goto("/soluciones/rehabilitacion");
+  const service = await jsonLdByType(page, "Service");
+
+  expect(service).toBeTruthy();
+  expect(service?.["@id"]).toBe("https://greenatics.com.co/soluciones/rehabilitacion#service");
+  expect(service?.name).toBe("Diagnóstico, rehabilitación y puesta en marcha de infraestructura existente");
+  expect(service?.description).toBe("Recuperamos plantas, composteras o sistemas subutilizados antes de recomendar reemplazarlos.");
+  expect(service?.url).toBe("https://greenatics.com.co/soluciones/rehabilitacion");
+  expect(service?.serviceType).toBe("Infraestructura");
+  expect(service?.provider).toEqual({ "@id": "https://greenatics.com.co/#organization" });
+  expect(service?.audience).toEqual({ "@type": "Audience", audienceType: "Ambos" });
+  expect(service?.offers).toBeUndefined();
+  expect(service?.aggregateRating).toBeUndefined();
+  expect(service?.review).toBeUndefined();
+});
+
+test("commercial Wondergreen reference emits descriptive Product data without inventing an Offer", async ({ page }) => {
+  await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
+  const product = await jsonLdByType(page, "Product");
+
+  expect(product).toBeTruthy();
+  expect(product?.["@id"]).toBe("https://greenatics.com.co/wondergreen/productos/2grow-solido-15-3-3#product");
+  expect(product?.name).toBe("2Grow Sólido");
+  expect(product?.description).toBe("Línea organomineral para establecimiento, brotación, crecimiento y recuperación vegetativa.");
+  expect(product?.url).toBe("https://greenatics.com.co/wondergreen/productos/2grow-solido-15-3-3");
+  expect(product?.brand).toEqual({ "@type": "Brand", name: "Wondergreen" });
+  expect(product?.category).toBe("2Grow");
+  expect(propertyValue(product, "Formulación declarada")).toBe("15-3-3");
+  expect(propertyValue(product, "Momento / función")).toBe("Crecimiento vegetativo");
+  expect(propertyValue(product, "Estado público")).toBe("Estado comercial confirmado");
+  expect(product?.offers).toBeUndefined();
+  expect(product?.aggregateRating).toBeUndefined();
+  expect(product?.review).toBeUndefined();
+  expect(product?.image).toBeUndefined();
+  expect(product?.sku).toBeUndefined();
+  expect(product?.gtin).toBeUndefined();
+  expect(product?.mpn).toBeUndefined();
+});
+
+test("technical Wondergreen reference stays non-transactional in Product structured data", async ({ page }) => {
+  await page.goto("/wondergreen/productos/2grow-liquido-200-0-0");
+  const product = await jsonLdByType(page, "Product");
+
+  expect(product).toBeTruthy();
+  expect(product?.name).toBe("2Grow Líquido · referencia nitrogenada");
+  expect(product?.url).toBe("https://greenatics.com.co/wondergreen/productos/2grow-liquido-200-0-0");
+  expect(propertyValue(product, "Estado público")).toBe("Portafolio técnico · disponibilidad por confirmar");
+  expect(product?.offers).toBeUndefined();
+  expect(product?.aggregateRating).toBeUndefined();
+  expect(product?.review).toBeUndefined();
+  expect(product?.image).toBeUndefined();
+});

--- a/src/app/soluciones/[slug]/page.tsx
+++ b/src/app/soluciones/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { ServiceJsonLd } from "@/components/service-json-ld";
 import { publicProjects } from "@/data/projects-public";
 import { getService, services } from "@/data/services";
 import styles from "../solutions.module.css";
@@ -45,6 +46,7 @@ export default async function SolutionDetailPage({ params }: Props) {
         { name: "Soluciones", path: "/soluciones" },
         { name: service.name, path: servicePath },
       ]} />
+      <ServiceJsonLd service={service} />
       <main>
         <section className={styles.detailHero}>
           <div className={styles.heroAccent} aria-hidden="true" />

--- a/src/app/wondergreen/productos/[slug]/page.tsx
+++ b/src/app/wondergreen/productos/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { WondergreenProductJsonLd } from "@/components/wondergreen-product-json-ld";
 import {
   getWondergreenProductArtwork,
   getWondergreenProductCrops,
@@ -68,6 +69,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
 
   return (
     <div className={styles.page} data-tone={visualTone}>
+      <WondergreenProductJsonLd reference={reference} publicStatus={publicStatus} />
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>

--- a/src/components/service-json-ld.tsx
+++ b/src/components/service-json-ld.tsx
@@ -1,0 +1,26 @@
+import { JsonLd } from "@/components/json-ld";
+import { publicSite } from "@/data/public-site";
+import type { GreenaticsService } from "@/data/services";
+
+export function ServiceJsonLd({ service }: { service: GreenaticsService }) {
+  const url = new URL(`/soluciones/${service.slug}`, `${publicSite.publicDomainTarget}/`).toString();
+
+  return (
+    <JsonLd
+      data={{
+        "@context": "https://schema.org",
+        "@type": "Service",
+        "@id": `${url}#service`,
+        name: service.name,
+        description: service.summary,
+        url,
+        serviceType: service.category,
+        provider: { "@id": `${publicSite.publicDomainTarget}/#organization` },
+        audience: {
+          "@type": "Audience",
+          audienceType: service.audience,
+        },
+      }}
+    />
+  );
+}

--- a/src/components/wondergreen-product-json-ld.tsx
+++ b/src/components/wondergreen-product-json-ld.tsx
@@ -1,0 +1,40 @@
+import { JsonLd } from "@/components/json-ld";
+import { publicSite } from "@/data/public-site";
+import type { WondergreenReference } from "@/data/wondergreen-public";
+
+export function WondergreenProductJsonLd({
+  reference,
+  publicStatus,
+}: {
+  reference: WondergreenReference;
+  publicStatus: string;
+}) {
+  const url = new URL(
+    `/wondergreen/productos/${reference.slug}`,
+    `${publicSite.publicDomainTarget}/`,
+  ).toString();
+
+  const additionalProperty = [
+    ...(reference.formula
+      ? [{ "@type": "PropertyValue", name: "Formulación declarada", value: reference.formula }]
+      : []),
+    { "@type": "PropertyValue", name: "Momento / función", value: reference.stage },
+    { "@type": "PropertyValue", name: "Estado público", value: publicStatus },
+  ];
+
+  return (
+    <JsonLd
+      data={{
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "@id": `${url}#product`,
+        name: reference.name,
+        description: reference.role,
+        url,
+        brand: { "@type": "Brand", name: "Wondergreen" },
+        category: reference.family,
+        additionalProperty,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
Refs #277.

## Objetivo
Añadir JSON-LD semántico a servicios exactos y referencias Wondergreen sin inventar señales transaccionales ni prometer rich results.

## Base congelada
`develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`.

Esta PR parte del release candidate actual pero **no debe fusionarse mientras ese SHA siga pendiente de publicación**, porque el workflow de release exige que `release_sha` sea exactamente el HEAD vigente de `develop`.

## RED candidato
Test-only SHA: `5809a33e30137cc33b5b450e1257b4910e8c24df`.

`e2e/public-structured-data.spec.ts` exige:
- `Service` exacto en `/soluciones/rehabilitacion` con URL/@id, nombre, descripción, categoría, provider Greenatics y audiencia;
- `Product` en `2Grow Sólido 15-3-3` con marca Wondergreen, familia, formulación, etapa y estado público;
- `Product` en `2Grow Líquido 200-0-0` preservando su estado técnico/no transaccional;
- ausencia explícita de `offers`, ratings y reviews;
- ausencia de SKU/GTIN/MPN inventados;
- ausencia de `Product.image` mientras el activo visible sea arte de línea y no packshot específico.

## Criterio SEO
Schema.org admite `Service` y `Product` para clasificación semántica. Google exige que structured data represente contenido visible; sus experiencias de merchant listing requieren que el producto sea comprable en la página. Esta PR no intentará fabricar elegibilidad mediante precio/stock/availability incompletos.

## Fuera de alcance
- Proyectos/casos como Article/CreativeWork;
- Offer/price/availability;
- Merchant Center;
- ratings/reviews;
- cambios visuales;
- producción.

Primero se certificará RED sobre el test-only SHA. Después se implementará únicamente el markup necesario.