### PR TITLE
fix(public): alinear metadata social de cultivos Wondergreen

### DIFF
--- a/e2e/wondergreen-crop-social.spec.ts
+++ b/e2e/wondergreen-crop-social.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+const publicOrigin = "https://greenatics.com.co";
+const cropSlugs = ["cacao", "cafe", "aguacate", "limon-tahiti", "pastos-gramineas"] as const;
+
+function normalizeUrl(value: string, base = publicOrigin) {
+  return new URL(value, base).toString();
+}
+
+for (const slug of cropSlugs) {
+  const route = `/wondergreen/cultivos/${slug}`;
+
+  test(`Wondergreen crop social metadata matches the exact page metadata: ${route}`, async ({ page }) => {
+    await page.goto(route);
+
+    const expectedUrl = normalizeUrl(route);
+    const pageTitle = await page.title();
+    const description = (await page.locator('meta[name="description"]').getAttribute("content")) ?? "";
+
+    expect(pageTitle).not.toBe("");
+    expect(description).not.toBe("");
+
+    const canonical = page.locator('link[rel="canonical"]');
+    await expect(canonical).toHaveCount(1);
+    expect(normalizeUrl((await canonical.getAttribute("href")) ?? "")).toBe(expectedUrl);
+
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[property="og:description"]')).toHaveAttribute("content", description);
+    expect(normalizeUrl((await page.locator('meta[property="og:url"]').getAttribute("content")) ?? "")).toBe(expectedUrl);
+    await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute("content", "Greenatics");
+    await expect(page.locator('meta[property="og:locale"]')).toHaveAttribute("content", "es_CO");
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");
+
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute("content", "summary");
+    await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute("content", pageTitle);
+    await expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute("content", description);
+    await expect(page.locator('meta[property="og:image"]')).toHaveCount(0);
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveCount(0);
+
+    const jsonLdBlocks = await page.locator('script[type="application/ld+json"]').allTextContents();
+    const breadcrumbs = jsonLdBlocks
+      .map((block) => JSON.parse(block) as { "@type"?: string; itemListElement?: Array<{ name?: string; item?: string }> })
+      .filter((block) => block["@type"] === "BreadcrumbList");
+
+    expect(breadcrumbs).toHaveLength(1);
+    const items = breadcrumbs[0]?.itemListElement ?? [];
+    expect(items).toHaveLength(4);
+    expect(items.slice(0, 3).map((item) => item.name)).toEqual(["Greenatics", "Wondergreen", "Cultivos"]);
+    expect(items.at(-1)?.name).toBeTruthy();
+    expect(normalizeUrl(items.at(-1)?.item ?? "")).toBe(expectedUrl);
+  });
+}

--- a/src/app/wondergreen/cultivos/[slug]/layout.tsx
+++ b/src/app/wondergreen/cultivos/[slug]/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { BreadcrumbJsonLd } from "@/components/breadcrumb-json-ld";
+import { getWondergreenCropDocument } from "@/data/wondergreen-crop-documents";
 import { getWondergreenCrop } from "@/data/wondergreen-crops";
 import { publicSocialMetadata } from "@/lib/public-social-metadata";
 
@@ -12,8 +13,11 @@ export async function generateMetadata({ params }: Pick<Props, "params">): Promi
   const { slug } = await params;
   const crop = getWondergreenCrop(slug);
   if (!crop) return {};
+  const guide = getWondergreenCropDocument(slug);
   const title = `${crop.name} | Programa Wondergreen`;
-  const description = `${crop.headline} Programa orientativo por etapa, contexto del lote y seguimiento.`;
+  const description = guide
+    ? `${crop.headline} Consulta el programa navegable y abre la guía Wondergreen completa en PDF.`
+    : `${crop.headline} Programa por etapa, contexto del lote y seguimiento.`;
   const path = `/wondergreen/cultivos/${crop.slug}` as `/${string}`;
   return {
     alternates: { canonical: path },


### PR DESCRIPTION
Closes #285 only when explicitly promoted.

## Base congelada
`develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`

## RED
Commit test-only `bf105fb647fd34d282c9fdc60a2838e3e1493aff` añadió contrato para:
- `/wondergreen/cultivos/cacao`
- `/wondergreen/cultivos/cafe`
- `/wondergreen/cultivos/aguacate`
- `/wondergreen/cultivos/limon-tahiti`
- `/wondergreen/cultivos/pastos-gramineas`

El run #958 confirmó una divergencia real entre la `meta description` guide-aware de la página y `og:description`/`twitter:description` del layout dinámico.

## Corrección
Commit `2f92df484800d7099915645c93208d841ae2ef9d` hace que el layout consulte el mismo estado de guía PDF y use exactamente la misma descripción con/sin guía que `page.tsx`.

No modifica:
- contenido agronómico;
- canonical;
- breadcrumb de 4 niveles;
- política de imágenes sociales.

## Certificación final
Run #960 (`33000575237`) sobre el head exacto `2f92df484800d7099915645c93208d841ae2ef9d`:
- quality ✅
- database / RLS ✅
- desktop Chromium ✅
- mobile Chromium ✅

## Restricciones preservadas
- `develop` permanece en `9de516df1b3ce7eeedd59db500bbc858551e86c4`;
- PR en draft;
- sin merge;
- sin despliegue.