### PR TITLE
test(integration): certificar bundle público V2.9–V2.13

### DIFF
--- a/e2e/public-aux-discovery.spec.ts
+++ b/e2e/public-aux-discovery.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+
+const publicOrigin = "https://greenatics.com.co";
+
+const routes = [
+  {
+    path: "/soluciones/diagnostico-inicial",
+    breadcrumb: ["Greenatics", "Soluciones", "Diagnóstico inicial"],
+  },
+  {
+    path: "/wondergreen/productos",
+    breadcrumb: ["Greenatics", "Wondergreen", "Productos"],
+  },
+  {
+    path: "/biblioteca/manual-uso-wondergreen",
+    breadcrumb: ["Greenatics", "Biblioteca", "Manual de uso Wondergreen"],
+  },
+  {
+    path: "/biblioteca/criterios-nutricionales",
+    breadcrumb: ["Greenatics", "Biblioteca", "Criterios nutricionales"],
+  },
+] as const;
+
+function normalizeUrl(value: string, base = publicOrigin) {
+  return new URL(value, base).toString();
+}
+
+for (const route of routes) {
+  test(`auxiliary public discovery is route-specific: ${route.path}`, async ({ page }) => {
+    await page.goto(route.path);
+
+    const expectedUrl = normalizeUrl(route.path);
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    expect(normalizeUrl((await canonical.getAttribute("href")) ?? "")).toBe(expectedUrl);
+
+    const pageTitle = await page.title();
+    const description = (await page.locator('meta[name="description"]').getAttribute("content")) ?? "";
+    expect(pageTitle).not.toBe("");
+    expect(description).not.toBe("");
+
+    await expect(page.locator('meta[property="og:title"]')).toHaveCount(1);
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[property="og:description"]')).toHaveAttribute("content", description);
+    expect(normalizeUrl((await page.locator('meta[property="og:url"]').getAttribute("content")) ?? "")).toBe(expectedUrl);
+    await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute("content", "Greenatics");
+    await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute("content", "es_CO");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");
+
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute("content", "summary");
+    await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute("content", description);
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(0);
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveCount(0);
+
+    const jsonLdBlocks = await page.locator('script[type="application/ld+json"]').allTextContents();
+    const breadcrumbs = jsonLdBlocks
+      .map((block) => JSON.parse(block) as { "@type"?: string; itemListElement?: Array<{ name?: string; item?: string }> })
+      .filter((block) => block["@type"] === "BreadcrumbList");
+
+    expect(breadcrumbs).toHaveLength(1);
+    const items = breadcrumbs[0]?.itemListElement ?? [];
+    expect(items.map((item) => item.name)).toEqual(route.breadcrumb);
+    expect(normalizeUrl(items.at(-1)?.item ?? "")).toBe(expectedUrl);
+  });
+}

