### PR TITLE
feat(public): cierre discovery social y breadcrumbs V2.13

### DIFF
--- a/e2e/public-discovery-closure.spec.ts
+++ b/e2e/public-discovery-closure.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+const publicOrigin = "https://greenatics.com.co";
+
+const routes = [
+  {
+    path: "/soluciones/diagnostico-inicial",
+    breadcrumb: ["Greenatics", "Soluciones", "Diagnóstico inicial"],
+  },
+  {
+    path: "/wondergreen/productos",
+    breadcrumb: ["Greenatics", "Wondergreen", "Productos"],
+  },
+  {
+    path: "/biblioteca/manual-uso-wondergreen",
+    breadcrumb: ["Greenatics", "Biblioteca", "Manual de uso Wondergreen"],
+  },
+  {
+    path: "/biblioteca/criterios-nutricionales",
+    breadcrumb: ["Greenatics", "Biblioteca", "Criterios de revisión nutricional"],
+  },
+] as const;
+
+function normalizeUrl(value: string, base = publicOrigin) {
+  return new URL(value, base).toString();
+}
+
+for (const route of routes) {
+  test(`public discovery closes social metadata and breadcrumb: ${route.path}`, async ({ page }) => {
+    await page.goto(route.path);
+
+    const expectedUrl = normalizeUrl(route.path);
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    expect(normalizeUrl((await canonical.getAttribute("href")) ?? "")).toBe(expectedUrl);
+
+    const pageTitle = await page.title();
+    const description = (await page.locator('meta[name="description"]').getAttribute("content")) ?? "";
+    expect(pageTitle).not.toBe("");
+    expect(description).not.toBe("");
+
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[property="og:description"]')).toHaveAttribute("content", description);
+    expect(normalizeUrl((await page.locator('meta[property="og:url"]').getAttribute("content")) ?? "")).toBe(expectedUrl);
+    await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute("content", "Greenatics");
+    await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute("content", "es_CO");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");
+
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute("content", "summary");
+    await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute("content", description);
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(0);
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveCount(0);
+
+    const jsonLdBlocks = await page.locator('script[type="application/ld+json"]').allTextContents();
+    const breadcrumb = jsonLdBlocks
+      .map((block) => JSON.parse(block) as { "@type"?: string; itemListElement?: Array<{ position?: number; name?: string; item?: string }> })
+      .find((block) => block["@type"] === "BreadcrumbList");
+
+    expect(breadcrumb).toBeTruthy();
+    const items = breadcrumb?.itemListElement ?? [];
+    expect(items).toHaveLength(route.breadcrumb.length);
+    expect(items.map((item) => item.position)).toEqual(route.breadcrumb.map((_, index) => index + 1));
+    expect(items.map((item) => item.name)).toEqual([...route.breadcrumb]);
+    expect(normalizeUrl(items.at(-1)?.item ?? "")).toBe(expectedUrl);
+  });
+}

--- a/src/app/biblioteca/criterios-nutricionales/page.tsx
+++ b/src/app/biblioteca/criterios-nutricionales/page.tsx
@@ -1,13 +1,19 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
 import { wondergreenCrops } from "@/data/wondergreen-crops";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import styles from "../library.module.css";
 
