### PR TITLE
fix(public): coherencia social de programas Wondergreen por cultivo V2.14

### DIFF
--- a/e2e/wondergreen-crop-seo.spec.ts
+++ b/e2e/wondergreen-crop-seo.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+
+const publicOrigin = "https://greenatics.com.co";
+
+const crops = [
+  ["cacao", "Cacao"],
+  ["cafe", "Café"],
+  ["aguacate", "Aguacate"],
+  ["limon-tahiti", "Limón Tahití"],
+  ["pastos-gramineas", "Pastos y gramíneas"],
+] as const;
+
+function normalizeUrl(value: string, base = publicOrigin) {
+  return new URL(value, base).toString();
+}
+
+for (const [slug, name] of crops) {
+  test(`crop SEO is exact: ${slug}`, async ({ page }) => {
+    const path = `/wondergreen/cultivos/${slug}`;
+    const expectedUrl = normalizeUrl(path);
+    await page.goto(path);
+
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    expect(normalizeUrl((await canonical.getAttribute("href")) ?? "")).toBe(expectedUrl);
+
+    const pageTitle = await page.title();
+    const description = (await page.locator('meta[name="description"]').getAttribute("content")) ?? "";
+    expect(pageTitle).toContain(name);
+    expect(description).not.toBe("");
+
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[property="og:description"]')).toHaveAttribute("content", description);
+    expect(normalizeUrl((await page.locator('meta[property="og:url"]').getAttribute("content")) ?? "")).toBe(expectedUrl);
+    await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute("content", "Greenatics");
+    await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute("content", "es_CO");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");
+
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute("content", "summary");
+    await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute("content", description);
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(0);
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveCount(0);
+
+    const jsonLdBlocks = await page.locator('script[type="application/ld+json"]').allTextContents();
+    const breadcrumb = jsonLdBlocks
+      .map((block) => JSON.parse(block) as { "@type"?: string; itemListElement?: Array<{ position?: number; name?: string; item?: string }> })
+      .find((block) => block["@type"] === "BreadcrumbList");
+
+    expect(breadcrumb).toBeTruthy();
+    const items = breadcrumb?.itemListElement ?? [];
+    expect(items).toHaveLength(4);
+    expect(items.map((item) => item.position)).toEqual([1, 2, 3, 4]);
+    expect(items.map((item) => item.name)).toEqual(["Greenatics", "Wondergreen", "Cultivos", name]);
+    expect(normalizeUrl(items.at(-1)?.item ?? "")).toBe(expectedUrl);
+  });
+}


### PR DESCRIPTION
Refs #285.

## Objetivo corregido
Cerrar la divergencia entre la descripción real de cada programa Wondergreen por cultivo y su `og:description`/`twitter:description`, preservando los canonical, OG URL y breadcrumbs exactos que el layout dinámico ya publica correctamente.

## Base congelada
`develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`.

**No fusionar** mientras ese SHA siga reservado como candidato pendiente de publicación gobernada.

## Hallazgo
`src/app/wondergreen/cultivos/[slug]/page.tsx` calcula la descripción según exista o no guía PDF publicada. El layout dinámico `[slug]/layout.tsx` ya resuelve canonical/social URL/breadcrumb, pero duplica una descripción genérica distinta. Por eso la misma ficha puede publicar una `meta description` y una descripción social diferentes.

## RED candidato
Test-only SHA: `1ed3add33e8681b8d3e046d1e27298bdab09982c`.

`e2e/wondergreen-crop-seo.spec.ts` recorre cacao, café, aguacate, limón Tahití y pastos/gramíneas y exige:
- canonical exacto preservado;
- OG title/description/url coherentes con la ficha real;
- site name/locale/type gobernados;
- Twitter `summary`, title y description específicos;
- ausencia deliberada de imágenes sociales;
- BreadcrumbList Greenatics → Wondergreen → Cultivos → cultivo exacto.

## Arquitectura prevista
Modificar únicamente `src/app/wondergreen/cultivos/[slug]/layout.tsx` para reutilizar la misma lógica guide-aware de descripción que ya usa `page.tsx`. No tocar la página visual ni contenidos agronómicos.

## Fuera de alcance
Recomendaciones, guías/PDF, Product Truth, Finder, UX, sitemap, indexación, imágenes sociales, OPS, backend, workflows y producción.

Primero se certifica RED sobre el SHA test-only; después se implementará GREEN mínimo.