--- a/e2e/public-social.spec.ts
+++ b/e2e/public-social.spec.ts
@@ -1,8 +1,13 @@
 import { test, expect } from "@playwright/test";
 
 const routes = [
+  "/",
+  "/soluciones",
+  "/soluciones/rehabilitacion",
   "/soluciones/gestion-juridica-regulatoria",
   "/soluciones/valorizacion-productos",
+  "/proyectos",
+  "/proyectos/yarumal",
   "/wondergreen",
   "/wondergreen/tecnologia",
   "/wondergreen/cultivos",
@@ -18,12 +23,32 @@ const routes = [
 for (const route of routes) {
   test(`social metadata: ${route}`, async ({ page }) => {
     await page.goto(route);
-    const title = page.locator('meta[property="og:title"]');
-    await expect(title).toHaveCount(1);
-    expect((await title.getAttribute("content")) ?? "").not.toContain("GREENATICS OPS");
-    await expect(page.locator('meta[property="og:url"]')).toHaveAttribute("content", `https://greenatics.com.co${route}`);
+
+    const ogTitle = page.locator('meta[property="og:title"]');
+    const ogDescription = page.locator('meta[property="og:description"]');
+    const ogUrl = page.locator('meta[property="og:url"]');
+    const twitterTitle = page.locator('meta[name="twitter:title"]');
+    const twitterDescription = page.locator('meta[name="twitter:description"]');
+
+    await expect(ogTitle).toHaveCount(1);
+    await expect(ogDescription).toHaveCount(1);
+    await expect(ogUrl).toHaveCount(1);
+    await expect(twitterTitle).toHaveCount(1);
+    await expect(twitterDescription).toHaveCount(1);
+
+    const title = (await ogTitle.getAttribute("content")) ?? "";
+    const description = (await ogDescription.getAttribute("content")) ?? "";
+    const socialUrl = (await ogUrl.getAttribute("content")) ?? "";
+    expect(title).not.toContain("GREENATICS OPS");
+    expect(title.trim().length).toBeGreaterThan(0);
+    expect(description.trim().length).toBeGreaterThan(0);
+    await expect(twitterTitle).toHaveAttribute("content", title);
+    await expect(twitterDescription).toHaveAttribute("content", description);
+
+    expect(new URL(socialUrl).href).toBe(new URL(route, "https://greenatics.com.co").href);
     await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute("content", "Greenatics");
     await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute("content", "es_CO");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");
     await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute("content", "summary");
   });
 }

--- a/e2e/public-solution-discovery.spec.ts
+++ b/e2e/public-solution-discovery.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+
+const publicOrigin = "https://greenatics.com.co";
+
+const routes = [
+  "/soluciones/esp",
+  "/soluciones/municipios",
+  "/soluciones/empresas",
+  "/soluciones/propiedad-horizontal",
+  "/soluciones/plantas",
+  "/soluciones/residuos-organicos",
+  "/soluciones/infraestructura-plantas",
+  "/soluciones/propiedad-horizontal-redes",
+  "/soluciones/programas/esp-ready",
+  "/soluciones/programas/greenatics-base",
+  "/soluciones/programas/pmirs-red",
+] as const;
+
+function normalizeUrl(value: string, base = publicOrigin) {
+  return new URL(value, base).toString();
+}
+
+for (const route of routes) {
+  test(`solution discovery metadata is route-specific: ${route}`, async ({ page }) => {
+    await page.goto(route);
+
+    const expectedUrl = normalizeUrl(route);
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    expect(normalizeUrl((await canonical.getAttribute("href")) ?? "")).toBe(expectedUrl);
+
+    const pageTitle = await page.title();
+    const description = (await page.locator('meta[name="description"]').getAttribute("content")) ?? "";
+    expect(pageTitle).not.toBe("");
+    expect(pageTitle).not.toContain("GREENATICS OPS");
+    expect(description).not.toBe("");
+
+    const ogTitle = page.locator('meta[property="og:title"]');
+    const ogDescription = page.locator('meta[property="og:description"]');
+    const ogUrl = page.locator('meta[property="og:url"]');
+    await expect(ogTitle).toHaveCount(1);
+    await expect(ogDescription).toHaveCount(1);
+    await expect(ogUrl).toHaveCount(1);
+    await expect(ogTitle).toHaveAttribute("content", pageTitle);
+    await expect(ogDescription).toHaveAttribute("content", description);
+    expect(normalizeUrl((await ogUrl.getAttribute("content")) ?? "")).toBe(expectedUrl);
+    await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute("content", "Greenatics");
+    await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute("content", "es_CO");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");
+
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute("content", "summary");
+    await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute("content", description);
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(0);
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveCount(0);
+
+    const jsonLdBlocks = await page.locator('script[type="application/ld+json"]').allTextContents();
+    const breadcrumb = jsonLdBlocks
+      .map((block) => JSON.parse(block) as { "@type"?: string; itemListElement?: Array<{ name?: string; item?: string }> })
+      .find((block) => block["@type"] === "BreadcrumbList");
+
+    expect(breadcrumb).toBeTruthy();
+    const items = breadcrumb?.itemListElement ?? [];
+    expect(items.length).toBeGreaterThanOrEqual(3);
+    const lastItem = items.at(-1);
+    expect(lastItem?.name).toBeTruthy();
+    expect(normalizeUrl(lastItem?.item ?? "")).toBe(expectedUrl);
+  });
+}

--- a/e2e/public-structured-data.spec.ts
+++ b/e2e/public-structured-data.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+
+async function jsonLdByType(page: import("@playwright/test").Page, type: string) {
+  const payloads = await page.locator('script[type="application/ld+json"]').allTextContents();
+  return payloads
+    .map((payload) => JSON.parse(payload) as Record<string, unknown>)
+    .find((payload) => payload["@type"] === type);
+}
+
+function propertyValue(entity: Record<string, unknown> | undefined, name: string) {
+  const properties = Array.isArray(entity?.additionalProperty)
+    ? entity.additionalProperty as Record<string, unknown>[]
+    : [];
+  return properties.find((property) => property.name === name)?.value;
+}
+
+test("service detail emits exact non-transactional Service structured data", async ({ page }) => {
+  await page.goto("/soluciones/rehabilitacion");
+  const service = await jsonLdByType(page, "Service");
+
+  expect(service).toBeTruthy();
+  expect(service?.["@id"]).toBe("https://greenatics.com.co/soluciones/rehabilitacion#service");
+  expect(service?.name).toBe("Diagnóstico, rehabilitación y puesta en marcha de infraestructura existente");
+  expect(service?.description).toBe("Recuperamos plantas, composteras o sistemas subutilizados antes de recomendar reemplazarlos.");
+  expect(service?.url).toBe("https://greenatics.com.co/soluciones/rehabilitacion");
+  expect(service?.serviceType).toBe("Infraestructura");
+  expect(service?.provider).toEqual({ "@id": "https://greenatics.com.co/#organization" });
+  expect(service?.audience).toEqual({ "@type": "Audience", audienceType: "Ambos" });
+  expect(service?.offers).toBeUndefined();
+  expect(service?.aggregateRating).toBeUndefined();
+  expect(service?.review).toBeUndefined();
+});
+
+test("commercial Wondergreen reference emits descriptive Product data without inventing an Offer", async ({ page }) => {
+  await page.goto("/wondergreen/productos/2grow-solido-15-3-3");
+  const product = await jsonLdByType(page, "Product");
+
+  expect(product).toBeTruthy();
+  expect(product?.["@id"]).toBe("https://greenatics.com.co/wondergreen/productos/2grow-solido-15-3-3#product");
+  expect(product?.name).toBe("2Grow Sólido");
+  expect(product?.description).toBe("Línea organomineral para establecimiento, brotación, crecimiento y recuperación vegetativa.");
+  expect(product?.url).toBe("https://greenatics.com.co/wondergreen/productos/2grow-solido-15-3-3");
+  expect(product?.brand).toEqual({ "@type": "Brand", name: "Wondergreen" });
+  expect(product?.category).toBe("2Grow");
+  expect(propertyValue(product, "Formulación declarada")).toBe("15-3-3");
+  expect(propertyValue(product, "Momento / función")).toBe("Crecimiento vegetativo");
+  expect(propertyValue(product, "Estado público")).toBe("Estado comercial confirmado");
+  expect(product?.offers).toBeUndefined();
+  expect(product?.aggregateRating).toBeUndefined();
+  expect(product?.review).toBeUndefined();
+  expect(product?.image).toBeUndefined();
+  expect(product?.sku).toBeUndefined();
+  expect(product?.gtin).toBeUndefined();
+  expect(product?.mpn).toBeUndefined();
+});
+
+test("technical Wondergreen reference stays non-transactional in Product structured data", async ({ page }) => {
+  await page.goto("/wondergreen/productos/2grow-liquido-200-0-0");
+  const product = await jsonLdByType(page, "Product");
+
+  expect(product).toBeTruthy();
+  expect(product?.name).toBe("2Grow Líquido · referencia nitrogenada");
+  expect(product?.url).toBe("https://greenatics.com.co/wondergreen/productos/2grow-liquido-200-0-0");
+  expect(propertyValue(product, "Estado público")).toBe("Portafolio técnico · condición comercial por confirmar");
+  expect(product?.offers).toBeUndefined();
+  expect(product?.aggregateRating).toBeUndefined();
+  expect(product?.review).toBeUndefined();
+  expect(product?.image).toBeUndefined();
+});

--- a/e2e/wondergreen-product-seo.spec.ts
+++ b/e2e/wondergreen-product-seo.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+
+type ProductSeoCase = {
+  path: `/wondergreen/productos/${string}`;
+  title: string;
+  description: string;
+  breadcrumbName: string;
+};
+
+const products: ProductSeoCase[] = [
+  {
+    path: "/wondergreen/productos/2grow-solido-15-3-3",
+    title: "2Grow Sólido 15-3-3 | Wondergreen",
+    description: "Línea organomineral para establecimiento, brotación, crecimiento y recuperación vegetativa. Consulta formulación, presentaciones, estado público y documentación Wondergreen vinculada.",
+    breadcrumbName: "2Grow Sólido",
+  },
+  {
+    path: "/wondergreen/productos/2grow-liquido-200-0-0",
+    title: "2Grow Líquido · referencia nitrogenada 200-0-0 | Wondergreen",
+    description: "Referencia adicional con orientación nitrogenada dentro del portafolio técnico. Consulta formulación, presentaciones, estado público y documentación Wondergreen vinculada.",
+    breadcrumbName: "2Grow Líquido · referencia nitrogenada",
+  },
+];
+
+async function metaContent(page: import("@playwright/test").Page, selector: string) {
+  const element = page.locator(selector);
+  await expect(element).toHaveCount(1);
+  return element.getAttribute("content");
+}
+
+async function jsonLdByType(page: import("@playwright/test").Page, type: string) {
+  const payloads = await page.locator('script[type="application/ld+json"]').allTextContents();
+  return payloads
+    .map((payload) => JSON.parse(payload) as Record<string, unknown>)
+    .find((payload) => payload["@type"] === type);
+}
+
+for (const product of products) {
+  test(`exact Wondergreen product owns social metadata and breadcrumb: ${product.path}`, async ({ page }) => {
+    await page.goto(product.path);
+
+    const expectedUrl = new URL(product.path, "https://greenatics.com.co").toString();
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    expect(new URL((await canonical.getAttribute("href")) ?? "", expectedUrl).toString()).toBe(expectedUrl);
+
+    expect(await metaContent(page, 'meta[property="og:title"]')).toBe(product.title);
+    expect(await metaContent(page, 'meta[property="og:description"]')).toBe(product.description);
+    expect(new URL((await metaContent(page, 'meta[property="og:url"]')) ?? "").toString()).toBe(expectedUrl);
+    expect(await metaContent(page, 'meta[property="og:site_name"]')).toBe("Greenatics");
+    expect(await metaContent(page, 'meta[property="og:locale"]')).toBe("es_CO");
+    expect(await metaContent(page, 'meta[property="og:type"]')).toBe("website");
+
+    expect(await metaContent(page, 'meta[name="twitter:card"]')).toBe("summary");
+    expect(await metaContent(page, 'meta[name="twitter:title"]')).toBe(product.title);
+    expect(await metaContent(page, 'meta[name="twitter:description"]')).toBe(product.description);
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(0);
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveCount(0);
+
+    const breadcrumb = await jsonLdByType(page, "BreadcrumbList");
+    expect(breadcrumb).toBeTruthy();
+    expect(breadcrumb?.itemListElement).toEqual([
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Greenatics",
+        item: "https://greenatics.com.co/",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Wondergreen",
+        item: "https://greenatics.com.co/wondergreen",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "Productos",
+        item: "https://greenatics.com.co/wondergreen/productos",
+      },
+      {
+        "@type": "ListItem",
+        position: 4,
+        name: product.breadcrumbName,
+        item: expectedUrl,
+      },
+    ]);
+  });
+}

--- a/src/app/biblioteca/criterios-nutricionales/layout.tsx
+++ b/src/app/biblioteca/criterios-nutricionales/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const title = "Criterios de revisión nutricional | Greenatics";
+const description = "Criterios técnicos para revisar suelo, etapa, densidad, historial de fertilización y objetivo productivo antes de orientar un programa Wondergreen.";
+const path = "/biblioteca/criterios-nutricionales" as const;
+
+export const metadata: Metadata = {
+  ...publicSocialMetadata({ title, description, path }),
+};
+
+export default function NutritionalCriteriaDiscoveryLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Biblioteca", path: "/biblioteca" },
+        { name: "Criterios nutricionales", path },
+      ]} />
+      {children}
+    </>
+  );
+}

