### PR TITLE
feat(public): discovery exacto en rutas auxiliares V2.13

### DIFF
--- a/e2e/public-aux-discovery.spec.ts
+++ b/e2e/public-aux-discovery.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+
+const publicOrigin = "https://greenatics.com.co";
+
+const routes = [
+  {
+    path: "/soluciones/diagnostico-inicial",
+    breadcrumb: ["Greenatics", "Soluciones", "Diagnóstico inicial"],
+  },
+  {
+    path: "/wondergreen/productos",
+    breadcrumb: ["Greenatics", "Wondergreen", "Productos"],
+  },
+  {
+    path: "/biblioteca/manual-uso-wondergreen",
+    breadcrumb: ["Greenatics", "Biblioteca", "Manual de uso Wondergreen"],
+  },
+  {
+    path: "/biblioteca/criterios-nutricionales",
+    breadcrumb: ["Greenatics", "Biblioteca", "Criterios nutricionales"],
+  },
+] as const;
+
+function normalizeUrl(value: string, base = publicOrigin) {
+  return new URL(value, base).toString();
+}
+
+for (const route of routes) {
+  test(`auxiliary public discovery is route-specific: ${route.path}`, async ({ page }) => {
+    await page.goto(route.path);
+
+    const expectedUrl = normalizeUrl(route.path);
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    expect(normalizeUrl((await canonical.getAttribute("href")) ?? "")).toBe(expectedUrl);
+
+    const pageTitle = await page.title();
+    const description = (await page.locator('meta[name="description"]').getAttribute("content")) ?? "";
+    expect(pageTitle).not.toBe("");
+    expect(description).not.toBe("");
+
+    await expect(page.locator('meta[property="og:title"]')).toHaveCount(1);
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[property="og:description"]')).toHaveAttribute("content", description);
+    expect(normalizeUrl((await page.locator('meta[property="og:url"]').getAttribute("content")) ?? "")).toBe(expectedUrl);
+    await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute("content", "Greenatics");
+    await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute("content", "es_CO");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");
+
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute("content", "summary");
+    await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute("content", description);
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(0);
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveCount(0);
+
+    const jsonLdBlocks = await page.locator('script[type="application/ld+json"]').allTextContents();
+    const breadcrumbs = jsonLdBlocks
+      .map((block) => JSON.parse(block) as { "@type"?: string; itemListElement?: Array<{ name?: string; item?: string }> })
+      .filter((block) => block["@type"] === "BreadcrumbList");
+
+    expect(breadcrumbs).toHaveLength(1);
+    const items = breadcrumbs[0]?.itemListElement ?? [];
+    expect(items.map((item) => item.name)).toEqual(route.breadcrumb);
+    expect(normalizeUrl(items.at(-1)?.item ?? "")).toBe(expectedUrl);
+  });
+}

--- a/src/app/biblioteca/criterios-nutricionales/layout.tsx
+++ b/src/app/biblioteca/criterios-nutricionales/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const title = "Criterios de revisión nutricional | Greenatics";
+const description = "Criterios técnicos para revisar suelo, etapa, densidad, historial de fertilización y objetivo productivo antes de orientar un programa Wondergreen.";
+const path = "/biblioteca/criterios-nutricionales" as const;
+
+export const metadata: Metadata = {
+  ...publicSocialMetadata({ title, description, path }),
+};
+
+export default function NutritionalCriteriaDiscoveryLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Biblioteca", path: "/biblioteca" },
+        { name: "Criterios nutricionales", path },
+      ]} />
+      {children}
+    </>
+  );
+}

--- a/src/app/biblioteca/manual-uso-wondergreen/layout.tsx
+++ b/src/app/biblioteca/manual-uso-wondergreen/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const title = "Manual de uso Wondergreen | Greenatics";
+const description = "Ruta práctica para preparar, aplicar, registrar y hacer seguimiento al uso de Wondergreen sin convertir una guía general en una receta universal.";
+const path = "/biblioteca/manual-uso-wondergreen" as const;
+
+export const metadata: Metadata = {
+  ...publicSocialMetadata({ title, description, path }),
+};
+
+export default function WondergreenUseManualDiscoveryLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Biblioteca", path: "/biblioteca" },
+        { name: "Manual de uso Wondergreen", path },
+      ]} />
+      {children}
+    </>
+  );
+}

--- a/src/app/soluciones/diagnostico-inicial/layout.tsx
+++ b/src/app/soluciones/diagnostico-inicial/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const title = "Diagnóstico inicial | Greenatics";
+const description = "Orientador inicial para identificar contexto, necesidad y estado actual antes de elegir una solución Greenatics.";
+const path = "/soluciones/diagnostico-inicial" as const;
+
+export const metadata: Metadata = {
+  ...publicSocialMetadata({ title, description, path }),
+};
+
+export default function InitialDiagnosticDiscoveryLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Soluciones", path: "/soluciones" },
+        { name: "Diagnóstico inicial", path },
+      ]} />
+      {children}
+    </>
+  );
+}

--- a/src/app/wondergreen/productos/layout.tsx
+++ b/src/app/wondergreen/productos/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const title = "Productos Wondergreen | Portafolio técnico y comercial";
+const description = "Explora fertilizantes sólidos y líquidos Wondergreen por línea, formulación, presentación, estado comercial y documentación pública vinculada.";
+const path = "/wondergreen/productos" as const;
+
+export const metadata: Metadata = {
+  ...publicSocialMetadata({ title, description, path }),
+};
+
+export default function WondergreenProductsDiscoveryLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Wondergreen", path: "/wondergreen" },
+        { name: "Productos", path },
+      ]} />
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
Refs #287.

## Objetivo
Completar metadata social y BreadcrumbList específicos en cuatro rutas públicas indexables que hoy tienen canonical propio pero heredan identidad social del hub y no emiten breadcrumb exacto.

## Base congelada
`develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`.

**No fusionar** mientras ese SHA siga reservado como candidato pendiente de publicación gobernada.

## Rutas
- `/soluciones/diagnostico-inicial`
- `/wondergreen/productos`
- `/biblioteca/manual-uso-wondergreen`
- `/biblioteca/criterios-nutricionales`

## RED candidato
Test-only SHA: `8545732d83853535a268f389c927e59e9cdb333f`.

`e2e/public-aux-discovery.spec.ts` exige por ruta:
- canonical exacto preservado;
- OG title/description/url específicos;
- Twitter textual coherente;
- cero imagen social hasta #129 fase B;
- exactamente un BreadcrumbList con jerarquía y URL final exactas.

## Fuera de alcance
Contenido/UI, navegación, sitemap, indexación, OPS/backend, imágenes sociales, ecommerce y producción.

Primero se certificará RED sobre el SHA test-only. Después se implementará el cambio mínimo y se exigirá GREEN 4/4.