### PR TITLE
fix(ops): distinguir demo local de datos Supabase en Hoy

### DIFF
--- a/e2e/today-source-controls.spec.ts
+++ b/e2e/today-source-controls.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+
+test("Today makes local demo controls explicit", async ({ page }) => {
+  await page.goto("/app");
+
+  await expect(page.getByRole("heading", { name: "Operación de hoy", exact: true })).toBeVisible();
+  await expect(page.getByText("Demo local · este navegador", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Restablecer demo", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Actualizar datos", exact: true })).toHaveCount(0);
+  await expect(page.getByText("Persistencia local activa", { exact: true })).toHaveCount(0);
+});

--- a/src/components/today-dashboard.tsx
+++ b/src/components/today-dashboard.tsx
@@ -9,6 +9,7 @@ import { useCompostStore } from "@/components/compost-store";
 import { buildOperationalAnalytics } from "@/lib/analytics";
 import { getRejectionPct, type AcceptanceStatus } from "@/lib/domain";
 import { bogotaDateKey, bogotaTime } from "@/lib/time";
+import { getTodaySourceControl } from "@/lib/today-source-control";
 
 function Metric({ label, value, note }: { label: string; value: string; note: string }) {
   return <div className="metric-block"><span>{label}</span><strong>{value}</strong><small>{note}</small></div>;
@@ -23,7 +24,7 @@ function timeLabel(iso?: string) {
 }
 
 export function TodayDashboard({ initialNowIso }: { initialNowIso: string }) {
-  const { activities, incidents, receptions, workers, ready, resetDemo } = useOpsStore();
+  const { activities, incidents, receptions, workers, backend, ready, refresh, resetDemo } = useOpsStore();
   const { equipment, tickets } = useMaintenanceStore();
   const { piles, measurements } = useCompostStore();
   const [nowIso, setNowIso] = useState(initialNowIso);
@@ -45,6 +46,15 @@ export function TodayDashboard({ initialNowIso }: { initialNowIso: string }) {
   const activeMaintenance = tickets.filter((ticket) => ticket.status !== "closed");
   const currentAttentionCount = activeMaintenance.length + openIncidents.length + nonConforming.length + delayed.length;
   const dayLabel = dayFormatter.format(new Date(nowIso));
+  const sourceControl = getTodaySourceControl(backend, ready);
+
+  const handleSourceAction = () => {
+    if (sourceControl.action === "refresh") {
+      void refresh().catch(() => undefined);
+      return;
+    }
+    resetDemo();
+  };
 
   return <>
     <header className="page-header">
@@ -78,7 +88,7 @@ export function TodayDashboard({ initialNowIso }: { initialNowIso: string }) {
     </div>
 
     <section className="panel plant-panel" id="estado-plantas">
-      <div className="section-head"><div><p className="eyebrow">Plantas</p><h2>Estado operativo</h2></div><div className="flex items-center gap-3"><Link className="text-xs font-semibold text-[var(--green)]" href="/dashboard">Abrir dashboard</Link><span className="quiet">{ready ? "Persistencia local activa" : "Cargando estado…"}</span><button className="text-xs font-semibold text-[var(--green)] underline underline-offset-4" type="button" onClick={resetDemo}>Restablecer demo</button></div></div>
+      <div className="section-head"><div><p className="eyebrow">Plantas</p><h2>Estado operativo</h2></div><div className="flex items-center gap-3"><Link className="text-xs font-semibold text-[var(--green)]" href="/dashboard">Abrir dashboard</Link><span className="quiet">{sourceControl.label}</span><button className="text-xs font-semibold text-[var(--green)] underline underline-offset-4" type="button" onClick={handleSourceAction}>{sourceControl.actionLabel}</button></div></div>
       <div className="plant-table"><div className="plant-row plant-head"><span>Planta</span><span>Recibido</span><span>Rechazo</span><span>Plan</span><span>Atención</span></div>{analytics.plantComparison.map((plant)=><div className="plant-row" key={plant.plantId}><strong>{plant.plant}</strong><span>{(plant.receivedKg/1000).toFixed(2)} t</span><span>{plant.rejectionPct.toFixed(1)} %</span><span>{plant.compliancePct.toFixed(0)} %</span><strong className={plant.attention ? "text-[var(--red)]" : "text-[var(--green)]"}>{plant.attention}</strong></div>)}</div>
     </section>
 

--- a/src/lib/today-source-control.test.ts
+++ b/src/lib/today-source-control.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getTodaySourceControl } from "./today-source-control";
+
+describe("Today source controls", () => {
+  it("keeps demo reset explicit in local mode", () => {
+    expect(getTodaySourceControl({ mode: "local", status: "ready" }, true)).toEqual({
+      label: "Demo local · este navegador",
+      actionLabel: "Restablecer demo",
+      action: "reset-demo",
+    });
+  });
+
+  it("never presents a Supabase refresh as a demo reset", () => {
+    expect(getTodaySourceControl({ mode: "supabase", status: "ready" }, true)).toEqual({
+      label: "Supabase · datos sincronizados",
+      actionLabel: "Actualizar datos",
+      action: "refresh",
+    });
+  });
+
+  it("keeps Supabase state explicit while synchronizing or failing", () => {
+    expect(getTodaySourceControl({ mode: "supabase", status: "booting" }, false).label).toBe("Supabase · sincronizando");
+    expect(getTodaySourceControl({ mode: "supabase", status: "error", error: "offline" }, true).label).toBe("Supabase · requiere atención");
+  });
+});

--- a/src/lib/today-source-control.ts
+++ b/src/lib/today-source-control.ts
@@ -1,0 +1,31 @@
+import type { OpsBackendState } from "@/lib/ops-data-contract";
+
+export type TodaySourceAction = "reset-demo" | "refresh";
+
+export type TodaySourceControl = Readonly<{
+  label: string;
+  actionLabel: string;
+  action: TodaySourceAction;
+}>;
+
+export function getTodaySourceControl(backend: OpsBackendState, ready: boolean): TodaySourceControl {
+  if (backend.mode === "supabase") {
+    const label = backend.status === "error"
+      ? "Supabase · requiere atención"
+      : backend.status === "ready" && ready
+        ? "Supabase · datos sincronizados"
+        : "Supabase · sincronizando";
+
+    return {
+      label,
+      actionLabel: "Actualizar datos",
+      action: "refresh",
+    };
+  }
+
+  return {
+    label: ready ? "Demo local · este navegador" : "Demo local · cargando",
+    actionLabel: "Restablecer demo",
+    action: "reset-demo",
+  };
+}


### PR DESCRIPTION
Cierra #300.

## Problema
`TodayDashboard` mostraba `Persistencia local activa` y `Restablecer demo` sin distinguir el backend. En modo Supabase, `resetDemo()` no es destructivo —solo refresca—, pero la interfaz describía incorrectamente una operación remota como demo/local.

## Corrección
- añade `getTodaySourceControl()` como contrato explícito por backend;
- modo local: `Demo local · este navegador` + `Restablecer demo`;
- modo Supabase listo: `Supabase · datos sincronizados` + `Actualizar datos`;
- estados remotos booting/error conservan lenguaje Supabase;
- `Actualizar datos` llama `refresh()`; no introduce ninguna mutación/borrado remoto;
- se elimina el texto ambiguo `Persistencia local activa` del panel Hoy.

## QA
- unit tests para local, Supabase ready/booting/error;
- E2E local: dashboard visible, etiqueta local correcta, `Restablecer demo` presente, `Actualizar datos` ausente;
- el comportamiento remoto de `resetDemo()` permanece intacto y no destructivo.

## Diff
4 archivos:
- `src/lib/today-source-control.ts`
- `src/lib/today-source-control.test.ts`
- `src/components/today-dashboard.tsx`
- `e2e/today-source-controls.spec.ts`

No cambia esquema, RLS, repositorios, navegación, datos de negocio ni producción.

## Integración
Base exacta: `develop@9de516df1b3ce7eeedd59db500bbc858551e86c4`.
Mantener draft/sin merge mientras el release candidate siga congelado. Exigir quality + database/RLS + desktop + mobile 4/4 GREEN.