--- a/src/app/biblioteca/manual-uso-wondergreen/layout.tsx
+++ b/src/app/biblioteca/manual-uso-wondergreen/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const title = "Manual de uso Wondergreen | Greenatics";
+const description = "Ruta práctica para preparar, aplicar, registrar y hacer seguimiento al uso de Wondergreen sin convertir una guía general en una receta universal.";
+const path = "/biblioteca/manual-uso-wondergreen" as const;
+
+export const metadata: Metadata = {
+  ...publicSocialMetadata({ title, description, path }),
+};
+
+export default function WondergreenUseManualDiscoveryLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Biblioteca", path: "/biblioteca" },
+        { name: "Manual de uso Wondergreen", path },
+      ]} />
+      {children}
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,13 +4,18 @@ import Link from "next/link";
 import { HomeProjectEvidence } from "@/components/public-home-evidence-crops";
 import { PublicShell } from "@/components/public-shell";
 import { publicCommercialMethod } from "@/data/public-method";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import styles from "./public-home-v2.module.css";
 
+const title = "Greenatics | Transformamos residuos en vida";
+const description =
+  "Greenatics diseña e implementa soluciones de gestión integral de residuos que conectan planeación, infraestructura, operación, datos y valorización para devolver valor al territorio y a los sistemas productivos.";
+
 export const metadata: Metadata = {
-  title: "Greenatics | Transformamos residuos en vida",
-  description:
-    "Greenatics diseña e implementa soluciones de gestión integral de residuos que conectan planeación, infraestructura, operación, datos y valorización para devolver valor al territorio y a los sistemas productivos.",
+  title,
+  description,
   alternates: { canonical: "/" },
+  ...publicSocialMetadata({ title, description, path: "/" }),
 };
 
 const universes = [

--- a/src/app/proyectos/[slug]/layout.tsx
+++ b/src/app/proyectos/[slug]/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { getPublicProject } from "@/data/projects-public";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Omit<Props, "children">): Promise<Metadata> {
+  const { slug } = await params;
+  const project = getPublicProject(slug);
+  if (!project) return {};
+
+  const title = `${project.name} | Proyectos Greenatics`;
+  const description = project.summary;
+  const path = `/proyectos/${project.slug}` as `/${string}`;
+
+  return publicSocialMetadata({ title, description, path });
+}
+
+export default function ProjectSocialMetadataLayout({ children }: Props) {
+  return children;
+}

