### PR TITLE
fix(release): validar marcadores sobre texto visible

### DIFF
--- a/.github/workflows/publish-greenatics-web.yml
+++ b/.github/workflows/publish-greenatics-web.yml
@@ -189,6 +189,7 @@ jobs:
             local marker="$2"
             counter=$((counter + 1))
             local outfile="/tmp/greenatics-route-${counter}.body"
+            local textfile="/tmp/greenatics-route-${counter}.visible.txt"
             local status
             status="$(curl --silent --show-error --location --retry 3 --retry-delay 2 --max-time 45 -w '%{http_code}' "$base$path" -o "$outfile" || printf '000')"
             local bytes=0
@@ -205,13 +206,15 @@ jobs:
               failures=$((failures + 1))
               return
             fi
-            if ! grep -Fq "$marker" "$outfile"; then
-              echo "::error::$path did not contain release marker '$marker'."
+
+            node scripts/http-visible-text.mjs "$outfile" > "$textfile"
+            if ! grep -Fq "$marker" "$textfile"; then
+              echo "::error::$path did not contain visible release marker '$marker'."
               failures=$((failures + 1))
               return
             fi
 
-            echo "- PASS: $path (HTTP 200, $bytes bytes, marker '$marker')" >> "$GITHUB_STEP_SUMMARY"
+            echo "- PASS: $path (HTTP 200, $bytes bytes, visible marker '$marker')" >> "$GITHUB_STEP_SUMMARY"
           }
 
           echo "### Public production smoke" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/http-visible-text.mjs
+++ b/scripts/http-visible-text.mjs
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 const namedEntities = new Map([
   ["amp", "&"],
@@ -28,7 +29,8 @@ export function normalizeResponseText(source) {
     .trim();
 }
 
-if (process.argv[1]?.endsWith("http-visible-text.mjs")) {
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
   const inputPath = process.argv[2];
   if (!inputPath) {
     console.error("Usage: node scripts/http-visible-text.mjs <response-body-file>");

--- a/scripts/http-visible-text.mjs
+++ b/scripts/http-visible-text.mjs
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+
+const namedEntities = new Map([
+  ["amp", "&"],
+  ["lt", "<"],
+  ["gt", ">"],
+  ["quot", '"'],
+  ["apos", "'"],
+  ["nbsp", " "],
+]);
+
+function decodeHtmlEntities(value) {
+  return value
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, decimal) => String.fromCodePoint(Number.parseInt(decimal, 10)))
+    .replace(/&([a-z]+);/gi, (entity, name) => namedEntities.get(name.toLowerCase()) ?? entity);
+}
+
+export function normalizeResponseText(source) {
+  return decodeHtmlEntities(
+    source
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
+      .replace(/<!--[\s\S]*?-->/g, " ")
+      .replace(/<[^>]+>/g, " "),
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+if (process.argv[1]?.endsWith("http-visible-text.mjs")) {
+  const inputPath = process.argv[2];
+  if (!inputPath) {
+    console.error("Usage: node scripts/http-visible-text.mjs <response-body-file>");
+    process.exit(2);
+  }
+
+  process.stdout.write(normalizeResponseText(readFileSync(inputPath, "utf8")));
+}

--- a/scripts/publish-greenatics-web-workflow.test.mjs
+++ b/scripts/publish-greenatics-web-workflow.test.mjs
@@ -1,5 +1,6 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { normalizeResponseText } from "./http-visible-text.mjs";
 
 const workflowPath = ".github/workflows/publish-greenatics-web.yml";
 const workflow = readFileSync(workflowPath, "utf8");
@@ -61,6 +62,28 @@ describe("GREENATICS manual production release workflow", () => {
     ]) {
       expect(workflow).toContain(marker);
     }
+  });
+
+  it("checks semantic markers against normalized visible response text", () => {
+    expect(workflow).toContain('node scripts/http-visible-text.mjs "$outfile" > "$textfile"');
+    expect(workflow).toContain('grep -Fq "$marker" "$textfile"');
+    expect(workflow).not.toContain('grep -Fq "$marker" "$outfile"');
+
+    const renderedHome = [
+      "<main>",
+      "<h1>Transformamos residuos <em>en vida.</em></h1>",
+      "<script>Transformamos residuos en vida. hidden hydration payload</script>",
+      "<style>.fake::after { content: 'Transformamos residuos en vida.'; }</style>",
+      "</main>",
+    ].join("");
+    const visibleHome = normalizeResponseText(renderedHome);
+
+    expect(visibleHome).toContain("Transformamos residuos en vida.");
+    expect(visibleHome).not.toContain("hidden hydration payload");
+    expect(visibleHome).not.toContain(".fake::after");
+    expect(normalizeResponseText("User-agent: *\nDisallow: /app\n")).toContain("Disallow: /app");
+    expect(normalizeResponseText("<url><loc>https://greenatics.com.co/wondergreen</loc></url>"))
+      .toContain("https://greenatics.com.co/wondergreen");
   });
 
   it("has exactly one manual workflow capable of stable production deployment", () => {

--- a/scripts/publish-greenatics-web-workflow.test.mjs
+++ b/scripts/publish-greenatics-web-workflow.test.mjs
@@ -84,6 +84,8 @@ describe("GREENATICS manual production release workflow", () => {
     expect(normalizeResponseText("User-agent: *\nDisallow: /app\n")).toContain("Disallow: /app");
     expect(normalizeResponseText("<url><loc>https://greenatics.com.co/wondergreen</loc></url>"))
       .toContain("https://greenatics.com.co/wondergreen");
+    expect(normalizeResponseText("<p>Rutas &amp; logística&nbsp;operativa</p>"))
+      .toBe("Rutas & logística operativa");
   });
 
   it("has exactly one manual workflow capable of stable production deployment", () => {


### PR DESCRIPTION
Cierra #297.

## Hallazgo
El smoke de producción validaba marcadores con `grep` sobre HTML crudo. HOME renderiza el texto canónico `Transformamos residuos en vida.` con markup intermedio (`<em>`), por lo que una página correcta podía producir un falso negativo después del despliegue.

## Corrección
- añade `scripts/http-visible-text.mjs`, sin dependencias externas;
- elimina `script`, `style` y comentarios antes de validar;
- sustituye tags por espacios, decodifica entidades básicas/numerales y colapsa whitespace;
- el workflow conserva exactamente las mismas 16 rutas y marcadores, pero ahora valida sobre texto visible normalizado;
- `robots.txt` y `sitemap.xml` continúan siendo compatibles;
- no se cambia copy, rutas, secretos, despliegue ni lógica de aplicación.

## Contrato de prueba
El test reproduce explícitamente:
- `Transformamos residuos <em>en vida.</em>` → contiene `Transformamos residuos en vida.`;
- texto presente solo en `script/style` no cuenta;
- `Disallow: /app` sigue detectable en texto plano;
- URL Wondergreen sigue detectable dentro de XML;
- el workflow debe usar el archivo normalizado y no volver a hacer `grep` sobre el body crudo.

## Diff controlado
Contra `develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`:
- 3 archivos;
- workflow: +6/-3;
- helper: +39;
- test: +23;
- ninguna modificación funcional de Greenatics web/OPS.

## Relación con release
- #296 ya está 4/4 GREEN y contiene el stack funcional consolidado;
- este PR endurece únicamente el canal de publicación;
- una integración posterior deberá certificar #296 + este PR antes de cualquier promoción.

## Restricciones
- DRAFT;
- no merge;
- no deploy;
- no mover `develop`;
- no ejecutar `publish-greenatics-web` desde esta rama.