### PR TITLE
fix(public): SEO exacto de fichas Wondergreen V2.11

### DIFF
--- a/e2e/wondergreen-product-seo.spec.ts
+++ b/e2e/wondergreen-product-seo.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+
+type ProductSeoCase = {
+  path: `/wondergreen/productos/${string}`;
+  title: string;
+  description: string;
+  breadcrumbName: string;
+};
+
+const products: ProductSeoCase[] = [
+  {
+    path: "/wondergreen/productos/2grow-solido-15-3-3",
+    title: "2Grow Sólido 15-3-3 | Wondergreen",
+    description: "Línea organomineral para establecimiento, brotación, crecimiento y recuperación vegetativa. Consulta formulación, presentaciones, estado público y documentación Wondergreen vinculada.",
+    breadcrumbName: "2Grow Sólido",
+  },
+  {
+    path: "/wondergreen/productos/2grow-liquido-200-0-0",
+    title: "2Grow Líquido · referencia nitrogenada 200-0-0 | Wondergreen",
+    description: "Referencia adicional con orientación nitrogenada dentro del portafolio técnico. Consulta formulación, presentaciones, estado público y documentación Wondergreen vinculada.",
+    breadcrumbName: "2Grow Líquido · referencia nitrogenada",
+  },
+];
+
+async function metaContent(page: import("@playwright/test").Page, selector: string) {
+  const element = page.locator(selector);
+  await expect(element).toHaveCount(1);
+  return element.getAttribute("content");
+}
+
+async function jsonLdByType(page: import("@playwright/test").Page, type: string) {
+  const payloads = await page.locator('script[type="application/ld+json"]').allTextContents();
+  return payloads
+    .map((payload) => JSON.parse(payload) as Record<string, unknown>)
+    .find((payload) => payload["@type"] === type);
+}
+
+for (const product of products) {
+  test(`exact Wondergreen product owns social metadata and breadcrumb: ${product.path}`, async ({ page }) => {
+    await page.goto(product.path);
+
+    const expectedUrl = new URL(product.path, "https://greenatics.com.co").toString();
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    expect(new URL((await canonical.getAttribute("href")) ?? "", expectedUrl).toString()).toBe(expectedUrl);
+
+    expect(await metaContent(page, 'meta[property="og:title"]')).toBe(product.title);
+    expect(await metaContent(page, 'meta[property="og:description"]')).toBe(product.description);
+    expect(new URL((await metaContent(page, 'meta[property="og:url"]')) ?? "").toString()).toBe(expectedUrl);
+    expect(await metaContent(page, 'meta[property="og:site_name"]')).toBe("Greenatics");
+    expect(await metaContent(page, 'meta[property="og:locale"]')).toBe("es_CO");
+    expect(await metaContent(page, 'meta[property="og:type"]')).toBe("website");
+
+    expect(await metaContent(page, 'meta[name="twitter:card"]')).toBe("summary");
+    expect(await metaContent(page, 'meta[name="twitter:title"]')).toBe(product.title);
+    expect(await metaContent(page, 'meta[name="twitter:description"]')).toBe(product.description);
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(0);
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveCount(0);
+
+    const breadcrumb = await jsonLdByType(page, "BreadcrumbList");
+    expect(breadcrumb).toBeTruthy();
+    expect(breadcrumb?.itemListElement).toEqual([
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Greenatics",
+        item: "https://greenatics.com.co/",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Wondergreen",
+        item: "https://greenatics.com.co/wondergreen",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "Productos",
+        item: "https://greenatics.com.co/wondergreen/productos",
+      },
+      {
+        "@type": "ListItem",
+        position: 4,
+        name: product.breadcrumbName,
+        item: expectedUrl,
+      },
+    ]);
+  });
+}

--- a/src/app/wondergreen/productos/[slug]/layout.tsx
+++ b/src/app/wondergreen/productos/[slug]/layout.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { getWondergreenReference } from "@/data/wondergreen-public";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Pick<Props, "params">): Promise<Metadata> {
+  const { slug } = await params;
+  const reference = getWondergreenReference(slug);
+  if (!reference) return {};
+
+  const title = `${reference.name}${reference.formula ? ` ${reference.formula}` : ""} | Wondergreen`;
+  const description = `${reference.role} Consulta formulación, presentaciones, estado público y documentación Wondergreen vinculada.`;
+  const path = `/wondergreen/productos/${reference.slug}` as `/${string}`;
+
+  return publicSocialMetadata({ title, description, path });
+}
+
+export default async function WondergreenProductLayout({ children, params }: Props) {
+  const { slug } = await params;
+  const reference = getWondergreenReference(slug);
+  if (!reference) return children;
+
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Wondergreen", path: "/wondergreen" },
+        { name: "Productos", path: "/wondergreen/productos" },
+        { name: reference.name, path: `/wondergreen/productos/${reference.slug}` as `/${string}` },
+      ]} />
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
Refs #279.

## Objetivo
Cerrar la brecha de descubrimiento/compartibilidad de las fichas exactas Wondergreen sin tocar contenido comercial, Product JSON-LD ni ecommerce.

## Base congelada
`develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`.

Esta PR **no debe fusionarse** mientras ese SHA siga reservado como release candidate pendiente, porque el workflow canónico exige `release_sha = HEAD actual de develop`.

## Hallazgo reproducido en código
`src/app/wondergreen/layout.tsx` publica metadata social genérica de `/wondergreen`. Las rutas `/wondergreen/productos/<slug>` tienen title/description/canonical propios en `page.tsx`, pero no un `layout.tsx` que sobrescriba Open Graph/Twitter ni emita `BreadcrumbList`.

## RED candidato
Test-only SHA: `24df62b5d92f54653e0c9d71fa26cc2bc0a714ea`.

`e2e/wondergreen-product-seo.spec.ts` exige, en una referencia comercial y una técnica:
- canonical exacto preservado;
- OG title/description/url exactos de la referencia;
- site name/locale/type gobernados;
- Twitter summary coherente;
- ausencia de `og:image`/Twitter image hasta #129 fase B;
- BreadcrumbList Greenatics → Wondergreen → Productos → referencia exacta.

## Fuera de alcance
- Product JSON-LD de #277/#278;
- Offer/precio/stock/availability/checkout;
- cambios visuales;
- imagen social;
- indexación;
- servicios/casos cubiertos por #274;
- producción.

Primero se certificará RED sobre el test-only SHA. Después la corrección se limitará a la capa metadata/breadcrumb de la ruta de producto.