--- a/src/app/proyectos/layout.tsx
+++ b/src/app/proyectos/layout.tsx
@@ -1,4 +1,13 @@
+import type { Metadata } from "next";
 import { PublicShell } from "@/components/public-shell";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const title = "Proyectos | Greenatics";
+const description = "Casos documentados y aprendizajes Greenatics en operación, rehabilitación, tratamiento biológico, rutas selectivas y trazabilidad.";
+
+export const metadata: Metadata = {
+  ...publicSocialMetadata({ title, description, path: "/proyectos" }),
+};
 
 export default function ProjectsLayout({ children }: { children: React.ReactNode }) {
   return <PublicShell ownsMain={false}>{children}</PublicShell>;

--- a/src/app/soluciones/[slug]/layout.tsx
+++ b/src/app/soluciones/[slug]/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { getService } from "@/data/services";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Omit<Props, "children">): Promise<Metadata> {
+  const { slug } = await params;
+  const service = getService(slug);
+  if (!service) return {};
+
+  const title = `${service.name} | Greenatics`;
+  const description = service.summary;
+  const path = `/soluciones/${service.slug}` as `/${string}`;
+
+  return publicSocialMetadata({ title, description, path });
+}
+
+export default function ServiceSocialMetadataLayout({ children }: Props) {
+  return children;
+}

