### PR TITLE
fix(ops): alinear rechazo parcial con semántica de excepción

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -84,7 +84,8 @@ function inPeriod(iso: string | undefined, period: DashboardPeriod) { if (!iso) 
 export function overlapMinutes(startIso: string | undefined, endIso: string | undefined, period: DashboardPeriod, nowIso: string) { if (!startIso) return 0; const { startMs, endMs } = periodBounds(period); const start = Math.max(new Date(startIso).getTime(), startMs); const end = Math.min(new Date(endIso ?? nowIso).getTime(), endMs); return Math.max(0, (end - start) / 60_000); }
 function filterPlant<T extends { plantId: string }>(items: T[], plantId: PlantFilter) { return plantId === "all" ? items : items.filter((item) => item.plantId === plantId); }
 function pct(numerator: number, denominator: number) { return denominator > 0 ? (numerator / denominator) * 100 : 0; }
-function isNonConforming(receipt: ReceptionRecord) { return receipt.acceptance === "conditioned" || receipt.acceptance === "rejected"; }
+function isNonConforming(receipt: ReceptionRecord) { return receptionAttentionStatuses.has(receipt.acceptance); }
+const receptionAttentionStatuses = new Set<ReceptionRecord["acceptance"]>(["conditioned", "partial_rejection", "rejected"]);
 function hasKnownRejection(receipt: ReceptionRecord) { return receipt.rejectionKnown !== false; }
 function isMaintenanceOpenAtPeriodEnd(ticket: MaintenanceTicket, period: DashboardPeriod) {
   const { endMs } = periodBounds(period);

--- a/src/lib/partial-rejection-analytics.test.ts
+++ b/src/lib/partial-rejection-analytics.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { ReceptionRecord } from "./domain";
+import { buildOperationalAnalytics } from "./analytics";
+
+function reception(id: string, plantId: string, plant: string, acceptance: ReceptionRecord["acceptance"], rejectionKg: number): ReceptionRecord {
+  return {
+    id,
+    plantId,
+    plant,
+    generator: `Generador ${id}`,
+    route: `Ruta ${id}`,
+    wasteType: "FORSU",
+    netWeightKg: 1000,
+    rejectionKg,
+    rejectionKnown: true,
+    acceptance,
+    startedAt: "2026-08-11T08:00:00-05:00",
+    endedAt: "2026-08-11T08:20:00-05:00",
+    lotCode: `LOT-${id}`,
+    source: "local",
+  };
+}
+
+function analytics(receptions: ReceptionRecord[], plantId = "all") {
+  return buildOperationalAnalytics({
+    activities: [],
+    receptions,
+    incidents: [],
+    tickets: [],
+    equipment: [],
+    piles: [],
+    measurements: [],
+    workers: [],
+    preset: "day",
+    anchorKey: "2026-08-11",
+    plantId,
+    nowIso: "2026-08-11T16:00:00-05:00",
+  });
+}
+
+describe("partial rejection exception semantics", () => {
+  it("counts partial rejection as non-conformity and plant attention", () => {
+    const partial = reception("partial", "tamesis", "Támesis", "partial_rejection", 120);
+    const accepted = reception("accepted", "tamesis", "Támesis", "accepted", 0);
+    const result = analytics([partial, accepted]);
+
+    expect(result.nonConformingReceipts).toBe(1);
+    expect(result.exceptionsCount).toBe(1);
+    expect(result.plantComparison.find((row) => row.plantId === "tamesis")?.attention).toBe(1);
+    expect(result.rejectionKg).toBe(120);
+    expect(result.rejectionPct).toBe(6);
+  });
+
+  it("keeps unknown acceptance outside exceptions and inside data-quality", () => {
+    const unknown = reception("unknown", "yarumal", "Yarumal", "unknown", 0);
+    const result = analytics([unknown]);
+
+    expect(result.nonConformingReceipts).toBe(0);
+    expect(result.exceptionsCount).toBe(0);
+    expect(result.plantComparison.find((row) => row.plantId === "yarumal")?.attention).toBe(0);
+    expect(result.dataQualityAlerts.find((alert) => alert.id === "acceptance-unknown")?.count).toBe(1);
+  });
+
+  it("preserves plant filtering for partial rejection", () => {
+    const partial = reception("partial", "tamesis", "Támesis", "partial_rejection", 80);
+    const result = analytics([partial], "yarumal");
+
+    expect(result.nonConformingReceipts).toBe(0);
+    expect(result.exceptionsCount).toBe(0);
+    expect(result.receivedKg).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #310.

## Dependencia
PR apilado sobre #309 (`feat/ops-incident-history-rc@ae68e93cf074861ae221df8ada84602f13f6ba82`), ya certificado 4/4 GREEN. No modifica `develop`.

## Hallazgo
`TodayDashboard` ya considera `conditioned`, `partial_rejection` y `rejected` como recepciones que requieren atención. `analytics.ts` omitía `partial_rejection`, por lo que Dashboard/CSV subestimaban `nonConformingReceipts`, `exceptionsCount` y `plantComparison.attention`.

## Implementación
- el predicado interno de Analytics ahora reconoce `conditioned`, `partial_rejection` y `rejected`;
- `accepted` y `unknown` permanecen fuera de no conformidad operacional;
- `unknown` conserva su tratamiento como alerta de calidad de datos;
- no se modifica masa física, porcentaje de rechazo, cobertura ni registros históricos.

## QA añadido
- `partial_rejection` incrementa `nonConformingReceipts` y `exceptionsCount`;
- incrementa `plantComparison.attention` solo en la planta correspondiente;
- `accepted` no añade excepción;
- `unknown` no añade excepción y sigue generando `acceptance-unknown`;
- filtro por planta conserva la semántica.

## Guardrails
- sin migraciones;
- sin reinterpretar `unknown`;
- sin cambios de persistencia;
- sin merge/deploy mientras continúe el freeze/gobierno de release.

## Gate
Exigir quality + database/RLS + desktop Chromium + mobile Chromium 4/4 antes de certificar.