### PR TITLE
feat(public): captura gobernada de consultas comerciales

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,12 @@ NEXT_PUBLIC_DATA_MODE=local
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 
-# Server-only key required for user invitations/bootstrap. Never expose it through NEXT_PUBLIC_* variables.
+# Server-only key required for user invitations/bootstrap and governed public lead persistence. Never expose it through NEXT_PUBLIC_* variables.
 SUPABASE_SECRET_KEY=
+
+# Optional dedicated HMAC secret for public lead rate-limit fingerprints.
+# If omitted, the server falls back to SUPABASE_SECRET_KEY. Never expose it through NEXT_PUBLIC_* variables.
+PUBLIC_LEAD_RATE_LIMIT_SECRET=
 
 # Canonical public origin used for auth redirects, for example https://greenatics.com.co.
 # Production must configure it explicitly; server code never trusts the request Host header.

--- a/e2e/public-company-contact.spec.ts
+++ b/e2e/public-company-contact.spec.ts
@@ -21,7 +21,7 @@ test("contact page starts with context without forcing diagnosis or a service na
   await expect(page.getByRole("heading", { name: /Cuatro datos pueden llevar la conversación mucho más rápido/i })).toBeVisible();
   await expect(page.getByLabel("¿Desde qué contexto nos escribes?")).toBeVisible();
   await expect(page.getByLabel("¿Qué necesitas resolver primero?")).toBeVisible();
-  await expect(page.getByText(/Este paso no envía información a Greenatics/i)).toBeVisible();
+  await expect(page.getByText(/Puedes preparar y copiar el contexto sin enviarlo/i)).toBeVisible();
   await expect(page.getByRole("link", { name: /Preparar conversación/i }).first()).toHaveAttribute("href", /\/contacto\?audience=/);
   await expect(page.getByRole("heading", { name: "Si ya sabes qué necesitas, podemos empezar por ahí." })).toBeVisible();
   await expect(page.getByRole("link", { name: "Explorar servicios", exact: true })).toHaveAttribute("href", "/soluciones");

--- a/e2e/public-leads.spec.ts
+++ b/e2e/public-leads.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+
+test("contact keeps preparation and booking while adding a real governed consultation path", async ({ page }) => {
+  await page.goto("/contacto?audience=planta&need=operacion");
+
+  await expect(page.getByLabel("Nombre")).toBeVisible();
+  await expect(page.getByLabel("Correo electrónico")).toBeVisible();
+  await expect(page.getByLabel("Teléfono")).toBeVisible();
+  await expect(page.getByLabel("Organización")).toBeVisible();
+  await expect(page.getByLabel(/Autorizo a Greenatics/i)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Enviar consulta", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Preparar contexto", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Agendar reunión", exact: true }).first()).toBeVisible();
+  await expect(page.getByText(/Este paso no envía información a Greenatics/i)).toHaveCount(0);
+  await expect(page.getByText(/No incluyas secretos industriales, datos personales sensibles ni documentación confidencial/i)).toBeVisible();
+});
+
+test("public consultation posts PII only in the request body and preserves inherited commercial context", async ({ page }) => {
+  const service = "Dirección técnica y coordinación de operación";
+  const captured: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+  await page.route("**/api/public-leads", async (route) => {
+    const request = route.request();
+    captured.push({ url: request.url(), body: request.postDataJSON() as Record<string, unknown> });
+    await route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.goto(`/contacto?audience=planta&need=operacion&service=${encodeURIComponent(service)}&contexto=${encodeURIComponent("Interés en fortalecer una planta existente.")}`);
+  await page.getByLabel("Nombre").fill("Ana Pérez");
+  await page.getByLabel("Correo electrónico").fill("ana@example.com");
+  await page.getByLabel("Teléfono").fill("+57 300 555 1212");
+  await page.getByLabel("Organización").fill("ESP Ejemplo");
+  await page.getByLabel("Ubicación").fill("Antioquia");
+  await page.getByLabel("Describe brevemente la situación").fill("Queremos fortalecer la operación sin reemplazar infraestructura útil.");
+  await page.getByLabel(/Autorizo a Greenatics/i).check();
+  await page.getByRole("button", { name: "Enviar consulta", exact: true }).click();
+
+  await expect(page.getByText(/Consulta enviada/i)).toBeVisible();
+  expect(captured).toHaveLength(1);
+  const submission = captured[0]!;
+  expect(submission.url).toMatch(/\/api\/public-leads$/);
+  expect(submission.url).not.toContain("ana@example.com");
+  expect(submission.url).not.toContain("Ana%20P");
+  expect(submission.body).toMatchObject({
+    name: "Ana Pérez",
+    email: "ana@example.com",
+    phone: "+57 300 555 1212",
+    organization: "ESP Ejemplo",
+    audience: "planta",
+    need: "operacion",
+    location: "Antioquia",
+    service,
+    context: "Interés en fortalecer una planta existente.",
+    details: "Queremos fortalecer la operación sin reemplazar infraestructura útil.",
+    consent: true,
+  });
+  expect(submission.body.requestId).toEqual(expect.any(String));
+});
+
+test("public consultation requires a contact channel before it sends", async ({ page }) => {
+  let requests = 0;
+  await page.route("**/api/public-leads", async (route) => {
+    requests += 1;
+    await route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.goto("/contacto?audience=empresa&need=diagnostico");
+  await page.getByLabel("Nombre").fill("Laura Gómez");
+  await page.getByLabel(/Autorizo a Greenatics/i).check();
+  await page.getByRole("button", { name: "Enviar consulta", exact: true }).click();
+
+  await expect(page.getByText(/correo o teléfono/i)).toBeVisible();
+  expect(requests).toBe(0);
+});
+
+test("public consultation handles server rate limiting without losing the booking route", async ({ page }) => {
+  await page.route("**/api/public-leads", async (route) => {
+    await route.fulfill({ status: 429, contentType: "application/json", body: JSON.stringify({ ok: false, code: "rate_limited" }) });
+  });
+
+  await page.goto("/contacto?audience=wondergreen&need=nutricion");
+  await page.getByLabel("Nombre").fill("Carlos Ruiz");
+  await page.getByLabel("Correo electrónico").fill("carlos@example.com");
+  await page.getByLabel(/Autorizo a Greenatics/i).check();
+  await page.getByRole("button", { name: "Enviar consulta", exact: true }).click();
+
+  await expect(page.getByText(/demasiados intentos|intenta más tarde/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: "Agendar reunión", exact: true }).first()).toBeVisible();
+});

--- a/src/app/api/admin/public-leads/route.ts
+++ b/src/app/api/admin/public-leads/route.ts
@@ -1,6 +1,9 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient, isSupabaseAdminConfigured } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
+
+const allowedStatuses = new Set(["new", "contacted", "closed", "discarded"]);
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function noStoreJson(body: unknown, status = 200) {
   const response = NextResponse.json(body, { status });
@@ -8,7 +11,7 @@ function noStoreJson(body: unknown, status = 200) {
   return response;
 }
 
-async function canReadPublicLeads() {
+async function canManagePublicLeads() {
   if (!isSupabaseAdminConfigured()) return false;
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -25,21 +28,71 @@ async function canReadPublicLeads() {
   return Boolean(data?.length);
 }
 
+async function authorize() {
+  if (!isSupabaseAdminConfigured()) return noStoreJson({ error: "Admin backend no configurado." }, 503);
+  if (!(await canManagePublicLeads())) return noStoreJson({ error: "No autorizado." }, 403);
+  return null;
+}
+
 export async function GET() {
-  if (!isSupabaseAdminConfigured()) {
-    return noStoreJson({ error: "Admin backend no configurado." }, 503);
-  }
-  if (!(await canReadPublicLeads())) {
-    return noStoreJson({ error: "No autorizado." }, 403);
-  }
+  const denied = await authorize();
+  if (denied) return denied;
 
   const admin = createAdminClient();
   const { data, error } = await admin
     .from("public_leads")
-    .select("id,status,name,email,phone,organization,role_title,audience,need,location,service,product,crop,context,details,consent_at,created_at,retention_expires_at")
+    .select("id,status,name,email,phone,organization,role_title,audience,need,location,service,product,crop,context,details,consent_at,created_at,updated_at,retention_expires_at")
     .order("created_at", { ascending: false })
     .limit(100);
 
   if (error) return noStoreJson({ error: "No fue posible consultar las solicitudes." }, 500);
   return noStoreJson({ leads: data ?? [] });
+}
+
+export async function PATCH(request: NextRequest) {
+  const denied = await authorize();
+  if (denied) return denied;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return noStoreJson({ error: "Solicitud inválida." }, 400);
+  }
+  const input = body && typeof body === "object" ? body as Record<string, unknown> : {};
+  const id = typeof input.id === "string" ? input.id : "";
+  const status = typeof input.status === "string" ? input.status : "";
+  if (!uuidPattern.test(id) || !allowedStatuses.has(status)) return noStoreJson({ error: "Solicitud inválida." }, 400);
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("public_leads")
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .select("id,status,updated_at")
+    .maybeSingle();
+  if (error) return noStoreJson({ error: "No fue posible actualizar la solicitud." }, 500);
+  if (!data) return noStoreJson({ error: "Solicitud no encontrada." }, 404);
+  return noStoreJson({ lead: data });
+}
+
+export async function DELETE(request: NextRequest) {
+  const denied = await authorize();
+  if (denied) return denied;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return noStoreJson({ error: "Solicitud inválida." }, 400);
+  }
+  const input = body && typeof body === "object" ? body as Record<string, unknown> : {};
+  const id = typeof input.id === "string" ? input.id : "";
+  if (!uuidPattern.test(id)) return noStoreJson({ error: "Solicitud inválida." }, 400);
+
+  const admin = createAdminClient();
+  const { data, error } = await admin.from("public_leads").delete().eq("id", id).select("id").maybeSingle();
+  if (error) return noStoreJson({ error: "No fue posible eliminar la solicitud." }, 500);
+  if (!data) return noStoreJson({ error: "Solicitud no encontrada." }, 404);
+  return noStoreJson({ ok: true });
 }

--- a/src/app/api/admin/public-leads/route.ts
+++ b/src/app/api/admin/public-leads/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { createAdminClient, isSupabaseAdminConfigured } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+
+function noStoreJson(body: unknown, status = 200) {
+  const response = NextResponse.json(body, { status });
+  response.headers.set("Cache-Control", "private, no-store");
+  return response;
+}
+
+async function canReadPublicLeads() {
+  if (!isSupabaseAdminConfigured()) return false;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return false;
+
+  const { data, error } = await supabase
+    .from("plant_memberships")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("active", true)
+    .in("role", ["admin", "director"])
+    .limit(1);
+  if (error) return false;
+  return Boolean(data?.length);
+}
+
+export async function GET() {
+  if (!isSupabaseAdminConfigured()) {
+    return noStoreJson({ error: "Admin backend no configurado." }, 503);
+  }
+  if (!(await canReadPublicLeads())) {
+    return noStoreJson({ error: "No autorizado." }, 403);
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("public_leads")
+    .select("id,status,name,email,phone,organization,role_title,audience,need,location,service,product,crop,context,details,consent_at,created_at,retention_expires_at")
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  if (error) return noStoreJson({ error: "No fue posible consultar las solicitudes." }, 500);
+  return noStoreJson({ leads: data ?? [] });
+}

--- a/src/app/api/public-leads/route.ts
+++ b/src/app/api/public-leads/route.ts
@@ -1,0 +1,96 @@
+import { createHmac } from "node:crypto";
+import { Buffer } from "node:buffer";
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient, isSupabaseAdminConfigured } from "@/lib/supabase/admin";
+import { validatePublicLeadSubmission } from "@/lib/public-leads";
+
+export const runtime = "nodejs";
+const MAX_BODY_BYTES = 16 * 1024;
+
+function noStoreJson(body: unknown, status: number) {
+  const response = NextResponse.json(body, { status });
+  response.headers.set("Cache-Control", "private, no-store");
+  return response;
+}
+
+function requestFingerprint(request: NextRequest) {
+  const secret = process.env.PUBLIC_LEAD_RATE_LIMIT_SECRET || process.env.SUPABASE_SECRET_KEY;
+  if (!secret) return null;
+  const forwarded = request.headers.get("x-vercel-forwarded-for")
+    || request.headers.get("x-forwarded-for")
+    || request.headers.get("x-real-ip")
+    || "unknown";
+  const clientAddress = forwarded.split(",")[0]?.trim().slice(0, 128) || "unknown";
+  return createHmac("sha256", secret).update(clientAddress).digest("hex");
+}
+
+export async function POST(request: NextRequest) {
+  if (!isSupabaseAdminConfigured()) {
+    return noStoreJson({ ok: false, code: "service_unavailable" }, 503);
+  }
+
+  const declaredLength = Number(request.headers.get("content-length") || "0");
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_BODY_BYTES) {
+    return noStoreJson({ ok: false, code: "payload_too_large" }, 413);
+  }
+
+  let rawBody = "";
+  try {
+    rawBody = await request.text();
+  } catch {
+    return noStoreJson({ ok: false, code: "invalid_payload" }, 400);
+  }
+  if (Buffer.byteLength(rawBody, "utf8") > MAX_BODY_BYTES) {
+    return noStoreJson({ ok: false, code: "payload_too_large" }, 413);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return noStoreJson({ ok: false, code: "invalid_payload" }, 400);
+  }
+
+  const validation = validatePublicLeadSubmission(payload);
+  if (!validation.ok) {
+    return noStoreJson({ ok: false, code: validation.code }, 400);
+  }
+
+  // Honeypot: present a normal success shape to automated submissions without storing PII.
+  if (validation.value.website) {
+    return noStoreJson({ ok: true }, 201);
+  }
+
+  const fingerprint = requestFingerprint(request);
+  if (!fingerprint) {
+    return noStoreJson({ ok: false, code: "service_unavailable" }, 503);
+  }
+
+  const admin = createAdminClient();
+  const { error } = await admin.rpc("submit_public_lead_service", {
+    p_request_id: validation.value.requestId,
+    p_request_fingerprint: fingerprint,
+    p_name: validation.value.name,
+    p_email: validation.value.email ?? null,
+    p_phone: validation.value.phone ?? null,
+    p_organization: validation.value.organization ?? null,
+    p_role_title: validation.value.roleTitle ?? null,
+    p_audience: validation.value.audience,
+    p_need: validation.value.need,
+    p_location: validation.value.location ?? null,
+    p_service: validation.value.service ?? null,
+    p_product: validation.value.product ?? null,
+    p_crop: validation.value.crop ?? null,
+    p_context: validation.value.context ?? null,
+    p_details: validation.value.details ?? null,
+  });
+
+  if (error) {
+    if (error.message.includes("PUBLIC_LEAD_RATE_LIMIT")) {
+      return noStoreJson({ ok: false, code: "rate_limited" }, 429);
+    }
+    return noStoreJson({ ok: false, code: "submission_failed" }, 500);
+  }
+
+  return noStoreJson({ ok: true }, 201);
+}

--- a/src/app/contacto/contact-context-builder.tsx
+++ b/src/app/contacto/contact-context-builder.tsx
@@ -206,7 +206,7 @@ export function ContactContextBuilder({ bookingUrl, initialAudience = "", initia
       </label>
 
       <div className={styles.actions}>
-        <button className={`${styles.button} ${styles.primary}`} type="submit" disabled={submitState === "submitting" || submitState === "success"}>{submitState === "submitting" ? "Enviando…" : submitState === "success" ? "Consulta enviada" : "Enviar consulta"}</button>
+        <button className={`${styles.button} ${styles.primary}`} type="submit" disabled={submitState === "submitting" || submitState === "success"}>{submitState === "submitting" ? "Enviando…" : submitState === "success" ? "Enviado" : "Enviar consulta"}</button>
         <button className={`${styles.button} ${styles.ghost}`} type="button" onClick={prepareContext}>Preparar contexto</button>
         <a className={`${styles.button} ${styles.ghost}`} href={bookingUrl} target="_blank" rel="noreferrer">Agendar sin preparar</a>
       </div>
@@ -215,7 +215,7 @@ export function ContactContextBuilder({ bookingUrl, initialAudience = "", initia
       {prepared ? (
         <div className={styles.prepared} aria-live="polite">
           <h3>Contexto preparado.</h3>
-          <p>Úsalo como guía al agendar o al iniciar la conversación. Nada se ha enviado todavía por esta acción.</p>
+          <p>Úsalo como guía al agendar o al iniciar la conversación. Nada se ha enviado todavía. Esta acción solo prepara el resumen local.</p>
           <textarea className={styles.summary} value={summary} readOnly aria-label="Resumen preparado para la conversación" />
           <div className={styles.actions}><button className={`${styles.button} ${styles.ghost}`} type="button" onClick={copySummary}>Copiar contexto</button><a className={`${styles.button} ${styles.primary}`} href={bookingUrl} target="_blank" rel="noreferrer">Agendar reunión</a></div>
           <div className={styles.copyStatus} aria-live="polite">{copyStatus}</div>

--- a/src/app/contacto/contact-context-builder.tsx
+++ b/src/app/contacto/contact-context-builder.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { publicLeadValidationMessage, validatePublicLeadSubmission } from "@/lib/public-leads";
 import styles from "./contact-v2.module.css";
 
 type ContactContextBuilderProps = {
@@ -44,12 +45,22 @@ function optionLabel(options: readonly (readonly [string, string])[], value: str
 }
 
 export function ContactContextBuilder({ bookingUrl, initialAudience = "", initialNeed = "", initialService, initialProduct, initialCrop, initialContext }: ContactContextBuilderProps) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [organization, setOrganization] = useState("");
+  const [roleTitle, setRoleTitle] = useState("");
   const [audience, setAudience] = useState(initialAudience);
   const [need, setNeed] = useState(initialNeed);
   const [location, setLocation] = useState("");
   const [details, setDetails] = useState("");
+  const [consent, setConsent] = useState(false);
+  const [website, setWebsite] = useState("");
   const [prepared, setPrepared] = useState(false);
   const [copyStatus, setCopyStatus] = useState("");
+  const [submitState, setSubmitState] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [submitMessage, setSubmitMessage] = useState("");
+  const requestIdRef = useRef<string | null>(null);
 
   const summary = useMemo(() => {
     const lines = [
@@ -74,9 +85,90 @@ export function ContactContextBuilder({ bookingUrl, initialAudience = "", initia
     }
   }
 
+  function prepareContext() {
+    setPrepared(true);
+    setCopyStatus("");
+  }
+
+  async function submitLead(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitState === "submitting" || submitState === "success") return;
+    if (!requestIdRef.current) requestIdRef.current = window.crypto.randomUUID();
+
+    const validation = validatePublicLeadSubmission({
+      requestId: requestIdRef.current,
+      name,
+      email,
+      phone,
+      organization,
+      roleTitle,
+      audience,
+      need,
+      location,
+      service: initialService,
+      product: initialProduct,
+      crop: initialCrop,
+      context: initialContext,
+      details,
+      consent,
+      website,
+    });
+
+    if (!validation.ok) {
+      setSubmitState("error");
+      setSubmitMessage(publicLeadValidationMessage(validation.code));
+      return;
+    }
+
+    setSubmitState("submitting");
+    setSubmitMessage("Enviando consulta…");
+    try {
+      const response = await fetch("/api/public-leads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(validation.value),
+      });
+      if (response.ok) {
+        setSubmitState("success");
+        setSubmitMessage("Consulta enviada. Greenatics recibió tu contexto. Si prefieres, también puedes agendar una reunión.");
+        return;
+      }
+      if (response.status === 429) {
+        setSubmitState("error");
+        setSubmitMessage("Recibimos demasiados intentos desde esta conexión. Intenta más tarde o usa la agenda directa.");
+        return;
+      }
+      setSubmitState("error");
+      setSubmitMessage("No pudimos enviar la consulta. Puedes intentarlo de nuevo o usar la agenda directa.");
+    } catch {
+      setSubmitState("error");
+      setSubmitMessage("No pudimos conectar con el canal de consultas. Puedes intentarlo de nuevo o usar la agenda directa.");
+    }
+  }
+
   return (
-    <form className={styles.form} onSubmit={(event) => { event.preventDefault(); setPrepared(true); setCopyStatus(""); }}>
+    <form className={styles.form} onSubmit={submitLead}>
       <div className={styles.fields}>
+        <div className={styles.field}>
+          <label htmlFor="contact-name">Nombre</label>
+          <input id="contact-name" value={name} onChange={(event) => setName(event.target.value)} autoComplete="name" maxLength={120} required />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="contact-email">Correo electrónico</label>
+          <input id="contact-email" type="email" value={email} onChange={(event) => setEmail(event.target.value)} autoComplete="email" maxLength={254} placeholder="nombre@organizacion.com" />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="contact-phone">Teléfono</label>
+          <input id="contact-phone" type="tel" value={phone} onChange={(event) => setPhone(event.target.value)} autoComplete="tel" maxLength={40} placeholder="+57 300 000 0000" />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="contact-organization">Organización</label>
+          <input id="contact-organization" value={organization} onChange={(event) => setOrganization(event.target.value)} autoComplete="organization" maxLength={180} placeholder="Empresa, entidad, finca o proyecto" />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="contact-role">Rol / cargo</label>
+          <input id="contact-role" value={roleTitle} onChange={(event) => setRoleTitle(event.target.value)} autoComplete="organization-title" maxLength={120} />
+        </div>
         <div className={styles.field}>
           <label htmlFor="contact-audience">¿Desde qué contexto nos escribes?</label>
           <select id="contact-audience" value={audience} onChange={(event) => setAudience(event.target.value)} required>
@@ -91,23 +183,39 @@ export function ContactContextBuilder({ bookingUrl, initialAudience = "", initia
         </div>
         <div className={styles.field}>
           <label htmlFor="contact-location">Ubicación</label>
-          <input id="contact-location" value={location} onChange={(event) => setLocation(event.target.value)} placeholder="Municipio, ciudad o zona" />
+          <input id="contact-location" value={location} onChange={(event) => setLocation(event.target.value)} maxLength={180} placeholder="Municipio, ciudad o zona" />
         </div>
         <div className={styles.field}>
           <label htmlFor="contact-details">Describe brevemente la situación</label>
-          <textarea id="contact-details" value={details} onChange={(event) => setDetails(event.target.value)} placeholder="Qué ocurre hoy, qué información tienes y qué decisión necesitas tomar." />
+          <textarea id="contact-details" value={details} onChange={(event) => setDetails(event.target.value)} maxLength={1500} placeholder="Qué ocurre hoy, qué información tienes y qué decisión necesitas tomar." />
         </div>
+      </div>
+
+      <div className={styles.honeypotField} aria-hidden="true">
+        <label htmlFor="contact-website">Sitio web</label>
+        <input id="contact-website" value={website} onChange={(event) => setWebsite(event.target.value)} tabIndex={-1} autoComplete="off" />
       </div>
 
       {initialService ? <p className={styles.formHelp} aria-label="Servicio recibido de la navegación"><strong>Servicio de interés:</strong> {initialService}</p> : null}
       {initialContext ? <p className={styles.formHelp} aria-label="Contexto recibido de la navegación"><strong>Contexto recibido de la navegación:</strong> {initialContext}</p> : null}
-      <p className={styles.formHelp}>Este paso no envía información a Greenatics ni la guarda en un servidor. Solo organiza el contexto en tu navegador para que llegues mejor preparado a la conversación.</p>
-      <div className={styles.actions}><button className={`${styles.button} ${styles.primary}`} type="submit">Preparar contexto</button><a className={`${styles.button} ${styles.ghost}`} href={bookingUrl} target="_blank" rel="noreferrer">Agendar sin preparar</a></div>
+      <p className={styles.formHelp}>Puedes preparar y copiar el contexto sin enviarlo. Si eliges <strong>Enviar consulta</strong>, Greenatics recibirá los datos de contacto y el contexto que ves en este formulario.</p>
+      <p className={styles.formHelp}><strong>Aviso de privacidad.</strong> Usaremos estos datos para gestionar esta consulta y su seguimiento comercial. Si no se establece una relación, la retención inicial es de hasta 180 días. No incluyas secretos industriales, datos personales sensibles ni documentación confidencial en este primer contacto.</p>
+      <label className={styles.consentRow}>
+        <input type="checkbox" checked={consent} onChange={(event) => setConsent(event.target.checked)} required />
+        <span>Autorizo a Greenatics a usar estos datos para responder esta consulta y gestionar su seguimiento comercial.</span>
+      </label>
+
+      <div className={styles.actions}>
+        <button className={`${styles.button} ${styles.primary}`} type="submit" disabled={submitState === "submitting" || submitState === "success"}>{submitState === "submitting" ? "Enviando…" : submitState === "success" ? "Consulta enviada" : "Enviar consulta"}</button>
+        <button className={`${styles.button} ${styles.ghost}`} type="button" onClick={prepareContext}>Preparar contexto</button>
+        <a className={`${styles.button} ${styles.ghost}`} href={bookingUrl} target="_blank" rel="noreferrer">Agendar sin preparar</a>
+      </div>
+      <div className={submitState === "success" ? styles.submitSuccess : styles.submitStatus} aria-live="polite">{submitMessage}</div>
 
       {prepared ? (
         <div className={styles.prepared} aria-live="polite">
           <h3>Contexto preparado.</h3>
-          <p>Úsalo como guía al agendar o al iniciar la conversación. Nada se ha enviado todavía.</p>
+          <p>Úsalo como guía al agendar o al iniciar la conversación. Nada se ha enviado todavía por esta acción.</p>
           <textarea className={styles.summary} value={summary} readOnly aria-label="Resumen preparado para la conversación" />
           <div className={styles.actions}><button className={`${styles.button} ${styles.ghost}`} type="button" onClick={copySummary}>Copiar contexto</button><a className={`${styles.button} ${styles.primary}`} href={bookingUrl} target="_blank" rel="noreferrer">Agendar reunión</a></div>
           <div className={styles.copyStatus} aria-live="polite">{copyStatus}</div>

--- a/src/app/contacto/contact-v2.module.css
+++ b/src/app/contacto/contact-v2.module.css
@@ -32,6 +32,7 @@
 .lead { margin-top: 28px; max-width: 760px; color: #4d5a53; font-size: clamp(1.06rem, 1.5vw, 1.26rem); line-height: 1.68; }
 .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 28px; }
 .button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; padding: 0 20px; border: 1px solid transparent; border-radius: 4px; font: inherit; font-size: .8rem; font-weight: 800; letter-spacing: .045em; text-transform: uppercase; cursor: pointer; }
+.button:disabled { cursor: default; opacity: .72; }
 .primary { background: var(--green); color: white !important; }
 .ghost { border-color: var(--line); background: transparent; }
 .light { background: var(--paper); color: var(--forest-deep) !important; }
@@ -58,13 +59,19 @@
 .builderGrid { display: grid; grid-template-columns: minmax(0,1fr) minmax(360px,.78fr); gap: 64px; align-items: start; }
 .builderIntro p { margin-top: 22px; color: var(--muted); line-height: 1.75; }
 .builderNote { margin-top: 28px; padding: 18px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); color: #59665f; font-size: .84rem; line-height: 1.65; }
-.form { padding: 30px; background: white; border: 1px solid var(--line); }
+.form { position: relative; padding: 30px; background: white; border: 1px solid var(--line); }
 .fields { display: grid; gap: 18px; }
 .field { display: grid; gap: 8px; }
 .field label { color: var(--forest); font-size: .76rem; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
 .field input, .field select, .field textarea { width: 100%; border: 1px solid rgba(24,36,31,.25); border-radius: 3px; background: var(--paper); padding: 13px 14px; color: var(--ink); font: inherit; }
 .field textarea { min-height: 130px; resize: vertical; }
 .formHelp { margin-top: 14px; color: var(--muted); font-size: .78rem; line-height: 1.6; }
+.consentRow { margin-top: 18px; display: grid; grid-template-columns: 20px 1fr; gap: 10px; align-items: start; color: #536159; font-size: .8rem; line-height: 1.55; cursor: pointer; }
+.consentRow input { width: 18px; height: 18px; margin: 2px 0 0; accent-color: var(--green); }
+.honeypotField { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap; }
+.submitStatus, .submitSuccess { min-height: 22px; margin-top: 12px; font-size: .8rem; font-weight: 700; line-height: 1.5; }
+.submitStatus { color: #8b3f2d; }
+.submitSuccess { color: var(--green); }
 .prepared { margin-top: 24px; padding: 22px; background: #edf3e5; border-left: 5px solid var(--green); }
 .prepared h3 { font-size: 1.65rem; }
 .prepared p { margin-top: 10px; color: #4f5c55; line-height: 1.65; }

--- a/src/lib/public-leads.test.ts
+++ b/src/lib/public-leads.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { validatePublicLeadSubmission } from "./public-leads";
+
+const base = {
+  requestId: "550e8400-e29b-41d4-a716-446655440000",
+  name: "Ana Pérez",
+  email: "ana@example.com",
+  audience: "planta",
+  need: "operacion",
+  consent: true,
+};
+
+describe("public lead validation", () => {
+  it("accepts and normalizes a valid governed submission", () => {
+    const result = validatePublicLeadSubmission({
+      ...base,
+      email: " ANA@EXAMPLE.COM ",
+      organization: " ESP Ejemplo ",
+      context: " Interés heredado ",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.email).toBe("ana@example.com");
+    expect(result.value.organization).toBe("ESP Ejemplo");
+    expect(result.value.context).toBe("Interés heredado");
+  });
+
+  it("requires at least one contact channel", () => {
+    const result = validatePublicLeadSubmission({ ...base, email: "", phone: "" });
+    expect(result).toEqual({ ok: false, code: "contact_required" });
+  });
+
+  it("rejects consent gaps and unknown public taxonomy", () => {
+    expect(validatePublicLeadSubmission({ ...base, consent: false })).toEqual({ ok: false, code: "consent_required" });
+    expect(validatePublicLeadSubmission({ ...base, audience: "internal-admin" })).toEqual({ ok: false, code: "invalid_audience" });
+    expect(validatePublicLeadSubmission({ ...base, need: "secret" })).toEqual({ ok: false, code: "invalid_need" });
+  });
+
+  it("rejects malformed ids, email and oversized context", () => {
+    expect(validatePublicLeadSubmission({ ...base, requestId: "retry-1" })).toEqual({ ok: false, code: "invalid_request_id" });
+    expect(validatePublicLeadSubmission({ ...base, email: "not-an-email" })).toEqual({ ok: false, code: "invalid_email" });
+    expect(validatePublicLeadSubmission({ ...base, context: "x".repeat(481) })).toEqual({ ok: false, code: "field_too_long" });
+  });
+});

--- a/src/lib/public-leads.test.ts
+++ b/src/lib/public-leads.test.ts
@@ -25,9 +25,9 @@ describe("public lead validation", () => {
     expect(result.value.context).toBe("Interés heredado");
   });
 
-  it("requires at least one contact channel", () => {
-    const result = validatePublicLeadSubmission({ ...base, email: "", phone: "" });
-    expect(result).toEqual({ ok: false, code: "contact_required" });
+  it("requires at least one valid contact channel", () => {
+    expect(validatePublicLeadSubmission({ ...base, email: "", phone: "" })).toEqual({ ok: false, code: "contact_required" });
+    expect(validatePublicLeadSubmission({ ...base, email: "", phone: "123" })).toEqual({ ok: false, code: "invalid_phone" });
   });
 
   it("rejects consent gaps and unknown public taxonomy", () => {

--- a/src/lib/public-leads.ts
+++ b/src/lib/public-leads.ts
@@ -1,0 +1,115 @@
+export const publicLeadAudiences = ["esp", "municipio", "empresa", "ph", "planta", "wondergreen", "otro"] as const;
+export const publicLeadNeeds = ["diagnostico", "planeacion", "regulacion", "rutas", "planta", "operacion", "datos", "valorizacion", "nutricion", "distribucion", "otro"] as const;
+
+export type PublicLeadSubmission = {
+  requestId: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  organization?: string;
+  roleTitle?: string;
+  audience: (typeof publicLeadAudiences)[number];
+  need: (typeof publicLeadNeeds)[number];
+  location?: string;
+  service?: string;
+  product?: string;
+  crop?: string;
+  context?: string;
+  details?: string;
+  consent: true;
+  website?: string;
+};
+
+export type PublicLeadValidationCode =
+  | "invalid_payload"
+  | "invalid_request_id"
+  | "name_required"
+  | "invalid_email"
+  | "contact_required"
+  | "invalid_audience"
+  | "invalid_need"
+  | "consent_required"
+  | "field_too_long";
+
+type ValidationResult =
+  | { ok: true; value: PublicLeadSubmission }
+  | { ok: false; code: PublicLeadValidationCode };
+
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function cleanOptional(value: unknown, max: number) {
+  if (typeof value !== "string") return { value: undefined as string | undefined, tooLong: false };
+  const cleaned = value.trim();
+  if (!cleaned) return { value: undefined as string | undefined, tooLong: false };
+  return { value: cleaned, tooLong: cleaned.length > max };
+}
+
+export function validatePublicLeadSubmission(input: unknown): ValidationResult {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return { ok: false, code: "invalid_payload" };
+  const raw = input as Record<string, unknown>;
+  const requestId = typeof raw.requestId === "string" ? raw.requestId.trim() : "";
+  if (!uuidPattern.test(requestId)) return { ok: false, code: "invalid_request_id" };
+
+  const name = typeof raw.name === "string" ? raw.name.trim() : "";
+  if (name.length < 2) return { ok: false, code: "name_required" };
+  if (name.length > 120) return { ok: false, code: "field_too_long" };
+
+  const emailResult = cleanOptional(raw.email, 254);
+  const phoneResult = cleanOptional(raw.phone, 40);
+  if (emailResult.tooLong || phoneResult.tooLong) return { ok: false, code: "field_too_long" };
+  if (emailResult.value && !emailPattern.test(emailResult.value)) return { ok: false, code: "invalid_email" };
+  if (!emailResult.value && !phoneResult.value) return { ok: false, code: "contact_required" };
+
+  const audience = typeof raw.audience === "string" ? raw.audience : "";
+  if (!publicLeadAudiences.includes(audience as PublicLeadSubmission["audience"])) return { ok: false, code: "invalid_audience" };
+  const need = typeof raw.need === "string" ? raw.need : "";
+  if (!publicLeadNeeds.includes(need as PublicLeadSubmission["need"])) return { ok: false, code: "invalid_need" };
+  if (raw.consent !== true) return { ok: false, code: "consent_required" };
+
+  const organization = cleanOptional(raw.organization, 180);
+  const roleTitle = cleanOptional(raw.roleTitle, 120);
+  const location = cleanOptional(raw.location, 180);
+  const service = cleanOptional(raw.service, 180);
+  const product = cleanOptional(raw.product, 180);
+  const crop = cleanOptional(raw.crop, 120);
+  const context = cleanOptional(raw.context, 480);
+  const details = cleanOptional(raw.details, 1500);
+  const website = cleanOptional(raw.website, 200);
+  if ([organization, roleTitle, location, service, product, crop, context, details, website].some((item) => item.tooLong)) {
+    return { ok: false, code: "field_too_long" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      requestId,
+      name,
+      email: emailResult.value?.toLowerCase(),
+      phone: phoneResult.value,
+      organization: organization.value,
+      roleTitle: roleTitle.value,
+      audience: audience as PublicLeadSubmission["audience"],
+      need: need as PublicLeadSubmission["need"],
+      location: location.value,
+      service: service.value,
+      product: product.value,
+      crop: crop.value,
+      context: context.value,
+      details: details.value,
+      consent: true,
+      website: website.value,
+    },
+  };
+}
+
+export function publicLeadValidationMessage(code: PublicLeadValidationCode) {
+  if (code === "name_required") return "Indica tu nombre para enviar la consulta.";
+  if (code === "invalid_email") return "Revisa el correo electrónico.";
+  if (code === "contact_required") return "Indica un correo o teléfono para poder contactarte.";
+  if (code === "invalid_audience") return "Selecciona desde qué contexto nos escribes.";
+  if (code === "invalid_need") return "Selecciona qué necesitas resolver primero.";
+  if (code === "consent_required") return "Necesitamos tu autorización para gestionar esta consulta.";
+  if (code === "field_too_long") return "Uno de los campos supera la longitud permitida. Resume el contenido e inténtalo de nuevo.";
+  return "Revisa la información e inténtalo de nuevo.";
+}

--- a/src/lib/public-leads.ts
+++ b/src/lib/public-leads.ts
@@ -25,6 +25,7 @@ export type PublicLeadValidationCode =
   | "invalid_request_id"
   | "name_required"
   | "invalid_email"
+  | "invalid_phone"
   | "contact_required"
   | "invalid_audience"
   | "invalid_need"
@@ -59,6 +60,7 @@ export function validatePublicLeadSubmission(input: unknown): ValidationResult {
   const phoneResult = cleanOptional(raw.phone, 40);
   if (emailResult.tooLong || phoneResult.tooLong) return { ok: false, code: "field_too_long" };
   if (emailResult.value && !emailPattern.test(emailResult.value)) return { ok: false, code: "invalid_email" };
+  if (phoneResult.value && phoneResult.value.length < 7) return { ok: false, code: "invalid_phone" };
   if (!emailResult.value && !phoneResult.value) return { ok: false, code: "contact_required" };
 
   const audience = typeof raw.audience === "string" ? raw.audience : "";
@@ -106,6 +108,7 @@ export function validatePublicLeadSubmission(input: unknown): ValidationResult {
 export function publicLeadValidationMessage(code: PublicLeadValidationCode) {
   if (code === "name_required") return "Indica tu nombre para enviar la consulta.";
   if (code === "invalid_email") return "Revisa el correo electrónico.";
+  if (code === "invalid_phone") return "Revisa el número de teléfono.";
   if (code === "contact_required") return "Indica un correo o teléfono para poder contactarte.";
   if (code === "invalid_audience") return "Selecciona desde qué contexto nos escribes.";
   if (code === "invalid_need") return "Selecciona qué necesitas resolver primero.";

--- a/supabase/migrations/0053_public_leads.sql
+++ b/supabase/migrations/0053_public_leads.sql
@@ -1,0 +1,163 @@
+-- Public Contact · governed lead capture.
+-- Public leads contain PII and intentionally live outside GREENATICS OPS operational masters.
+-- The browser never writes this table directly: a server-side route calls the service-only RPC.
+
+create table public.public_leads (
+  id uuid primary key default gen_random_uuid(),
+  request_id uuid not null unique,
+  status text not null default 'new' check (status in ('new','contacted','closed','discarded')),
+  name text not null check (char_length(btrim(name)) between 2 and 120),
+  email text check (email is null or char_length(email) between 3 and 254),
+  phone text check (phone is null or char_length(phone) between 7 and 40),
+  organization text check (organization is null or char_length(organization) <= 180),
+  role_title text check (role_title is null or char_length(role_title) <= 120),
+  audience text not null check (audience in ('esp','municipio','empresa','ph','planta','wondergreen','otro')),
+  need text not null check (need in ('diagnostico','planeacion','regulacion','rutas','planta','operacion','datos','valorizacion','nutricion','distribucion','otro')),
+  location text check (location is null or char_length(location) <= 180),
+  service text check (service is null or char_length(service) <= 180),
+  product text check (product is null or char_length(product) <= 180),
+  crop text check (crop is null or char_length(crop) <= 120),
+  context text check (context is null or char_length(context) <= 480),
+  details text check (details is null or char_length(details) <= 1500),
+  source_path text not null default '/contacto' check (char_length(source_path) <= 300),
+  consent_version text not null default 'public-contact-v1',
+  consent_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  retention_expires_at timestamptz not null default (now() + interval '180 days'),
+  constraint public_leads_contact_required check (email is not null or phone is not null),
+  constraint public_leads_retention_after_creation check (retention_expires_at > created_at)
+);
+
+create table public.public_lead_submission_events (
+  id bigint generated always as identity primary key,
+  lead_id uuid not null references public.public_leads(id) on delete cascade,
+  request_fingerprint text not null check (request_fingerprint ~ '^[0-9a-f]{64}$'),
+  created_at timestamptz not null default now()
+);
+
+create index public_lead_submission_events_fingerprint_created_idx
+  on public.public_lead_submission_events(request_fingerprint, created_at desc);
+create index public_leads_status_created_idx on public.public_leads(status, created_at desc);
+create index public_leads_retention_idx on public.public_leads(retention_expires_at);
+
+alter table public.public_leads enable row level security;
+alter table public.public_lead_submission_events enable row level security;
+
+-- PII is never exposed through the public/authenticated Supabase client roles.
+revoke all on table public.public_leads from public, anon, authenticated;
+revoke all on table public.public_lead_submission_events from public, anon, authenticated;
+grant select, insert, update, delete on table public.public_leads to service_role;
+grant select, insert, update, delete on table public.public_lead_submission_events to service_role;
+grant usage, select on sequence public.public_lead_submission_events_id_seq to service_role;
+
+create or replace function public.submit_public_lead_service(
+  p_request_id uuid,
+  p_request_fingerprint text,
+  p_name text,
+  p_email text,
+  p_phone text,
+  p_organization text,
+  p_role_title text,
+  p_audience text,
+  p_need text,
+  p_location text,
+  p_service text,
+  p_product text,
+  p_crop text,
+  p_context text,
+  p_details text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  existing_lead_id uuid;
+  new_lead_id uuid;
+  recent_submissions integer;
+begin
+  if p_request_id is null then
+    raise exception 'PUBLIC_LEAD_INVALID_REQUEST_ID';
+  end if;
+  if p_request_fingerprint is null or p_request_fingerprint !~ '^[0-9a-f]{64}$' then
+    raise exception 'PUBLIC_LEAD_INVALID_FINGERPRINT';
+  end if;
+
+  -- Idempotent browser retries return the original lead and do not consume rate-limit quota.
+  select l.id into existing_lead_id
+  from public.public_leads l
+  where l.request_id = p_request_id;
+  if existing_lead_id is not null then
+    return existing_lead_id;
+  end if;
+
+  -- Serialize submissions by pseudonymous connection fingerprint so concurrent requests
+  -- cannot race the quota check.
+  perform pg_advisory_xact_lock(hashtext(p_request_fingerprint)::bigint);
+
+  select l.id into existing_lead_id
+  from public.public_leads l
+  where l.request_id = p_request_id;
+  if existing_lead_id is not null then
+    return existing_lead_id;
+  end if;
+
+  select count(*)::integer into recent_submissions
+  from public.public_lead_submission_events e
+  where e.request_fingerprint = p_request_fingerprint
+    and e.created_at >= now() - interval '15 minutes';
+
+  if recent_submissions >= 5 then
+    raise exception 'PUBLIC_LEAD_RATE_LIMIT';
+  end if;
+
+  insert into public.public_leads(
+    request_id,
+    name,
+    email,
+    phone,
+    organization,
+    role_title,
+    audience,
+    need,
+    location,
+    service,
+    product,
+    crop,
+    context,
+    details
+  ) values (
+    p_request_id,
+    btrim(p_name),
+    nullif(lower(btrim(coalesce(p_email,''))),''),
+    nullif(btrim(coalesce(p_phone,'')),''),
+    nullif(btrim(coalesce(p_organization,'')),''),
+    nullif(btrim(coalesce(p_role_title,'')),''),
+    p_audience,
+    p_need,
+    nullif(btrim(coalesce(p_location,'')),''),
+    nullif(btrim(coalesce(p_service,'')),''),
+    nullif(btrim(coalesce(p_product,'')),''),
+    nullif(btrim(coalesce(p_crop,'')),''),
+    nullif(btrim(coalesce(p_context,'')),''),
+    nullif(btrim(coalesce(p_details,'')),'')
+  ) returning id into new_lead_id;
+
+  insert into public.public_lead_submission_events(lead_id, request_fingerprint)
+  values (new_lead_id, p_request_fingerprint);
+
+  return new_lead_id;
+end;
+$$;
+
+revoke all on function public.submit_public_lead_service(uuid,text,text,text,text,text,text,text,text,text,text,text,text,text,text) from public, anon, authenticated;
+grant execute on function public.submit_public_lead_service(uuid,text,text,text,text,text,text,text,text,text,text,text,text,text,text) to service_role;
+
+comment on table public.public_leads is
+'PII-bearing public commercial inquiries. Separate from OPS customers and operational masters; no anon/authenticated table privileges. Unconverted inquiries default to 180-day retention.';
+comment on table public.public_lead_submission_events is
+'Non-PII submission throttle ledger keyed only by a server-generated HMAC fingerprint; raw client IP is never persisted.';
+comment on function public.submit_public_lead_service(uuid,text,text,text,text,text,text,text,text,text,text,text,text,text,text) is
+'Service-role-only public lead boundary. Provides idempotent request handling and an atomic five-submissions-per-15-minutes connection quota before storing PII.';

--- a/supabase/tests/database/public_leads.test.sql
+++ b/supabase/tests/database/public_leads.test.sql
@@ -1,0 +1,51 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+select plan(27);
+
+select has_table('public','public_leads','public lead PII ledger exists');
+select has_table('public','public_lead_submission_events','public lead throttle ledger exists');
+select ok(not has_table_privilege('anon','public.public_leads','SELECT'),'anon cannot read lead PII');
+select ok(not has_table_privilege('anon','public.public_leads','INSERT'),'anon cannot insert lead PII directly');
+select ok(not has_table_privilege('authenticated','public.public_leads','SELECT'),'authenticated OPS clients cannot read public lead PII directly');
+select ok(not has_table_privilege('authenticated','public.public_leads','INSERT'),'authenticated OPS clients cannot insert public lead PII directly');
+select ok(has_table_privilege('service_role','public.public_leads','SELECT'),'service role can support the protected admin read boundary');
+select ok(has_function_privilege('service_role','public.submit_public_lead_service(uuid,text,text,text,text,text,text,text,text,text,text,text,text,text,text)','EXECUTE'),'service role can call the governed lead boundary');
+select ok(not has_function_privilege('anon','public.submit_public_lead_service(uuid,text,text,text,text,text,text,text,text,text,text,text,text,text,text)','EXECUTE'),'anon cannot call the lead RPC directly');
+select ok(not has_function_privilege('authenticated','public.submit_public_lead_service(uuid,text,text,text,text,text,text,text,text,text,text,text,text,text,text)','EXECUTE'),'authenticated clients cannot call the lead RPC directly');
+
+set local role service_role;
+select lives_ok($$select public.submit_public_lead_service(
+  '550e8400-e29b-41d4-a716-446655440000'::uuid,
+  repeat('a',64),
+  'Ana Pérez','ANA@EXAMPLE.COM','+57 300 555 1212','ESP Ejemplo','Directora técnica',
+  'planta','operacion','Antioquia','Dirección técnica y coordinación de operación',null,null,
+  'Interés en fortalecer una planta existente.','Queremos mejorar la operación sin reemplazar infraestructura útil.'
+)$$,'service boundary stores a valid public consultation');
+select is((select count(*) from public.public_leads),1::bigint,'one public lead is stored');
+select is((select count(*) from public.public_lead_submission_events),1::bigint,'one throttle event is stored');
+select is((select consent_version from public.public_leads limit 1),'public-contact-v1','consent version is frozen on the lead');
+select ok((select retention_expires_at > created_at + interval '179 days' from public.public_leads limit 1),'unconverted lead receives the 180-day retention horizon');
+
+select lives_ok($$select public.submit_public_lead_service(
+  '550e8400-e29b-41d4-a716-446655440000'::uuid,
+  repeat('a',64),
+  'Ana Pérez','ana@example.com','+57 300 555 1212','ESP Ejemplo','Directora técnica',
+  'planta','operacion','Antioquia','Dirección técnica y coordinación de operación',null,null,
+  'Interés heredado','Retry del navegador.'
+)$$,'same request id is idempotent');
+select is((select count(*) from public.public_leads),1::bigint,'idempotent retry does not duplicate lead PII');
+select is((select count(*) from public.public_lead_submission_events),1::bigint,'idempotent retry does not consume throttle quota');
+
+select lives_ok($$select public.submit_public_lead_service('550e8400-e29b-41d4-a716-446655440001',repeat('a',64),'Lead 2','lead2@example.com',null,null,null,'empresa','diagnostico',null,null,null,null,null,null)$$,'second submission within quota lives');
+select lives_ok($$select public.submit_public_lead_service('550e8400-e29b-41d4-a716-446655440002',repeat('a',64),'Lead 3','lead3@example.com',null,null,null,'empresa','diagnostico',null,null,null,null,null,null)$$,'third submission within quota lives');
+select lives_ok($$select public.submit_public_lead_service('550e8400-e29b-41d4-a716-446655440003',repeat('a',64),'Lead 4','lead4@example.com',null,null,null,'empresa','diagnostico',null,null,null,null,null,null)$$,'fourth submission within quota lives');
+select lives_ok($$select public.submit_public_lead_service('550e8400-e29b-41d4-a716-446655440004',repeat('a',64),'Lead 5','lead5@example.com',null,null,null,'empresa','diagnostico',null,null,null,null,null,null)$$,'fifth submission within quota lives');
+select is((select count(*) from public.public_lead_submission_events),5::bigint,'quota ledger contains five accepted submissions');
+select throws_ok($$select public.submit_public_lead_service('550e8400-e29b-41d4-a716-446655440005',repeat('a',64),'Lead 6','lead6@example.com',null,null,null,'empresa','diagnostico',null,null,null,null,null,null)$$,'PUBLIC_LEAD_RATE_LIMIT','sixth submission inside fifteen minutes is rejected atomically');
+select is((select count(*) from public.public_leads),5::bigint,'rate-limited submission does not create PII');
+select is((select source_path from public.public_leads where request_id='550e8400-e29b-41d4-a716-446655440000'),'/contacto','lead source stays on the public contact surface');
+select is((select count(*) from public.customers where lower(name)=lower('Ana Pérez')),0::bigint,'public inquiry is not mixed into the OPS customer master');
+
+reset role;
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #276 only when the full RED→GREEN contract is certified and explicitly promoted.

## Base congelada
`develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`

## RED inicial
Commit test-only `4cf0a78ae35a32187081b687f3053218159c1143`.

Contrato exigido:
- captura real de consulta además de Outlook Booking;
- nombre + al menos un canal de contacto;
- consentimiento explícito;
- conserva audiencia, necesidad, servicio/producto/cultivo/contexto heredados;
- PII únicamente en body POST, nunca en URL;
- mantiene `Preparar contexto` como herramienta local;
- validación antes de enviar;
- UX explícita para rate limiting;
- no prometer respuesta automática;
- no reutilizar `customers` ni tablas OPS.

## Arquitectura objetivo
- modelo `public_leads` independiente;
- endpoint Next.js server-side;
- `SUPABASE_SECRET_KEY` solo en servidor;
- cero permisos `anon/authenticated` sobre PII;
- boundary service-only para idempotencia + rate limit atómico;
- lectura administrativa autenticada y restringida.

## Restricciones
- no merge;
- no despliegue;
- no tocar `develop`;
- no abrir escritura anónima directa en Supabase.