--- a/src/app/soluciones/[slug]/page.tsx
+++ b/src/app/soluciones/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { ServiceJsonLd } from "@/components/service-json-ld";
 import { publicProjects } from "@/data/projects-public";
 import { getService, services } from "@/data/services";
 import styles from "../solutions.module.css";
@@ -45,6 +46,7 @@ export default async function SolutionDetailPage({ params }: Props) {
         { name: "Soluciones", path: "/soluciones" },
         { name: service.name, path: servicePath },
       ]} />
+      <ServiceJsonLd service={service} />
       <main>
         <section className={styles.detailHero}>
           <div className={styles.heroAccent} aria-hidden="true" />

--- a/src/app/soluciones/diagnostico-inicial/layout.tsx
+++ b/src/app/soluciones/diagnostico-inicial/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const title = "Diagnóstico inicial | Greenatics";
+const description = "Orientador inicial para identificar contexto, necesidad y estado actual antes de elegir una solución Greenatics.";
+const path = "/soluciones/diagnostico-inicial" as const;
+
+export const metadata: Metadata = {
+  ...publicSocialMetadata({ title, description, path }),
+};
+
+export default function InitialDiagnosticDiscoveryLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Soluciones", path: "/soluciones" },
+        { name: "Diagnóstico inicial", path },
+      ]} />
+      {children}
+    </>
+  );
+}

--- a/src/app/soluciones/empresas/page.tsx
+++ b/src/app/soluciones/empresas/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getAudienceLanding } from "@/data/audience-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getAudienceLanding("empresas");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Soluciones para empresas y grandes generadores | Greenatics",
   description: "Diagnóstico, PMIRS, separación, logística, tratamiento, infraestructura y trazabilidad para empresas y grandes generadores.",
-  alternates: { canonical: "/soluciones/empresas" },
-};
+  path: "/soluciones/empresas",
+});
 
 export default function EmpresasPage() {
   if (!landing) return null;

--- a/src/app/soluciones/esp/page.tsx
+++ b/src/app/soluciones/esp/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getAudienceLanding } from "@/data/audience-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getAudienceLanding("esp");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Soluciones para ESP y prestadores | Greenatics",
   description: "Preparación, rutas, operación, orgánicos, infraestructura, dirección técnica y datos para empresas de servicios públicos y prestadores.",
-  alternates: { canonical: "/soluciones/esp" },
-};
+  path: "/soluciones/esp",
+});
 
 export default function EspPage() {
   if (!landing) return null;

--- a/src/app/soluciones/infraestructura-plantas/page.tsx
+++ b/src/app/soluciones/infraestructura-plantas/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getIntentLanding } from "@/data/intent-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getIntentLanding("infraestructura-plantas");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Infraestructura y plantas de residuos | Greenatics",
   description: "Prefactibilidad, evaluación técnica, factibilidad, ingeniería, construcción, rehabilitación y operación de plantas de tratamiento y valorización.",