+const title = "Criterios de revisión nutricional | Greenatics";
+const description =
+  "Criterios técnicos para revisar suelo, etapa, densidad, historial de fertilización y objetivo productivo antes de orientar un programa Wondergreen.";
+
 export const metadata: Metadata = {
-  title: "Criterios de revisión nutricional | Greenatics",
-  description:
-    "Criterios técnicos para revisar suelo, etapa, densidad, historial de fertilización y objetivo productivo antes de orientar un programa Wondergreen.",
+  title,
+  description,
   alternates: { canonical: "/biblioteca/criterios-nutricionales" },
+  ...publicSocialMetadata({ title, description, path: "/biblioteca/criterios-nutricionales" }),
 };
 
 const criteria = [
@@ -21,6 +27,11 @@ const criteria = [
 export default function NutritionalReviewCriteriaPage() {
   return (
     <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Biblioteca", path: "/biblioteca" },
+        { name: "Criterios de revisión nutricional", path: "/biblioteca/criterios-nutricionales" },
+      ]} />
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>

--- a/src/app/biblioteca/manual-uso-wondergreen/page.tsx
+++ b/src/app/biblioteca/manual-uso-wondergreen/page.tsx
@@ -1,13 +1,19 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
 import { fieldApplicationRules, fieldChecklist } from "@/data/wondergreen-crops";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import styles from "../library.module.css";
 
+const title = "Manual de uso Wondergreen | Greenatics";
+const description =
+  "Ruta práctica para preparar, aplicar, registrar y hacer seguimiento al uso de Wondergreen sin convertir una guía general en una receta universal.";
+
 export const metadata: Metadata = {
-  title: "Manual de uso Wondergreen | Greenatics",
-  description:
-    "Ruta práctica para preparar, aplicar, registrar y hacer seguimiento al uso de Wondergreen sin convertir una guía general en una receta universal.",
+  title,
+  description,
   alternates: { canonical: "/biblioteca/manual-uso-wondergreen" },
+  ...publicSocialMetadata({ title, description, path: "/biblioteca/manual-uso-wondergreen" }),
 };
 
 const route = [
@@ -31,6 +37,11 @@ const avoid = [
 export default function WondergreenUseManualPage() {
   return (
     <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Biblioteca", path: "/biblioteca" },
+        { name: "Manual de uso Wondergreen", path: "/biblioteca/manual-uso-wondergreen" },
+      ]} />
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>

--- a/src/app/soluciones/diagnostico-inicial/page.tsx
+++ b/src/app/soluciones/diagnostico-inicial/page.tsx
@@ -1,17 +1,28 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import { DiagnosticRouter } from "./diagnostic-router";
 import styles from "./diagnostic-initial.module.css";
 
+const title = "Diagnóstico inicial | Greenatics";
+const description = "Orientador inicial para identificar contexto, necesidad y estado actual antes de elegir una solución Greenatics.";
+
 export const metadata: Metadata = {
-  title: "Diagnóstico inicial | Greenatics",
-  description: "Orientador inicial para identificar contexto, necesidad y estado actual antes de elegir una solución Greenatics.",
+  title,
+  description,
   alternates: { canonical: "/soluciones/diagnostico-inicial" },
+  ...publicSocialMetadata({ title, description, path: "/soluciones/diagnostico-inicial" }),
 };
 
 export default function InitialDiagnosticPage() {
   return (
     <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Soluciones", path: "/soluciones" },
+        { name: "Diagnóstico inicial", path: "/soluciones/diagnostico-inicial" },
+      ]} />
       <main>
         <section className={styles.hero}>
           <div className={styles.heroAccent} aria-hidden="true" />

--- a/src/app/wondergreen/productos/page.tsx
+++ b/src/app/wondergreen/productos/page.tsx
@@ -1,12 +1,18 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import { ProductCatalogBrowser } from "./product-catalog-browser";
 import styles from "./catalog.module.css";
 
+const title = "Productos Wondergreen | Portafolio técnico y comercial";
+const description = "Explora fertilizantes sólidos y líquidos Wondergreen por línea, formulación, presentación, estado comercial y documentación pública vinculada.";
+
 export const metadata: Metadata = {
-  title: "Productos Wondergreen | Portafolio técnico y comercial",
-  description: "Explora fertilizantes sólidos y líquidos Wondergreen por línea, formulación, presentación, estado comercial y documentación pública vinculada.",
+  title,
+  description,
   alternates: { canonical: "/wondergreen/productos" },
+  ...publicSocialMetadata({ title, description, path: "/wondergreen/productos" }),
 };
 
 export default function WondergreenProductsPage() {
@@ -14,6 +20,11 @@ export default function WondergreenProductsPage() {
 
   return (
     <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Wondergreen", path: "/wondergreen" },
+        { name: "Productos", path: "/wondergreen/productos" },
+      ]} />
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>


### PR DESCRIPTION
Refs #283.

## Objetivo
Cerrar metadata social y BreadcrumbList específicos en las cuatro rutas públicas indexables restantes detectadas por auditoría.

## Base congelada
`develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`.

**No fusionar** mientras ese SHA siga reservado como candidato pendiente de publicación gobernada.

## Rutas
- `/soluciones/diagnostico-inicial`
- `/wondergreen/productos`
- `/biblioteca/manual-uso-wondergreen`
- `/biblioteca/criterios-nutricionales`

## RED candidato
Test-only SHA: `e1acd38a0c190b1bd309d043d13abde5d8a3c843`.

`e2e/public-discovery-closure.spec.ts` exige por ruta:
- canonical exacto;
- OG title/description/url específicos;
- site name, locale y type gobernados;
- Twitter `summary` específico;
- ausencia de imágenes sociales en esta fase;
- BreadcrumbList de tres niveles con nombres, posiciones y URL final exactos.

## Arquitectura prevista
Mantener cada página como autoridad de su propia identidad: `publicSocialMetadata()` en metadata local y `BreadcrumbJsonLd` dentro de la superficie. No modificar layouts padres ni contenido visible.

## Fuera de alcance
Copy/UX, sitemap, indexación, imágenes sociales, Product Truth, OPS, backend, workflows y producción.

Primero se certifica RED sobre el SHA test-only; después se implementará GREEN mínimo.