### PR TITLE
feat(public): discovery social exacto en soluciones V2.12

### DIFF
--- a/e2e/public-solution-discovery.spec.ts
+++ b/e2e/public-solution-discovery.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+
+const publicOrigin = "https://greenatics.com.co";
+
+const routes = [
+  "/soluciones/esp",
+  "/soluciones/municipios",
+  "/soluciones/empresas",
+  "/soluciones/propiedad-horizontal",
+  "/soluciones/plantas",
+  "/soluciones/residuos-organicos",
+  "/soluciones/infraestructura-plantas",
+  "/soluciones/propiedad-horizontal-redes",
+  "/soluciones/programas/esp-ready",
+  "/soluciones/programas/greenatics-base",
+  "/soluciones/programas/pmirs-red",
+] as const;
+
+function normalizeUrl(value: string, base = publicOrigin) {
+  return new URL(value, base).toString();
+}
+
+for (const route of routes) {
+  test(`solution discovery metadata is route-specific: ${route}`, async ({ page }) => {
+    await page.goto(route);
+
+    const expectedUrl = normalizeUrl(route);
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    expect(normalizeUrl((await canonical.getAttribute("href")) ?? "")).toBe(expectedUrl);
+
+    const pageTitle = await page.title();
+    const description = (await page.locator('meta[name="description"]').getAttribute("content")) ?? "";
+    expect(pageTitle).not.toBe("");
+    expect(pageTitle).not.toContain("GREENATICS OPS");
+    expect(description).not.toBe("");
+
+    const ogTitle = page.locator('meta[property="og:title"]');
+    const ogDescription = page.locator('meta[property="og:description"]');
+    const ogUrl = page.locator('meta[property="og:url"]');
+    await expect(ogTitle).toHaveCount(1);
+    await expect(ogDescription).toHaveCount(1);
+    await expect(ogUrl).toHaveCount(1);
+    await expect(ogTitle).toHaveAttribute("content", pageTitle);
+    await expect(ogDescription).toHaveAttribute("content", description);
+    expect(normalizeUrl((await ogUrl.getAttribute("content")) ?? "")).toBe(expectedUrl);
+    await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute("content", "Greenatics");
+    await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute("content", "es_CO");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");
+
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute("content", "summary");
+    await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute("content", description);
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(0);
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveCount(0);
+
+    const jsonLdBlocks = await page.locator('script[type="application/ld+json"]').allTextContents();
+    const breadcrumb = jsonLdBlocks
+      .map((block) => JSON.parse(block) as { "@type"?: string; itemListElement?: Array<{ name?: string; item?: string }> })
+      .find((block) => block["@type"] === "BreadcrumbList");
+
+    expect(breadcrumb).toBeTruthy();
+    const items = breadcrumb?.itemListElement ?? [];
+    expect(items.length).toBeGreaterThanOrEqual(3);
+    const lastItem = items.at(-1);
+    expect(lastItem?.name).toBeTruthy();
+    expect(normalizeUrl(lastItem?.item ?? "")).toBe(expectedUrl);
+  });
+}

--- a/src/app/soluciones/empresas/page.tsx
+++ b/src/app/soluciones/empresas/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getAudienceLanding } from "@/data/audience-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getAudienceLanding("empresas");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Soluciones para empresas y grandes generadores | Greenatics",
   description: "Diagnóstico, PMIRS, separación, logística, tratamiento, infraestructura y trazabilidad para empresas y grandes generadores.",
-  alternates: { canonical: "/soluciones/empresas" },
-};
+  path: "/soluciones/empresas",
+});
 
 export default function EmpresasPage() {
   if (!landing) return null;

--- a/src/app/soluciones/esp/page.tsx
+++ b/src/app/soluciones/esp/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getAudienceLanding } from "@/data/audience-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getAudienceLanding("esp");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Soluciones para ESP y prestadores | Greenatics",
   description: "Preparación, rutas, operación, orgánicos, infraestructura, dirección técnica y datos para empresas de servicios públicos y prestadores.",
-  alternates: { canonical: "/soluciones/esp" },
-};
+  path: "/soluciones/esp",
+});
 
 export default function EspPage() {
   if (!landing) return null;

--- a/src/app/soluciones/infraestructura-plantas/page.tsx
+++ b/src/app/soluciones/infraestructura-plantas/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getIntentLanding } from "@/data/intent-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getIntentLanding("infraestructura-plantas");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Infraestructura y plantas de residuos | Greenatics",
   description: "Prefactibilidad, evaluación técnica, factibilidad, ingeniería, construcción, rehabilitación y operación de plantas de tratamiento y valorización.",
-  alternates: { canonical: "/soluciones/infraestructura-plantas" },
-};
+  path: "/soluciones/infraestructura-plantas",
+});
 
 export default function InfraestructuraPlantasPage() {
   if (!landing) return null;

--- a/src/app/soluciones/municipios/page.tsx
+++ b/src/app/soluciones/municipios/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getAudienceLanding } from "@/data/audience-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getAudienceLanding("municipios");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Soluciones para municipios | Greenatics",
   description: "Diagnóstico, PGIRS, programas de orgánicos, proyectos, activos, infraestructura y seguimiento técnico para municipios y entidades territoriales.",