-  alternates: { canonical: "/soluciones/infraestructura-plantas" },
-};
+  path: "/soluciones/infraestructura-plantas",
+});
 
 export default function InfraestructuraPlantasPage() {
   if (!landing) return null;

--- a/src/app/soluciones/municipios/page.tsx
+++ b/src/app/soluciones/municipios/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getAudienceLanding } from "@/data/audience-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getAudienceLanding("municipios");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Soluciones para municipios | Greenatics",
   description: "Diagnóstico, PGIRS, programas de orgánicos, proyectos, activos, infraestructura y seguimiento técnico para municipios y entidades territoriales.",
-  alternates: { canonical: "/soluciones/municipios" },
-};
+  path: "/soluciones/municipios",
+});
 
 export default function MunicipiosPage() {
   if (!landing) return null;

--- a/src/app/soluciones/page.tsx
+++ b/src/app/soluciones/page.tsx
@@ -3,14 +3,19 @@ import Image from "next/image";
 import Link from "next/link";
 import { publicCommercialMethod } from "@/data/public-method";
 import { getPrimaryProjectMedia } from "@/data/public-media";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
 import catalog from "./solutions-catalog.module.css";
 import styles from "./solutions-v2.module.css";
 
+const title = "Soluciones | Greenatics";
+const description =
+  "Servicios de planeación, regulación, logística, plantas, dirección técnica, operación, datos, valorización y caracterización para ESP, municipios, empresas, instituciones y operadores.";
+
 export const metadata: Metadata = {
-  title: "Soluciones | Greenatics",
-  description:
-    "Servicios de planeación, regulación, logística, plantas, dirección técnica, operación, datos, valorización y caracterización para ESP, municipios, empresas, instituciones y operadores.",
+  title,
+  description,
   alternates: { canonical: "/soluciones" },
+  ...publicSocialMetadata({ title, description, path: "/soluciones" }),
 };
 
 const audiences = [

--- a/src/app/soluciones/plantas/page.tsx
+++ b/src/app/soluciones/plantas/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getAudienceLanding } from "@/data/audience-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getAudienceLanding("plantas");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Soluciones para plantas y operadores | Greenatics",
   description: "Diagnóstico, rehabilitación, dirección técnica, trazabilidad, prefactibilidad e ingeniería para plantas, operadores y propietarios de infraestructura.",
-  alternates: { canonical: "/soluciones/plantas" },
-};
+  path: "/soluciones/plantas",
+});
 
 export default function PlantasPage() {
   if (!landing) return null;

--- a/src/app/soluciones/programas/[slug]/layout.tsx
+++ b/src/app/soluciones/programas/[slug]/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { getStrategicProgram } from "@/data/strategic-programs";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Pick<Props, "params">): Promise<Metadata> {
+  const { slug } = await params;
+  const program = getStrategicProgram(slug);
+  if (!program) return {};
+
+  const title = `${program.name} | Soluciones Greenatics`;
+  const description = program.summary;
+  const path = `/soluciones/programas/${program.slug}` as `/${string}`;
+
+  return publicSocialMetadata({ title, description, path });
+}
+
+export default function StrategicProgramSocialLayout({ children }: Props) {
+  return children;
+}

--- a/src/app/soluciones/propiedad-horizontal-redes/page.tsx
+++ b/src/app/soluciones/propiedad-horizontal-redes/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getIntentLanding } from "@/data/intent-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getIntentLanding("propiedad-horizontal-redes");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Residuos para propiedad horizontal y redes | Greenatics",
   description: "Línea base, planes internos, PMIRS RED, rutas, orgánicos y trazabilidad para propiedad horizontal, constructoras y redes multiunidad.",
-  alternates: { canonical: "/soluciones/propiedad-horizontal-redes" },
-};
+  path: "/soluciones/propiedad-horizontal-redes",
+});
 
 export default function PropiedadHorizontalRedesPage() {
   if (!landing) return null;

--- a/src/app/soluciones/propiedad-horizontal/page.tsx
+++ b/src/app/soluciones/propiedad-horizontal/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getAudienceLanding } from "@/data/audience-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getAudienceLanding("propiedad-horizontal");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Soluciones para propiedad horizontal e instituciones | Greenatics",
   description: "Diagnóstico, PMIRS, redes multiunidad, rutas, orgánicos, indicadores y seguimiento para propiedad horizontal, instituciones y redes de sedes.",
-  alternates: { canonical: "/soluciones/propiedad-horizontal" },
-};
+  path: "/soluciones/propiedad-horizontal",
+});
 
 export default function PropiedadHorizontalPage() {
   if (!landing) return null;

--- a/src/app/soluciones/residuos-organicos/page.tsx
+++ b/src/app/soluciones/residuos-organicos/page.tsx
@@ -1,14 +1,15 @@
 import type { Metadata } from "next";
 import { AudienceSolutionLanding } from "@/components/audience-solution-landing";
 import { getIntentLanding } from "@/data/intent-landings";
+import { publicPageMetadata } from "@/lib/public-page-metadata";
 
 const landing = getIntentLanding("residuos-organicos");
 
-export const metadata: Metadata = {
+export const metadata: Metadata = publicPageMetadata({
   title: "Gestión de residuos orgánicos | Greenatics",
   description: "Diagnóstico, separación, rutas, captura, recolección, tratamiento, trazabilidad y prefactibilidad para residuos orgánicos.",
-  alternates: { canonical: "/soluciones/residuos-organicos" },
-};
+  path: "/soluciones/residuos-organicos",
+});
 
 export default function ResiduosOrganicosPage() {
   if (!landing) return null;

--- a/src/app/wondergreen/productos/[slug]/layout.tsx
+++ b/src/app/wondergreen/productos/[slug]/layout.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { getWondergreenReference } from "@/data/wondergreen-public";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Pick<Props, "params">): Promise<Metadata> {
+  const { slug } = await params;
+  const reference = getWondergreenReference(slug);
+  if (!reference) return {};
+
+  const title = `${reference.name}${reference.formula ? ` ${reference.formula}` : ""} | Wondergreen`;
+  const description = `${reference.role} Consulta formulación, presentaciones, estado público y documentación Wondergreen vinculada.`;
+  const path = `/wondergreen/productos/${reference.slug}` as `/${string}`;
+
+  return publicSocialMetadata({ title, description, path });
+}
+
+export default async function WondergreenProductLayout({ children, params }: Props) {
+  const { slug } = await params;
+  const reference = getWondergreenReference(slug);
+  if (!reference) return children;
+
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Wondergreen", path: "/wondergreen" },
+        { name: "Productos", path: "/wondergreen/productos" },
+        { name: reference.name, path: `/wondergreen/productos/${reference.slug}` as `/${string}` },
+      ]} />
+      {children}
+    </>
+  );
+}

--- a/src/app/wondergreen/productos/[slug]/page.tsx
+++ b/src/app/wondergreen/productos/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { WondergreenProductJsonLd } from "@/components/wondergreen-product-json-ld";
 import {
   getWondergreenProductArtwork,
   getWondergreenProductCrops,
@@ -68,6 +69,7 @@ export default async function WondergreenProductPage({ params }: { params: Promi
 
   return (
     <div className={styles.page} data-tone={visualTone}>
+      <WondergreenProductJsonLd reference={reference} publicStatus={publicStatus} />
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>

--- a/src/app/wondergreen/productos/layout.tsx
+++ b/src/app/wondergreen/productos/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
 import { publicSocialMetadata } from "@/lib/public-social-metadata";
 
 const title = "Productos Wondergreen | Portafolio técnico y comercial";
@@ -11,14 +10,5 @@ export const metadata: Metadata = {
 };
 
 export default function WondergreenProductsDiscoveryLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <>
-      <BreadcrumbJsonLd items={[
-        { name: "Greenatics", path: "/" },
-        { name: "Wondergreen", path: "/wondergreen" },
-        { name: "Productos", path },
-      ]} />
-      {children}
-    </>
-  );
+  return children;
 }

--- a/src/app/wondergreen/productos/layout.tsx
+++ b/src/app/wondergreen/productos/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+const title = "Productos Wondergreen | Portafolio técnico y comercial";
+const description = "Explora fertilizantes sólidos y líquidos Wondergreen por línea, formulación, presentación, estado comercial y documentación pública vinculada.";
+const path = "/wondergreen/productos" as const;
+
+export const metadata: Metadata = {
+  ...publicSocialMetadata({ title, description, path }),
+};
+
+export default function WondergreenProductsDiscoveryLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Wondergreen", path: "/wondergreen" },
+        { name: "Productos", path },
+      ]} />
+      {children}
+    </>
+  );
+}

--- a/src/app/wondergreen/productos/page.tsx
+++ b/src/app/wondergreen/productos/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
 import { ProductCatalogBrowser } from "./product-catalog-browser";
 import styles from "./catalog.module.css";
 