-  alternates: { canonical: "/soluciones/municipios" },
-};
+  path: "/soluciones/municipios",
+});
 
 export default function MunicipiosPage() {
   if (!landing) return null;

--- a/src/app/soluciones/plantas/page.tsx
+++ b/src/app/soluciones/plantas/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getAudienceLanding } from "@/data/audience-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getAudienceLanding("plantas");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Soluciones para plantas y operadores | Greenatics",
   description: "Diagnóstico, rehabilitación, dirección técnica, trazabilidad, prefactibilidad e ingeniería para plantas, operadores y propietarios de infraestructura.",
-  alternates: { canonical: "/soluciones/plantas" },
-};
+  path: "/soluciones/plantas",
+});
 
 export default function PlantasPage() {
   if (!landing) return null;

--- a/src/app/soluciones/programas/[slug]/layout.tsx
+++ b/src/app/soluciones/programas/[slug]/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { getStrategicProgram } from "@/data/strategic-programs";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Pick<Props, "params">): Promise<Metadata> {
+  const { slug } = await params;
+  const program = getStrategicProgram(slug);
+  if (!program) return {};
+
+  const title = `${program.name} | Soluciones Greenatics`;
+  const description = program.summary;
+  const path = `/soluciones/programas/${program.slug}` as `/${string}`;
+
+  return publicSocialMetadata({ title, description, path });
+}
+
+export default function StrategicProgramSocialLayout({ children }: Props) {
+  return children;
+}

--- a/src/app/soluciones/propiedad-horizontal-redes/page.tsx
+++ b/src/app/soluciones/propiedad-horizontal-redes/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getIntentLanding } from "@/data/intent-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getIntentLanding("propiedad-horizontal-redes");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Residuos para propiedad horizontal y redes | Greenatics",
   description: "Línea base, planes internos, PMIRS RED, rutas, orgánicos y trazabilidad para propiedad horizontal, constructoras y redes multiunidad.",
-  alternates: { canonical: "/soluciones/propiedad-horizontal-redes" },
-};
+  path: "/soluciones/propiedad-horizontal-redes",
+});
 
 export default function PropiedadHorizontalRedesPage() {
   if (!landing) return null;

--- a/src/app/soluciones/propiedad-horizontal/page.tsx
+++ b/src/app/soluciones/propiedad-horizontal/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getAudienceLanding } from "@/data/audience-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getAudienceLanding("propiedad-horizontal");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Soluciones para propiedad horizontal e instituciones | Greenatics",
   description: "Diagnóstico, PMIRS, redes multiunidad, rutas, orgánicos, indicadores y seguimiento para propiedad horizontal, instituciones y redes de sedes.",
-  alternates: { canonical: "/soluciones/propiedad-horizontal" },
-};
+  path: "/soluciones/propiedad-horizontal",
+});
 
 export default function PropiedadHorizontalPage() {
   if (!landing) return null;

--- a/src/app/soluciones/residuos-organicos/page.tsx
+++ b/src/app/soluciones/residuos-organicos/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getIntentLanding } from "@/data/intent-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getIntentLanding("residuos-organicos");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Gestión de residuos orgánicos | Greenatics",
   description: "Diagnóstico, separación, rutas, captura, recolección, tratamiento, trazabilidad y prefactibilidad para residuos orgánicos.",
-  alternates: { canonical: "/soluciones/residuos-organicos" },
-};
+  path: "/soluciones/residuos-organicos",
+});
 
 export default function ResiduosOrganicosPage() {
   if (!landing) return null;

--- a/src/lib/public-page-metadata.ts
+++ b/src/lib/public-page-metadata.ts
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type PublicPageMetadataInput = {
+  title: string;
+  description: string;
+  path: `/${string}` | "/";
+};
+
+export function publicPageMetadata({ title, description, path }: PublicPageMetadataInput): Metadata {
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    ...publicSocialMetadata({ title, description, path }),
+  };
+}


### PR DESCRIPTION
Refs #281.

## Objetivo
Completar la identidad social de las 11 rutas comerciales canónicas de audiencias, intenciones y programas, sin tocar contenido, UI, breadcrumbs, sitemap, indexación ni OPS.

## Base congelada
`develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`.

**No fusionar** mientras ese SHA siga reservado como candidato pendiente de publicación gobernada.

## Cobertura
Audiencias: ESP, municipios, empresas, propiedad horizontal y plantas.

Intenciones: residuos orgánicos, infraestructura/plantas y propiedad horizontal/redes.

Programas: ESP READY, GREENATICS BASE y PMIRS RED.

## RED candidato
Test-only SHA: `7a50426fb60f9f85a264d6cd6171baeaaf1855b0`.

`e2e/public-solution-discovery.spec.ts` recorre las 11 rutas y exige:
- canonical exacto preservado;
- `og:title` = title real de la ruta;
- `og:description` = description real;
- `og:url` = canonical exacto;
- site name/locale/type gobernados;
- Twitter `summary` coherente;
- ausencia de imágenes sociales hasta #129 fase B;
- BreadcrumbList existente y cerrado en la URL exacta.

## Arquitectura prevista
Usar un helper pequeño para combinar title/description/canonical con `publicSocialMetadata()` y aplicarlo a las entradas canónicas. Los programas dinámicos seguirán derivando metadata desde `strategicPrograms`.

## Fuera de alcance
- #274 (HOME/servicios/casos social metadata);
- #278 (structured data Service/Product);
- #280 (SEO exacto de fichas Wondergreen);
- imágenes sociales;
- cambios de branding/contenido;
- producción.

Primero se certificará RED sobre el SHA test-only. Después se implementará GREEN en un único commit para evitar ruido de CI.