@@ -14,6 +15,11 @@ export default function WondergreenProductsPage() {
 
   return (
     <div className={styles.page}>
+      <BreadcrumbJsonLd items={[
+        { name: "Greenatics", path: "/" },
+        { name: "Wondergreen", path: "/wondergreen" },
+        { name: "Productos", path: "/wondergreen/productos" },
+      ]} />
       <main>
         <section className={styles.hero}>
           <div className={`${styles.container} ${styles.heroGrid}`}>

--- a/src/components/service-json-ld.tsx
+++ b/src/components/service-json-ld.tsx
@@ -1,0 +1,26 @@
+import { JsonLd } from "@/components/json-ld";
+import { publicSite } from "@/data/public-site";
+import type { GreenaticsService } from "@/data/services";
+
+export function ServiceJsonLd({ service }: { service: GreenaticsService }) {
+  const url = new URL(`/soluciones/${service.slug}`, `${publicSite.publicDomainTarget}/`).toString();
+
+  return (
+    <JsonLd
+      data={{
+        "@context": "https://schema.org",
+        "@type": "Service",
+        "@id": `${url}#service`,
+        name: service.name,
+        description: service.summary,
+        url,
+        serviceType: service.category,
+        provider: { "@id": `${publicSite.publicDomainTarget}/#organization` },
+        audience: {
+          "@type": "Audience",
+          audienceType: service.audience,
+        },
+      }}
+    />
+  );
+}

--- a/src/components/wondergreen-product-json-ld.tsx
+++ b/src/components/wondergreen-product-json-ld.tsx
@@ -1,0 +1,40 @@
+import { JsonLd } from "@/components/json-ld";
+import { publicSite } from "@/data/public-site";
+import type { WondergreenReference } from "@/data/wondergreen-public";
+
+export function WondergreenProductJsonLd({
+  reference,
+  publicStatus,
+}: {
+  reference: WondergreenReference;
+  publicStatus: string;
+}) {
+  const url = new URL(
+    `/wondergreen/productos/${reference.slug}`,
+    `${publicSite.publicDomainTarget}/`,
+  ).toString();
+
+  const additionalProperty = [
+    ...(reference.formula
+      ? [{ "@type": "PropertyValue", name: "Formulación declarada", value: reference.formula }]
+      : []),
+    { "@type": "PropertyValue", name: "Momento / función", value: reference.stage },
+    { "@type": "PropertyValue", name: "Estado público", value: publicStatus },
+  ];
+
+  return (
+    <JsonLd
+      data={{
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "@id": `${url}#product`,
+        name: reference.name,
+        description: reference.role,
+        url,
+        brand: { "@type": "Brand", name: "Wondergreen" },
+        category: reference.family,
+        additionalProperty,
+      }}
+    />
+  );
+}

--- a/src/lib/public-page-metadata.ts
+++ b/src/lib/public-page-metadata.ts
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { publicSocialMetadata } from "@/lib/public-social-metadata";
+
+type PublicPageMetadataInput = {
+  title: string;
+  description: string;
+  path: `/${string}` | "/";
+};
+
+export function publicPageMetadata({ title, description, path }: PublicPageMetadataInput): Metadata {
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    ...publicSocialMetadata({ title, description, path }),
+  };
+}


### PR DESCRIPTION
Closes #289 only when the frozen bundle is explicitly promoted.

## Base congelada
`develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`

## Composición sintética
Se aplicaron los blobs finales certificados, sin reimplementar contenido, desde:
- #274 — metadata social fase A — `03c237e3bed37e007abcaebb1cfaac943403583d`
- #278 — structured data Service/Product — `d15125700bdf4c008c1355e0d0e6d8f597c160b8`
- #280 — SEO exacto fichas Wondergreen — `19fea38bd236895d69ae78f8bd5f9a539283bf5e`
- #282 — discovery social de rutas de solución — `cece2111ced286071f65a42c6f6406dcc720d523`
- #288 — discovery de rutas auxiliares — `653fa65c1885f8c3cc0efcf923891968352c2ba4`

Composición inicial: **29 paths, 0 solapamientos**, commit `954b5f979d4701455a6d3def318fb5975f963391`.

## Hallazgo de integración
La primera matriz detectó una interacción entre #280 y #288: el layout padre de `/wondergreen/productos` aportaba un `BreadcrumbList` de 3 niveles a las fichas, que ya tenían su breadcrumb exacto de 4 niveles. Eso produjo dos trails en las rutas de producto.

Corrección mínima de integración, commit `6926b6995c23f5980b2538ad9550c436c5deb7e3`:
- el layout padre conserva únicamente metadata social;
- el breadcrumb de 3 niveles se renderiza solo en `/wondergreen/productos`;
- cada ficha conserva un único breadcrumb de 4 niveles.

Diff final: **30 paths, 2 commits**.

## Certificación final
Run #959 (`33000148499`) sobre el head exacto `6926b6995c23f5980b2538ad9550c436c5deb7e3`:
- quality ✅
- database / RLS ✅
- desktop Chromium ✅
- mobile Chromium ✅

La suite incluye metadata social, structured data, breadcrumbs, hydration OPS y release/deployment-readiness.

## Restricciones preservadas
- `develop` no se mueve;
- PRs fuente no se cierran;
- no se despliega;
- producción permanece intacta hasta promoción explícita y gobernada.